### PR TITLE
Refactor/ simplify skill loading

### DIFF
--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -171,6 +171,8 @@ class MycroftSkill:
 
     @property
     def is_fully_initialized(self):
+        """Determines if the skill has been fully loaded and setup.
+        When True all data has been loaded and all internal state and events setup"""
         return self._init_event.is_set()
 
     def handle_first_run(self):
@@ -203,7 +205,9 @@ class MycroftSkill:
                 but skill loader can override this
         """
         if self.is_fully_initialized:
-            return  # already initialized
+            LOG.warning(f"Tried to initialize {self.skill_id} multiple times, ignoring")
+            return
+
         # NOTE: this method is called by SkillLoader
         # it is private to make it clear to skill devs they should not touch it
         try:

--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -114,13 +114,15 @@ class MycroftSkill:
     Args:
         name (str): skill name
         bus (MycroftWebsocketClient): Optional bus connection
-        use_settings (bool): Set to false to not use skill settings at all
+        use_settings (bool): Set to false to not use skill settings at all (DEPRECATED)
     """
 
     def __init__(self, name=None, bus=None, use_settings=True):
+        self._init_event = Event()
+
         self.name = name or self.__class__.__name__
         self.resting_name = None
-        self.skill_id = ''  # will be set from the path, so guaranteed unique
+        self.skill_id = ''  # will be set by SkillLoader, guaranteed unique
         self.settings_meta = None  # set when skill is loaded in SkillLoader
 
         # Get directory of skill
@@ -132,15 +134,16 @@ class MycroftSkill:
 
         self._bus = None
         self._enclosure = None
-        self.bind(bus)
+
         #: Mycroft global configuration. (dict)
         self.config_core = Configuration.get()
 
         self.settings = None
         self.settings_write_path = None
 
-        if use_settings:
-            self._init_settings()
+        # old kludge from fallback skills, unused according to grep
+        if use_settings is False:
+            LOG.warning("use_settings has been deprecated! skill settings are always enabled")
 
         #: Set to register a callback method that will be called every time
         #: the skills settings are updated. The referenced method should
@@ -165,6 +168,69 @@ class MycroftSkill:
 
         # Skill Public API
         self.public_api = {}
+
+    @property
+    def is_fully_initialized(self):
+        return self._init_event.is_set()
+
+    def handle_first_run(self):
+        """The very first time a skill is run, speak the intro."""
+        intro = self.get_intro_message()
+        if intro:
+            # supports .dialog files for easy localization
+            # when .dialog does not exist, the text is spoken
+            # it is backwards compatible
+            self.speak_dialog(intro)
+
+    def _check_for_first_run(self):
+        """Determine if its the very first time a skill is run."""
+        first_run = self.settings.get("__mycroft_skill_firstrun", True)
+        if first_run:
+            LOG.info("First run of " + self.skill_id)
+            self.handle_first_run()
+            self.settings["__mycroft_skill_firstrun"] = False
+            save_settings(self.settings_write_path, self.settings)
+
+    def _startup(self, bus, skill_id=""):
+        """Startup the skill.
+
+        This connects the skill to the messagebus, loads vocabularies and
+        data files and in the end calls the skill creator's "intialize" code.
+
+        Arguments:
+            bus: Mycroft Messagebus connection object.
+            skill_id (str): need to be unique, by default is set from skill path
+                but skill loader can override this
+        """
+        if self.is_fully_initialized:
+            return  # already initialized
+        # NOTE: this method is called by SkillLoader
+        # it is private to make it clear to skill devs they should not touch it
+        try:
+            # set the skill_id
+            self.skill_id = skill_id or basename(self.root_dir)
+            self.intent_service.set_id(self.skill_id)
+            self.event_scheduler.set_id(self.skill_id)
+            self._init_settings()
+
+            # initialize anything that depends on the messagebus
+            self.bind(bus)
+            self.load_data_files()
+            self._register_decorated()
+            self.register_resting_screen()
+
+            # run skill developer initialization code
+            self.initialize()
+            self._check_for_first_run()
+            self._init_event.set()
+        except Exception as e:
+            LOG.exception('Skill initialization failed')
+            # If an exception occurs, attempt to clean up the skill
+            try:
+                self.default_shutdown()
+            except Exception as e2:
+                pass
+            raise e
 
     @property
     def dialog_renderer(self):
