### PR TITLE
feat/allow_disabling_mic_meter_ipc

### DIFF
--- a/mycroft/client/speech/mic.py
+++ b/mycroft/client/speech/mic.py
@@ -374,6 +374,8 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
         self.recording_timeout_with_silence = listener_config.get(
             'recording_timeout_with_silence', 3.0)
 
+        self.mic_meter_ipc_enabled = listener_config.get("mic_meter_ipc", True)
+
     @property
     def account_id(self):
         """Fetch account from backend when needed.
@@ -472,13 +474,14 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
         return byte_data
 
     def write_mic_level(self, energy, source):
-        with open(self.mic_level_file, 'w') as f:
-            f.write('Energy:  cur={} thresh={:.3f} muted={}'.format(
-                energy,
-                self.energy_threshold,
-                int(source.muted)
+        if self.mic_meter_ipc_enabled:
+            with open(self.mic_level_file, 'w') as f:
+                f.write('Energy:  cur={} thresh={:.3f} muted={}'.format(
+                    energy,
+                    self.energy_threshold,
+                    int(source.muted)
+                    )
                 )
-            )
 
     def _skip_wake_word(self):
         """Check if told programatically to skip the wake word

--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -266,6 +266,12 @@
   // Override: REMOTE
   "listener": {
     "sample_rate": 16000,
+
+    // if enabled the noise level is saved to a ipc file, useful for
+    // debuging if microphone is working but writes a lot to disk,
+    // recommended that you set "ipc_path" to a tmpfs
+    "mic_meter_ipc": true,
+
     // Set 'save_path' to configure the location of files stored if
     // 'record_wake_words' and/or 'save_utterances' are set to 'true'.
     // WARNING: Make sure that user 'mycroft' has write-access on the


### PR DESCRIPTION
the speech client mic meter is only used by the debug cli, it writes a lot to disk!

should the default value be set to False or do we keep the mycroft-core default?