### PR TITLE
refactor/relax_deps

### DIFF
--- a/requirements/minimal.txt
+++ b/requirements/minimal.txt
@@ -1,5 +1,5 @@
 requests~=2.20.0
-pyee~=8.1.0
+pyee>=8.1.0
 mock_msm~=0.9.2
 pyxdg~=0.26
 mycroft-messagebus-client~=0.9.1,!=0.9.2,!=0.9.3

--- a/requirements/minimal.txt
+++ b/requirements/minimal.txt
@@ -1,5 +1,5 @@
 requests~=2.20.0
-pyee>=8.1.0
+pyee~=8.1
 mock_msm~=0.9.2
 pyxdg~=0.26
 mycroft-messagebus-client~=0.9.1,!=0.9.2,!=0.9.3

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,6 +1,6 @@
 requests~=2.20.0
 PyAudio~=0.2.11
-pyee>=8.1.0
+pyee~=8.1
 SpeechRecognition~=3.8.1
 tornado~=6.0.3
 websocket-client>=0.54.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,7 +1,6 @@
 requests~=2.20.0
-gTTS~=2.2.2
 PyAudio~=0.2.11
-pyee~=8.1.0
+pyee>=8.1.0
 SpeechRecognition~=3.8.1
 tornado~=6.0.3
 websocket-client>=0.54.0
@@ -31,6 +30,4 @@ adapt-parser>=0.5.1
 padatious~=0.4.8
 fann2==1.0.7
 padaos~=0.1.9
-precise-runner~=0.2.1
-petact~=0.1.2
 pyxdg~=0.26

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ def required(requirements_file):
         requirements = f.read().splitlines()
         if 'MYCROFT_LOOSE_REQUIREMENTS' in os.environ:
             print('USING LOOSE REQUIREMENTS!')
-            requirements = [r.replace('==', '>=') for r in requirements]
+            requirements = [r.replace('==', '>=').replace('~=', '>=') for r in requirements]
         return [pkg for pkg in requirements
                 if pkg.strip() and not pkg.startswith("#")]
 


### PR DESCRIPTION
- pyee is pinned by mycroft-bus-client, but we can use a newer version
- removed deps that are defined by individual plugin modules now
- fix ` 'MYCROFT_LOOSE_REQUIREMENTS'` flag to support `~=`