@@ -323,9 +389,7 @@ class MycroftSkill:
             self._bus = bus
             self.events.set_bus(bus)
             self.intent_service.set_bus(bus)
-            self.intent_service.set_id(self.skill_id)
             self.event_scheduler.set_bus(bus)
-            self.event_scheduler.set_id(self.skill_id)
             self._enclosure = EnclosureAPI(bus, self.name)
             self._register_system_event_handlers()
             # Initialize the SkillGui

--- a/mycroft/skills/skill_loader.py
+++ b/mycroft/skills/skill_loader.py
@@ -16,8 +16,9 @@
 import gc
 import importlib
 import os
-import sys
 from os import path, makedirs
+import sys
+from inspect import isclass, signature
 from time import time
 
 import xdg.BaseDirectory
@@ -25,8 +26,8 @@ import xdg.BaseDirectory
 from mycroft.configuration import Configuration
 from ovos_utils.configuration import get_xdg_base, is_using_xdg
 from mycroft.messagebus import Message
+from mycroft.skills.mycroft_skill.mycroft_skill import MycroftSkill
 from mycroft.skills.settings import SettingsMetaUploader
-from mycroft.skills.settings import save_settings
 from mycroft.util.log import LOG
 
 SKILL_MAIN_MODULE = '__init__.py'
