### PR TITLE
feat/extra_skill_dirs

### DIFF
--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -114,10 +114,6 @@
 
   // General skill values
   "skills": {
-    // if this is a string it will override the path used to load skills
-    // this allows power users, devs, and distro packagers to choose a
-    // different folder
-    "directory_override": false,
 
     // don't start loading skills until internet is detected
     // this config value is not present in mycroft-core ()internet is required)

--- a/mycroft/skills/msm_wrapper.py
+++ b/mycroft/skills/msm_wrapper.py
@@ -65,6 +65,9 @@ def get_skills_directory(conf=None):
     path_override = conf["skills"].get("directory_override")
     # if .conf wants to use a specific path, use it!
     if path_override:
+        LOG.warning("'directory_override' is deprecated!\n"
+                    "It will no longer be supported after version 0.0.3\n"
+                    "add the new path to 'extra_directories' instead")
         skills_folder = path_override
     # if xdg is disabled, ignore it!
     elif not is_using_xdg():


### PR DESCRIPTION
this allows users to organize skills like they want, i leave here my .conf to illustrate the use case

```
"skills": {
 // additional skill directories, (un)comment lines to enable/disable skill categories
  "extra_directories": [
        "/home/user/PycharmProjects/skills/game-skills",
        "/home/user/PycharmProjects/skills/ocp_skills/audiobooks",
        "/home/user/PycharmProjects/skills/ocp_skills/cartoons",
        "/home/user/PycharmProjects/skills/ocp_skills/documentaries",
        "/home/user/PycharmProjects/skills/ocp_skills/iptv",
        "/home/user/PycharmProjects/skills/ocp_skills/motion_comics",
        "/home/user/PycharmProjects/skills/ocp_skills/movie",
        "/home/user/PycharmProjects/skills/ocp_skills/music",
        "/home/user/PycharmProjects/skills/ocp_skills/news",
        "/home/user/PycharmProjects/skills/ocp_skills/podcasts",
        "/home/user/PycharmProjects/skills/ocp_skills/radio",
        "/home/user/PycharmProjects/skills/ocp_skills/radio_theatre",
        "/home/user/PycharmProjects/skills/ocp_skills/short_films",
        "/home/user/PycharmProjects/skills/ocp_skills/video",
    //  "/home/user/PycharmProjects/skills/ovos_skills",
        "/home/user/PycharmProjects/skills/mycroft_skills"
  ],
  "wait_for_internet": false,
  "msm": {"disabled": true}
}
```