### PR TITLE
fix/default to xdg

### DIFF
--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -89,8 +89,8 @@
     }
   },
 
-  // Also change in scripts/prepare-msm.sh
-  "data_dir": "/opt/mycroft",
+  // default to $XDG_DATA_DIRS/mycroft
+  // "data_dir": "/opt/mycroft",
 
   // whenever core needs to cache some files this directory will be used,
   // the main use case is for TTS files to avoid synthesizing the same thing

--- a/mycroft/configuration/ovos.py
+++ b/mycroft/configuration/ovos.py
@@ -11,9 +11,7 @@ XDG locations are then merged over the select default config (if found)
 Examples config:
 
 {
-   // check xdg directories OR only check old style hardcoded paths
-   // the default value is False so the default behaviour is the same as mycroft-core
-   // once MycroftAI/mycroft-core/pull/2794 is merged the default value will change to True
+   // check xdg directories OR only check old style hardcoded paths 
    "xdg": true,
 
    // the "name of the core",
@@ -120,4 +118,4 @@ def get_ovos_config():
 
 
 def is_using_xdg():
-    return get_ovos_config().get("xdg", False)
+    return get_ovos_config().get("xdg", True)

--- a/mycroft/skills/event_scheduler.py
+++ b/mycroft/skills/event_scheduler.py
@@ -66,8 +66,8 @@ class EventScheduler(Thread):
         self.is_running = True
 
         core_conf = Configuration.get(remote=False)
-        old_schedule_path = join(expanduser(core_conf['data_dir']),
-                                 schedule_file)
+        data_dir = core_conf.get('data_dir', xdg.BaseDirectory.save_data_path(BASE_FOLDER))
+        old_schedule_path = join(expanduser(data_dir), schedule_file)
 
         self.schedule_file = old_schedule_path
         if is_using_xdg():

--- a/mycroft/skills/msm_wrapper.py
+++ b/mycroft/skills/msm_wrapper.py
@@ -75,8 +75,12 @@ def get_skills_directory(conf=None):
     else:
         skills_folder = xdg.BaseDirectory.save_data_path(BASE_FOLDER + '/skills')
     # create folder if needed
-    if not path.exists(skills_folder):
-        makedirs(skills_folder)
+    try:
+        makedirs(skills_folder, exist_ok=True)
+    except PermissionError: # old style /opt/mycroft/skills not available
+        skills_folder = xdg.BaseDirectory.save_data_path(BASE_FOLDER + '/skills')
+        makedirs(skills_folder, exist_ok=True)
+
     return path.expanduser(skills_folder)
 
 
@@ -104,7 +108,7 @@ def build_msm_config(device_config: dict) -> MsmConfig:
     msm_config = device_config['skills'].get('msm', {})
     msm_repo_config = msm_config.get('repo', {})
     enclosure_config = device_config.get('enclosure', {})
-    data_dir = path.expanduser(device_config.get('data_dir', "/opt/mycroft"))
+    data_dir = path.expanduser(device_config.get('data_dir', xdg.BaseDirectory.save_data_path(BASE_FOLDER)))
     skills_dir = get_skills_directory(device_config)
     old_skills_dir = path.join(data_dir, msm_config.get('directory', "skills"))
 

--- a/mycroft/tts/mimic_tts.py
+++ b/mycroft/tts/mimic_tts.py
@@ -60,7 +60,7 @@ def get_subscriber_voices():
     Returns:
         (dict) map of voices to custom Mimic executables.
     """
-    data_dir = expanduser(Configuration.get()['data_dir'])
+    data_dir = Configuration.get().get('data_dir', xdg.BaseDirectory.save_data_path(BASE_FOLDER))
     old_path = join(data_dir, 'voices/mimic_tn')
     if exists(old_path):
         return {'trinity': old_path}

--- a/mycroft/util/file_utils.py
+++ b/mycroft/util/file_utils.py
@@ -76,8 +76,9 @@ def resolve_resource_file(res_name):
         return filename
 
     # Next look for /opt/mycroft/res/res_name
-    data_dir = os.path.join(os.path.expanduser(config['data_dir']), 'res')
-    filename = os.path.expanduser(os.path.join(data_dir, res_name))
+    data_dir = config.get('data_dir', xdg.BaseDirectory.save_data_path(mycroft.configuration.BASE_FOLDER))
+    res_dir = os.path.join(data_dir, 'res')
+    filename = os.path.expanduser(os.path.join(res_dir, res_name))
     if os.path.isfile(filename):
         return filename
 

--- a/mycroft/version/__init__.py
+++ b/mycroft/version/__init__.py
@@ -47,8 +47,6 @@ OVOS_VERSION_STR = '.'.join(map(str, OVOS_VERSION_TUPLE))
 class VersionManager:
     @staticmethod
     def get():
-        data_dir = expanduser(Configuration.get().get('data_dir',
-                                                      "/opt/mycroft"))
         return {"coreVersion": CORE_VERSION_STR,
                 "OpenVoiceOSVersion": OVOS_VERSION_STR,
                 "enclosureVersion": None}


### PR DESCRIPTION
previously the old mycroft paths were used for backwards compatibility and xdg compliance had to be manually enabled in the .conf

mycroft is now largely xdg compliant except for skills, this commit makes ovos-core xdg compliant by default

data_dir no longer defaults to /opt/mycroft !