@@ -168,15 +169,15 @@ def remove_submodule_refs(module_name):
         module_name: name of skill module.
     """
     submodules = []
-    LOG.debug('Skill module: {}'.format(module_name))
+    LOG.debug(f'Skill module: {module_name}')
     # Collect found submodules
     for m in sys.modules:
         if m.startswith(module_name + '.'):
             submodules.append(m)
     # Remove all references them to in sys.modules
     for m in submodules:
-        LOG.debug('Removing sys.modules ref for {}'.format(m))
-        del (sys.modules[m])
+        LOG.debug(f'Removing sys.modules ref for {m}')
+        del sys.modules[m]
 
 
 def load_skill_module(path, skill_id):
@@ -243,11 +244,50 @@ def _get_last_modified_time(path):
     # Ensure modification times are valid
     bad_times = _bad_mod_times(mod_times)
     if bad_times:
-        raise OSError('{} had bad modification times'.format(bad_times))
+        raise OSError(f'{bad_times} had bad modification times')
     if all_files:
         return max(os.path.getmtime(f) for f in all_files)
     else:
         return 0
+
+
+def get_skill_class(skill_module):
+    """Find MycroftSkill based class in skill module.
+
+    Arguments:
+        skill_module (module): module to search for Skill class
+
+    Returns:
+        (MycroftSkill): Found subclass of MycroftSkill or None.
+    """
+    candidates = []
+    for name, obj in skill_module.__dict__.items():
+        if isclass(obj):
+            if issubclass(obj, MycroftSkill) and obj is not MycroftSkill:
+                candidates.append(obj)
+
+    if len(candidates) > 1:
+        LOG.warning(f"Multiple skills found in a single file!\n"
+                    f"{candidates}")
+    if candidates:
+        LOG.debug(f"Loading skill class: {candidates[0]}")
+        return candidates[0]
+    return None
+
+
+def get_create_skill_function(skill_module):
+    """Find create_skill function in skill module.
+
+    Arguments:
+        skill_module (module): module to search for create_skill function
+
+    Returns:
+        (function): Found create_skill function or None.
+    """
+    if hasattr(skill_module, "create_skill") and \
+            callable(skill_module.create_skill):
+        return skill_module.create_skill
+    return None
 
 
 class SkillLoader:
@@ -287,8 +327,7 @@ class SkillLoader:
             self.last_modified = self.last_loaded
             if not self.modtime_error_log_written:
                 self.modtime_error_log_written = True
-                LOG.error('Failed to get last_modification time '
-                          '({})'.format(repr(err)))
+                LOG.error(f'Failed to get last_modification time ({err})')
         else:
             self.modtime_error_log_written = False
 
@@ -339,10 +378,9 @@ class SkillLoader:
         try:
             self.instance.default_shutdown()
         except Exception:
-            log_msg = 'An error occurred while shutting down {}'
-            LOG.exception(log_msg.format(self.instance.name))
+            LOG.exception(f'An error occurred while shutting down {self.skill_id}')
         else:
-            LOG.info('Skill {} shut down successfully'.format(self.skill_id))
+            LOG.info(f'Skill {self.skill_id} shut down successfully')
 
     def _garbage_collect(self):
         """Invoke Python garbage collector to remove false references"""
@@ -350,17 +388,14 @@ class SkillLoader:
         # Remove two local references that are known
         refs = sys.getrefcount(self.instance) - 2
         if refs > 0:
-            log_msg = (
-                "After shutdown of {} there are still {} references "
+            LOG.warning(
+                f"After shutdown of {self.skill_id} there are still {refs} references "
                 "remaining. The skill won't be cleaned from memory."
             )
-            LOG.warning(log_msg.format(self.instance.name, refs))
 
     def _emit_skill_shutdown_event(self):
-        message = Message(
-            "mycroft.skills.shutdown",
-            data=dict(path=self.skill_directory, id=self.skill_id)
-        )
+        message = Message("mycroft.skills.shutdown",
+                          {"path": self.skill_directory, "id": self.skill_id})
         self.bus.emit(message)
 
     def _load(self):
@@ -370,7 +405,6 @@ class SkillLoader:
         else:
             skill_module = self._load_skill_source()
             if skill_module and self._create_skill_instance(skill_module):
-                self._check_for_first_run()
                 self.loaded = True
 
         self.last_loaded = time()
@@ -390,95 +424,57 @@ class SkillLoader:
         self.instance = None
 
     def _skip_load(self):
-        log_msg = 'Skill {} is blacklisted - it will not be loaded'
-        LOG.info(log_msg.format(self.skill_id))
+        LOG.info(f'Skill {self.skill_id} is blacklisted - it will not be loaded')
 
     def _load_skill_source(self):
         """Use Python's import library to load a skill's source code."""
         main_file_path = os.path.join(self.skill_directory, SKILL_MAIN_MODULE)
+        skill_module = None
         if not os.path.exists(main_file_path):
-            error_msg = 'Failed to load {} due to a missing file.'
-            LOG.error(error_msg.format(self.skill_id))
+            LOG.error(f'Failed to load {self.skill_id} due to a missing file.')
         else:
             try:
                 skill_module = load_skill_module(main_file_path, self.skill_id)
             except Exception as e:
-                LOG.exception('Failed to load skill: '
-                              '{} ({})'.format(self.skill_id, repr(e)))
-            else:
-                module_is_skill = (
-                        hasattr(skill_module, 'create_skill') and
-                        callable(skill_module.create_skill)
-                )
-                if module_is_skill:
-                    return skill_module
-        return None  # Module wasn't loaded
+                LOG.exception(f'Failed to load skill: {self.skill_id} ({e})')
+        return skill_module
 
     def _create_skill_instance(self, skill_module):
-        """Use v2 skills framework to create the skill."""
-        try:
-            self.instance = skill_module.create_skill()
-        except Exception as e:
-            log_msg = 'Skill __init__ failed with {}'
-            LOG.exception(log_msg.format(repr(e)))
-            self.instance = None
+        """create the skill object.
 
