### PR TITLE
fix/mutable_config

### DIFF
--- a/mycroft/api/__init__.py
+++ b/mycroft/api/__init__.py
@@ -46,15 +46,22 @@ class Api:
 
     def __init__(self, path):
         self.path = path
-
-        # Load the config, skipping the remote config since we are
-        # getting the info needed to get to it!
-        config = Configuration.get(cache=False, remote=False)
-        config_server = config.get("server")
-        self.url = config_server.get("url")
-        self.version = config_server.get("version")
         self.identity = IdentityManager.get()
         self.disabled = is_backend_disabled()
+
+    @property
+    def url(self):
+        # Load the config, skipping the remote config since we are
+        # getting the info needed to get to it!
+        config = Configuration.get(cache=False, remote=False).get("server", {})
+        return config.get("url")
+
+    @property
+    def version(self):
+        # Load the config, skipping the remote config since we are
+        # getting the info needed to get to it!
+        config = Configuration.get(cache=False, remote=False).get("server", {})
+        return config.get("version")
 
     def request(self, params):
         self.check_token()

--- a/mycroft/audio/audioservice.py
+++ b/mycroft/audio/audioservice.py
@@ -201,7 +201,6 @@ class AudioService:
                 bus: Mycroft messagebus
         """
         self.bus = bus
-        self.config = Configuration.get().get("Audio")
         self.service_lock = Lock()
 
         self.default = None
@@ -212,6 +211,10 @@ class AudioService:
 
         self._loaded = MonotonicEvent()
         self.load_services()
+
+    @property
+    def config(self):
+        return Configuration.get().get("Audio")
 
     def load_services(self):
         """Method for loading services.

--- a/mycroft/client/enclosure/base.py
+++ b/mycroft/client/enclosure/base.py
@@ -20,14 +20,20 @@ from mycroft.util import start_message_bus_client
 
 class Enclosure:
     def __init__(self):
-        # Load full config
-        config = Configuration.get()
-        self.lang = config['lang']
-        self.config = config.get("enclosure")
-        self.global_config = config
-
         # Create Message Bus Client
         self.bus = MessageBusClient()
+
+    @property
+    def lang(self):
+        return self.global_config.get("lang", "en-us")
+
+    @property
+    def config(self):
+        return self.global_config.get("enclosure") or {}
+
+    @property
+    def global_config(self):
+        return Configuration.get()
 
     def run(self):
         """Start the Enclosure after it has been constructed."""

--- a/mycroft/client/speech/listener.py
+++ b/mycroft/client/speech/listener.py
@@ -267,15 +267,22 @@ class RecognizerLoop(EventEmitter):
     def bind(self, stt):
         self.stt = stt
 
+    @property
+    def config_core(self):
+        return Configuration.get()
+
+    @property
+    def config(self):
+        self._config_hash = recognizer_conf_hash(self.config_core)
+        return self.config_core.get('listener')
+
+    @property
+    def lang(self):
+        return self.config_core.get('lang', "en-us")
+
     def _load_config(self):
         """Load configuration parameters from configuration."""
-        config = Configuration.get()
-        self.config_core = config
-        self._config_hash = recognizer_conf_hash(config)
-        self.lang = config.get('lang')
-        self.config = config.get('listener')
         rate = self.config.get('sample_rate')
-
         device_index = self.config.get('device_index')
         device_name = self.config.get('device_name')
         if not device_index and device_name:

--- a/mycroft/client/speech/service.py
+++ b/mycroft/client/speech/service.py
@@ -51,7 +51,6 @@ class SpeechClient(Thread):
         self.status = ProcessStatus('speech', callback_map=callbacks)
         self.status.set_started()
 
-        self.config = Configuration.get()
         self.bus = start_message_bus_client("VOICE")
         self.connect_bus_events()
         self.status.bind(self.bus)
@@ -59,6 +58,10 @@ class SpeechClient(Thread):
         # Register handlers on internal RecognizerLoop bus
         self.loop = RecognizerLoop(self.bus, watchdog)
         self.connect_loop_events()
+
+    @property
+    def config(self):
+        return Configuration.get()
 
     # loop events
     def handle_record_begin(self):
@@ -188,7 +191,7 @@ class SpeechClient(Thread):
     def handle_open(self):
         # TODO: Move this into the Enclosure (not speech client)
         # Reset the UI to indicate ready for speech processing
