### PR TITLE
fix/RemoteTTS+remove_requests_futures_dep

### DIFF
--- a/mycroft/tts/remote_tts.py
+++ b/mycroft/tts/remote_tts.py
@@ -13,11 +13,8 @@
 # limitations under the License.
 #
 import abc
-import re
-from requests_futures.sessions import FuturesSession
-
+import requests
 from mycroft.tts.tts import TTS
-from mycroft.util import play_wav
 from mycroft.util.log import LOG
 
 
@@ -32,63 +29,25 @@ class RemoteTTSTimeoutException(RemoteTTSException):
 class RemoteTTS(TTS):
     """
     Abstract class for a Remote TTS engine implementation.
-
-    It provides a common logic to perform multiple requests by splitting the
-    whole sentence into small ones.
+    This class is only provided as import for mycroft plugins that do not use OPM
+    Usage is discouraged
     """
-
     def __init__(self, lang, config, url, api_path, validator):
         super(RemoteTTS, self).__init__(lang, config, validator)
         self.api_path = api_path
         self.auth = None
         self.url = config.get('url', url).rstrip('/')
-        self.session = FuturesSession()
-
-    def execute(self, sentence, ident=None, listen=False):
-        phrases = self.__get_phrases(sentence)
-
-        if len(phrases) > 0:
-            for req in self.__requests(phrases):
-                try:
-                    self.begin_audio()
-                    self.__play(req)
-                except Exception as e:
-                    LOG.error(e.message)
-                finally:
-                    self.end_audio(listen)
-
-    @staticmethod
-    def __get_phrases(sentence):
-        phrases = re.split(r'\.+[\s+|\n]', sentence)
-        phrases = [p.replace('\n', '').strip() for p in phrases]
-        phrases = [p for p in phrases if len(p) > 0]
-        return phrases
-
-    def __requests(self, phrases):
-        reqs = []
-        for p in phrases:
-            reqs.append(self.__request(p))
-        return reqs
-
-    def __request(self, p):
-        return self.session.get(
-            self.url + self.api_path, params=self.build_request_params(p),
-            timeout=10, verify=False, auth=self.auth)
 
     @abc.abstractmethod
     def build_request_params(self, sentence):
         pass
 
-    def __play(self, req):
-        resp = req.result()
-        if resp.status_code == 200:
-            self.__save(resp.content)
-            play_wav(self.filename).communicate()
-        else:
-            LOG.error(
-                '%s Http Error: %s for url: %s' %
-                (resp.status_code, resp.reason, resp.url))
-
-    def __save(self, data):
-        with open(self.filename, 'wb') as f:
-            f.write(data)
+    def get_tts(self, sentence, wav_file, lang=None):
+        r = requests.get(
+            self.url + self.api_path, params=self.build_request_params(sentence),
+            timeout=10, verify=False, auth=self.auth)
+        if r.status_code != 200:
+            return None
+        with open(wav_file, 'wb') as f:
+            f.write(r.content)
+        return wav_file, None

--- a/requirements/extra-mycroft.txt
+++ b/requirements/extra-mycroft.txt
@@ -5,7 +5,6 @@ pyee==8.1.0
 SpeechRecognition==3.8.1
 tornado~=6.1
 websocket-client~=1.2.1
-requests-futures==0.9.5
 pyserial==3.0
 psutil==5.6.6
 pocketsphinx==0.1.0

--- a/requirements/minimal.txt
+++ b/requirements/minimal.txt
@@ -5,5 +5,4 @@ pyxdg~=0.26
 mycroft-messagebus-client~=0.9.1,!=0.9.2,!=0.9.3
 psutil~=5.6.6
 combo-lock~=0.2
-requests-futures~=0.9.5
 ovos-plugin-manager>=0.0.2

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -3,7 +3,6 @@ PyAudio~=0.2.11
 pyee~=8.1
 SpeechRecognition~=3.8.1
 tornado~=6.0, >=6.0.3
-requests-futures~=0.9.5
 psutil~=5.6.6
 python-dateutil~=2.6.0
 combo-lock~=0.2


### PR DESCRIPTION
requests futures was only used by RemoteTTS base class, dated from 2016

RemoteTTS is basically unused, wasnt even ported to OPM and is only present for backwards compat imports. The sentence chunking has not been updated for a long time, the filename is not respected properly, it only supports .wav ....

This PR simplifies it to depend only on requests and no longer overrides the execute method, it behaves like any regular TTS now. Bugs are fixed at the cost of no automatic sentence chunking, text size limits should be handled in individual plugins and do not belong in the base class anyway imho

I do not know of any TTS depending on this, no plugins use it and individual engines have been removed in #1 

fixed bugs:
- self.filename is hardcoded to .wav (mycroft-core fixed in ovos-core)
- only wav format was supported
- tts execution skipped the TTS playback thread