-        if self.instance:
-            self.instance.skill_id = self.skill_id
-            self.instance.bind(self.bus)
-            try:
-                self.instance.load_data_files()
-                # Set up intent handlers
-                # TODO: can this be a public method?
-                self.instance._register_decorated()
-                self.instance.register_resting_screen()
-                self.instance.initialize()
-            except Exception as e:
-                LOG.exception(f'Skill initialization failed: {e}')
-                # If an exception occurs, attempt to clean up the skill
-                try:
-                    self.instance.default_shutdown()
-                except Exception as e2:
-                    # if initialize failed then it's likely
-                    # default_shutdown will fail
-                    LOG.debug(f'Skill cleanup failed: {e2}')
-                    LOG.debug(f'this is usually fine and often expected')
-                self.instance = None
+        Arguments:
+            skill_module (module): Module to load from
+
+        Returns:
+            (bool): True if skill was loaded successfully.
+        """
+        try:
+            skill_creator = get_create_skill_function(skill_module) or \
+                            get_skill_class(skill_module)
+
+            # create the skill
+            self.instance = skill_creator()
+
+            if not self.instance.is_fully_initialized:
+                # finish initialization of skill class
+                self.instance._startup(self.bus, self.skill_id)
+        except Exception as e:
+            LOG.exception(f'Skill __init__ failed with {e}')
+            self.instance = None
 
         return self.instance is not None
 
-    def _check_for_first_run(self):
-        """The very first time a skill is run, speak the intro."""
-        first_run = self.instance.settings.get(
-            "__mycroft_skill_firstrun",
-            True
-        )
-        if first_run:
-            LOG.info("First run of " + self.skill_id)
-            self.instance.settings["__mycroft_skill_firstrun"] = False
-            save_settings(self.instance.settings_write_path,
-                          self.instance.settings)
-            intro = self.instance.get_intro_message()
-            if intro:
-                self.instance.speak(intro)
-
     def _communicate_load_status(self):
         if self.loaded:
-            message = Message(
-                'mycroft.skills.loaded',
-                data=dict(
-                    path=self.skill_directory,
-                    id=self.skill_id,
-                    name=self.instance.name,
-                    modified=self.last_modified
-                )
-            )
+            message = Message('mycroft.skills.loaded',
+                              {"path": self.skill_directory,
+                               "id": self.skill_id,
+                               "name": self.instance.name,
+                               "modified": self.last_modified})
             self.bus.emit(message)
-            LOG.info('Skill {} loaded successfully'.format(self.skill_id))
+            LOG.info(f'Skill {self.skill_id} loaded successfully')
         else:
-            message = Message(
-                'mycroft.skills.loading_failure',
-                data=dict(path=self.skill_directory, id=self.skill_id)
-            )
+            message = Message('mycroft.skills.loading_failure',
+                              {"path": self.skill_directory, "id": self.skill_id})
             self.bus.emit(message)
-            LOG.error('Skill {} failed to load'.format(self.skill_id))
+            LOG.error(f'Skill {self.skill_id} failed to load')

--- a/mycroft/skills/skill_loader.py
+++ b/mycroft/skills/skill_loader.py
@@ -26,9 +26,12 @@ import xdg.BaseDirectory
 from mycroft.configuration import Configuration
 from ovos_utils.configuration import get_xdg_base, is_using_xdg
 from mycroft.messagebus import Message
-from mycroft.skills.mycroft_skill.mycroft_skill import MycroftSkill
 from mycroft.skills.settings import SettingsMetaUploader
 from mycroft.util.log import LOG
+
+from mycroft.skills import MycroftSkill, CommonIoTSkill, CommonQuerySkill, CommonPlaySkill, FallbackSkill
+from ovos_workshop.skills import OVOSSkill, OVOSFallbackSkill
+from ovos_workshop.skills.common_play import OVOSCommonPlaybackSkill
 
 SKILL_MAIN_MODULE = '__init__.py'
 
@@ -260,10 +263,15 @@ def get_skill_class(skill_module):
     Returns:
         (MycroftSkill): Found subclass of MycroftSkill or None.
     """
+    mycroft_base_classes = [MycroftSkill, CommonIoTSkill, CommonQuerySkill, CommonPlaySkill, FallbackSkill]
+    ovos_base_classes = [OVOSSkill, OVOSFallbackSkill, OVOSCommonPlaybackSkill]
+    skill_base_classes = mycroft_base_classes + ovos_base_classes
+
     candidates = []
     for name, obj in skill_module.__dict__.items():
         if isclass(obj):
-            if issubclass(obj, MycroftSkill) and obj is not MycroftSkill:
+            if issubclass(obj, MycroftSkill) and \
+                    not any(obj is b for b in skill_base_classes):
                 candidates.append(obj)
 
     if len(candidates) > 1:


### PR DESCRIPTION
refactor/simplify_skill_loading

This is an attempt at streamlining the skill loading process.
- Load skills directly from class
- Moves the setup code closer to where it's expected to be found (MycroftSkill class).
- Removes some boiler-plate code (create_skill function)
- the skill settings initialization is now ensured to be done after skill_id is set
- skill filesystem initialization is now ensured to be done after skill_id is set
- move first run check to skill class
- the unused `use_settings` argument has been deprecated , related issue https://github.com/MycroftAI/mycroft-core/issues/2848

based on https://github.com/MycroftAI/mycroft-core/pull/2855

the skill settings initialization is now ensured to be done after skill_id is set partially replacing #11 

the new startup method also ensures correctness of skill_id for #9 