-        EnclosureAPI(bus).reset()
+        EnclosureAPI(self.bus).reset()
 
     def connect_loop_events(self):
         self.loop.on('recognizer_loop:utterance', self.handle_utterance)
@@ -229,7 +232,3 @@ class SpeechClient(Thread):
         except Exception as e:
             self.status.set_error(e)
         self.status.set_stopping()
-
-
-if __name__ == "__main__":
-    main()

--- a/mycroft/enclosure/gui.py
+++ b/mycroft/enclosure/gui.py
@@ -50,13 +50,16 @@ class SkillGUI:
         self.current_page_idx = -1
         self.skill = skill
         self.on_gui_changed_callback = None
-        self.config = Configuration.get()
 
     @property
     def bus(self):
         if self.skill:
             return self.skill.bus
         return None
+
+    @property
+    def config(self):
+        return Configuration.get()
 
     @property
     def connected(self):

--- a/mycroft/gui/service.py
+++ b/mycroft/gui/service.py
@@ -25,7 +25,6 @@ gui_app_settings = {
 
 class GUIService:
     def __init__(self):
-        self.global_config = Configuration.get()
         # Create Message Bus Client
         self.bus = MessageBusClient()
 
@@ -63,6 +62,10 @@ class GUIService:
         self.bus.on("gui.clear.namespace", self.on_gui_delete_namespace)
         self.bus.on("gui.event.send", self.on_gui_send_event)
         self.bus.on("gui.status.request", self.handle_gui_status_request)
+
+    @property
+    def global_config(self):
+        return Configuration.get()
 
     def create_gui_socket(self):
         import tornado.options

--- a/mycroft/skills/intent_services/adapt_service.py
+++ b/mycroft/skills/intent_services/adapt_service.py
@@ -172,20 +172,23 @@ class AdaptService:
     def __init__(self, config):
         self.config = config
 
-        self.lang = Configuration.get().get("lang", "en-us")
         langs = Configuration.get().get('secondary_langs') or []
         if self.lang not in langs:
             langs.append(self.lang)
 
         self.engines = {lang: IntentDeterminationEngine()
                         for lang in langs}
-        # Context related intializations
+        # Context related initializations
         self.context_keywords = self.config.get('keywords', [])
         self.context_max_frames = self.config.get('max_frames', 3)
         self.context_timeout = self.config.get('timeout', 2)
         self.context_greedy = self.config.get('greedy', False)
         self.context_manager = ContextManager(self.context_timeout)
         self.lock = Lock()
+
+    @property
+    def lang(self):
+        return Configuration.get().get("lang", "en-us")
 
     def update_context(self, intent):
         """Updates context with keyword from the intent.

--- a/mycroft/skills/intent_services/padatious_service.py
+++ b/mycroft/skills/intent_services/padatious_service.py
@@ -114,7 +114,6 @@ class PadatiousService:
         intent_cache = expanduser(self.padatious_config['intent_cache'])
         self._padaos = self.padatious_config.get("padaos_only", False)
 
-        self.lang = Configuration.get().get("lang", "en-us")
         langs = Configuration.get().get('secondary_langs') or []
         if self.lang not in langs:
             langs.append(self.lang)
@@ -154,6 +153,10 @@ class PadatiousService:
 
         self.registered_intents = []
         self.registered_entities = []
+
+    @property
+    def lang(self):
+        return Configuration.get().get("lang", "en-us")
 
     def train(self, message=None):
         """Perform padatious training.

--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -133,8 +133,6 @@ class MycroftSkill:
         self._bus = None
         self._enclosure = None
         self.bind(bus)
-        #: Mycroft global configuration. (dict)
-        self.config_core = Configuration.get()
 
         self.settings = None
         self.settings_write_path = None
@@ -165,6 +163,13 @@ class MycroftSkill:
 
         # Skill Public API
         self.public_api = {}
+
+    @property
+    def config_core(self):
+        """ reads mycroft.conf
+        contains and internal cache and integrates with the bus
+        """
+        return Configuration.get()
 
     @property
     def dialog_renderer(self):
@@ -265,7 +270,7 @@ class MycroftSkill:
         NOTE: this should be public, but since if a skill uses this it wont
         work in regular mycroft-core it was made private! Equivalent PRs in
         mycroft-core have been rejected/abandoned"""
-        return Configuration.get().get("lang", "en-us").lower()
+        return self.config_core.get("lang", "en-us").lower()
 
     @property
     def _secondary_langs(self):

--- a/mycroft/skills/settings.py
+++ b/mycroft/skills/settings.py
@@ -136,7 +136,6 @@ class SettingsMetaUploader:
         self.skill_name = skill_name
         self.json_path = self.skill_directory.joinpath('settingsmeta.json')
         self.yaml_path = self.skill_directory.joinpath('settingsmeta.yaml')
-        self.config = Configuration.get()
         self.settings_meta = {}
         self.api = None
         self.upload_timer = None
@@ -154,6 +153,10 @@ class SettingsMetaUploader:
         # Property placeholders
         self._msm = None
         self._skill_gid = None
+
+    @property
+    def config(self):
+        return Configuration.get()
 
     @property
     def msm(self):

--- a/mycroft/skills/skill_loader.py
+++ b/mycroft/skills/skill_loader.py
@@ -134,9 +134,12 @@ class SkillLoader:
         self.last_loaded = 0
         self.instance = None
         self.active = True
-        self.config = Configuration.get()
 
         self.modtime_error_log_written = False
+
+    @property
+    def config(self):
+        return Configuration.get()
 
     @property
     def is_blacklisted(self):

--- a/mycroft/skills/skill_manager.py
+++ b/mycroft/skills/skill_manager.py
@@ -157,7 +157,6 @@ class SkillManager(Thread):
         self._watchdog = watchdog or (lambda: None)
         self._stop_event = Event()
         self._connected_event = Event()
-        self.config = Configuration.get()
         self.upload_queue = UploadQueue()
 
         self.skill_loaders = {}
@@ -175,6 +174,10 @@ class SkillManager(Thread):
         self.skill_updater = SkillUpdater()
         self._define_message_bus_events()
         self.daemon = True
+
+    @property
+    def config(self):
+        return Configuration.get()
 
     def _define_message_bus_events(self):
         """Define message bus events with handlers defined in this class."""

--- a/mycroft/skills/skill_updater.py
+++ b/mycroft/skills/skill_updater.py
@@ -51,7 +51,6 @@ class SkillUpdater:
     def __init__(self, bus=None):
         self.msm_lock = ComboLock(get_temp_path('mycroft-msm.lck'))
         self.install_retries = 0
-        self.config = Configuration.get()
         update_interval = self.config['skills'].get('update_interval', 1.0)
         self.update_interval = int(update_interval) * ONE_HOUR
         self.dot_msm_path = os.path.join(self.msm.skills_dir, '.msm')
@@ -62,6 +61,10 @@ class SkillUpdater:
 
         if bus:
             self._register_bus_handlers()
+
+    @property
+    def config(self):
+        return Configuration.get()
 
     def _register_bus_handlers(self):
         """TODO: Register bus handlers for triggering updates and such."""


### PR DESCRIPTION
makes `self.config_core` a property, ensures we always get the latest mycroft.conf

`Configuration` is a singleton, keeps an internal cache and reacts to bus events. This does not repeatedly read from disk

this is particularly relevant in the `self.location` property, once PHAL is implemented it will also solve the associated TODO

it is also relevant for `self.lang`, the hypothetical future algorithm to switch mycroft language on the fly will need this

relevant snippet from `MycroftSkill` class
```python
  @property
    def lang(self):
        """Get the current language."""
        lang = self._core_lang
        message = dig_for_message()
        if message:
            lang = message.data.get("lang") or lang
        return lang.lower()

    @property
    def _core_lang(self):
        """Get the configured default language.
        NOTE: this should be public, but since if a skill uses this it wont
        work in regular mycroft-core it was made private! Equivalent PRs in
        mycroft-core have been rejected/abandoned"""
        return self.config_core.get("lang", "en-us").lower()
        
    @property
    def location(self):
        """Get the JSON data struction holding location information."""
        # TODO: Allow Enclosure to override this for devices that
        # contain a GPS.
        return self.config_core.get('location')

    @property
    def location_pretty(self):
        """Get a more 'human' version of the location as a string."""
        loc = self.location
        if type(loc) is dict and loc['city']:
            return loc['city']['name']
        return None

    @property
    def location_timezone(self):
        """Get the timezone code, such as 'America/Los_Angeles'"""
        loc = self.location
        if type(loc) is dict and loc['timezone']:
            return loc['timezone']['code']
        return None
```

related issues:
- https://github.com/MycroftAI/mycroft-core/issues/2859