### PR TITLE
Refactor/converse

### DIFF
--- a/mycroft/skills/intent_service.py
+++ b/mycroft/skills/intent_service.py
@@ -184,7 +184,9 @@ class IntentService:
         self.converse.converse_with_skills(None, lang, message)
 
     def do_converse(self, utterances, skill_id, lang, message):
-        """Call skill and ask if they want to process the utterance.
+        """DEPRECATED: do not use, method only for api backwards compatibility
+
+        Logs a warning and calls ConverseService.converse
 
         Args:
             utterances (list of tuples): utterances paired with normalized
@@ -199,15 +201,16 @@ class IntentService:
         return self.converse.converse(utterances, skill_id, lang, message)
 
     def handle_converse_error(self, message):
-        """Handle error in converse system.
-        Args:
-            message (Message): info about the error.
+        """DEPRECATED: do not use, method only for api backwards compatibility
+        Logs a warning
         """
         # NOTE: can not delete method for backwards compat with upstream
         LOG.warning("handle_converse_error has been deprecated!")
 
     def remove_active_skill(self, skill_id):
-        """Remove a skill from being targetable by converse.
+        """DEPRECATED: do not use, method only for api backwards compatibility
+
+        Logs a warning and calls ConverseService.deactivate_skill
 
         Args:
             skill_id (str): skill to remove
@@ -218,10 +221,9 @@ class IntentService:
         self.converse.deactivate_skill(skill_id)
 
     def add_active_skill(self, skill_id):
-        """Add a skill or update the position of an active skill.
+        """DEPRECATED: do not use, method only for api backwards compatibility
 
-        The skill is added to the front of the list, if it's already in the
-        list it's removed so there is only a single entry of it.
+        Logs a warning and calls ConverseService.activate_skill
 
         Args:
             skill_id (str): identifier of skill to be added.

--- a/mycroft/skills/intent_service.py
+++ b/mycroft/skills/intent_service.py
@@ -13,22 +13,21 @@
 # limitations under the License.
 #
 """Mycroft's intent service, providing intent parsing since forever!"""
-from copy import copy
 import time
+from threading import Event
 
 from mycroft.configuration import Configuration, setup_locale
+from mycroft.messagebus.message import Message
+from mycroft.metrics import report_timing, Stopwatch
+from mycroft.skills.intent_service_interface import open_intent_envelope
+from mycroft.skills.intent_services import (
+    AdaptService, FallbackService,
+    PadatiousService, PadatiousMatcher,
+    ConverseService, IntentMatch
+)
+from mycroft.skills.permissions import ConverseMode, ConverseActivationMode
 from mycroft.util.log import LOG
 from mycroft.util.parse import normalize
-from mycroft.metrics import report_timing, Stopwatch
-from mycroft.skills.intent_services import (
-    AdaptService, AdaptIntent,
-    FallbackService,
-    PadatiousService, PadatiousMatcher,
-    IntentMatch
-)
-from mycroft.skills.intent_service_interface import open_intent_envelope
-from mycroft.skills.permissions import ConverseMode, ConverseActivationMode
-from mycroft.messagebus.message import Message
 
 
 def _get_message_lang(message):
@@ -88,14 +87,13 @@ class IntentService:
 
         # Dictionary for translating a skill id to a name
         self.skill_names = {}
-
         self.adapt_service = AdaptService(config.get('context', {}))
         try:
             self.padatious_service = PadatiousService(bus, config['padatious'])
         except Exception as err:
-            LOG.exception('Failed to create padatious handlers '
-                          '({})'.format(repr(err)))
+            LOG.exception(f'Failed to create padatious handlers ({err})')
         self.fallback = FallbackService(bus)
+        self.converse = ConverseService(bus)
 
         self.bus.on('register_vocab', self.handle_register_vocab)
         self.bus.on('register_intent', self.handle_register_intent)
@@ -108,7 +106,6 @@ class IntentService:
         self.bus.on('clear_context', self.handle_clear_context)
 
         # Converse method
-        self.converse_config = config["skills"].get("converse") or {}
         self.bus.on('mycroft.speech.recognition.unknown', self.reset_converse)
         self.bus.on('mycroft.skills.loaded', self.update_skill_name_dict)
 
@@ -118,9 +115,6 @@ class IntentService:
                     self.handle_deactivate_skill_request)
         # TODO backwards compat, deprecate
         self.bus.on('active_skill_request', self.handle_activate_skill_request)
-
-        self.active_skills = []  # [skill_id , timestamp]
-        self._consecutive_activations = {}
 
         # Intents API
         self.registered_vocab = []
@@ -161,67 +155,18 @@ class IntentService:
         return self.skill_names.get(skill_id, skill_id)
 
     # converse handling
-    def handle_activate_skill_request(self, message):
+    @property
+    def active_skills(self):
+        return self.converse.active_skills  # [skill_id , timestamp]
 
+    def handle_activate_skill_request(self, message):
+        # TODO imperfect solution - only a skill can activate itself
+        # someone can forge this message and emit it raw, but in OpenVoiceOS all
+        # skill messages should have skill_id in context, so let's make sure
+        # this doesnt happen accidentally at very least
         skill_id = message.data['skill_id']
-
-        # cross activation control if skills can activate each other
-        if not self.converse_config.get("cross_activation"):
-            # TODO imperfect solution - only a skill can activate itself
-            # someone can forge this message and emit it raw, but in OpenVoiceOS all
-            # skill messages should have skill_id in context, so let's make sure
-            # this doesnt happen accidentally at very least
-            source_skill = message.context.get("skill_id") or skill_id
-            if skill_id != source_skill:
-                # different skill is trying to activate this skill
-                return
-
-        # mode of activation dictates under what conditions a skill is
-        # allowed to activate itself
-        acmode = self.converse_config.get("converse_activation") or \
-                 ConverseActivationMode.ACCEPT_ALL
-
-        if acmode == ConverseActivationMode.PRIORITY:
-            prio = self.converse_config.get("converse_priorities") or {}
-            # only allowed to activate if no skill with higher priority is
-            # active, currently there is no api for skills to
-            # define their default priority, this is a user/developer setting
-            priority = prio.get(skill_id, 50)
-            if any(p > priority for p in
-                   [prio.get(s[0], 50) for s in self.active_skills]):
-                return
-
-        if acmode == ConverseActivationMode.BLACKLIST:
-            if skill_id in self.converse_config.get("converse_blacklist", []):
-                return
-
-        if acmode == ConverseActivationMode.WHITELIST:
-            if skill_id not in self.converse_config.get("converse_whitelist", []):
-                return
-
-        # limit of consecutive activations
-        default_max = self.converse_config.get("max_activations", -1)
-        # per skill override limit of consecutive activations
-        skill_max = self.converse_config.get("skill_activations", {}).get(skill_id)
-        max_activations = skill_max or default_max
-        if skill_id not in self._consecutive_activations:
-            self._consecutive_activations[skill_id] = 0
-        if max_activations < 0:
-            pass  # no limit (mycroft-core default)
-        elif max_activations == 0:
-            return  # skill activation disabled
-        elif self._consecutive_activations.get(skill_id, 0) > max_activations:
-            return  # skill exceeded authorized consecutive number of
-                    # activations
-
-        # activate skill
-        self.add_active_skill(skill_id)
-        self._consecutive_activations[skill_id] += 1
-
-        # converse handling
-
-    def handle_activate_skill_request(self, message):
-        self.add_active_skill(message.data['skill_id'])
+        source_skill = message.context.get("skill_id")
+        self.converse.activate_skill(skill_id, source_skill)
 
     def handle_deactivate_skill_request(self, message):
         # TODO imperfect solution - only a skill can deactivate itself
@@ -230,15 +175,13 @@ class IntentService:
         # this doesnt happen accidentally
         skill_id = message.data['skill_id']
         source_skill = message.context.get("skill_id") or skill_id
-        if skill_id == source_skill:
-            self.remove_active_skill(message.data['skill_id'])
+        self.converse.deactivate_skill(skill_id, source_skill)
 
     def reset_converse(self, message):
         """Let skills know there was a problem with speech recognition"""
         lang = _get_message_lang(message)
         setup_locale(lang)  # restore default lang
-        for skill in copy(self.active_skills):
-            self.do_converse(None, skill[0], lang, message)
+        self.converse.converse_with_skills(None, lang, message)
 
     def do_converse(self, utterances, skill_id, lang, message):
         """Call skill and ask if they want to process the utterance.
@@ -250,41 +193,18 @@ class IntentService:
             lang (str): current language
             message (Message): message containing interaction info.
         """
-        opmode = self.converse_config.get("converse_mode",
-                                          ConverseMode.ACCEPT_ALL)
-
-        if opmode == ConverseMode.BLACKLIST and skill_id in \
-                self.converse_config.get("converse_blacklist", []):
-            return False
-
-        elif opmode == ConverseMode.WHITELIST and skill_id not in \
-                self.converse_config.get("converse_whitelist", []):
-            return False
-
-        converse_msg = (message.reply("skill.converse.request", {
-            "skill_id": skill_id, "utterances": utterances, "lang": lang}))
-        result = self.bus.wait_for_response(converse_msg,
-                                            'skill.converse.response')
-        if result and 'error' in result.data:
-            self.handle_converse_error(result)
-            ret = False
-        elif result is not None:
-            ret = result.data.get('result', False)
-        else:
-            ret = False
-        return ret
+        # NOTE: can not delete method for backwards compat with upstream
+        LOG.warning("self.do_converse has been deprecated!\n"
+                    "use self.converse.converse instead")
+        return self.converse.converse(utterances, skill_id, lang, message)
 
     def handle_converse_error(self, message):
         """Handle error in converse system.
-
         Args:
             message (Message): info about the error.
         """
-        skill_id = message.data["skill_id"]
-        error_msg = message.data['error']
-        LOG.error("{}: {}".format(skill_id, error_msg))
-        if message.data["error"] == "skill id does not exist":
-            self.remove_active_skill(skill_id)
+        # NOTE: can not delete method for backwards compat with upstream
+        LOG.warning("handle_converse_error has been deprecated!")
 
     def remove_active_skill(self, skill_id):
         """Remove a skill from being targetable by converse.
@@ -292,14 +212,10 @@ class IntentService:
         Args:
             skill_id (str): skill to remove
         """
-        for skill in self.active_skills:
-            if skill[0] == skill_id:
-                self.active_skills.remove(skill)
-                self.bus.emit(
-                    Message("intent.service.skills.deactivated",
-                            {"skill_id": skill_id}))
-                if skill_id in self._consecutive_activations:
-                    self._consecutive_activations[skill_id] = 0
+        # NOTE: can not delete method for backwards compat with upstream
+        LOG.warning("self.remove_active_skill has been deprecated!\n"
+                    "use self.converse.deactivate_skill instead")
+        self.converse.deactivate_skill(skill_id)
 
     def add_active_skill(self, skill_id):
         """Add a skill or update the position of an active skill.
@@ -310,21 +226,10 @@ class IntentService:
         Args:
             skill_id (str): identifier of skill to be added.
         """
-        # search the list for an existing entry that already contains it
-        # and remove that reference
-        if skill_id != '':
-            # do not call remove method to not send deactivate bus event!
-            for skill in self.active_skills:
-                if skill[0] == skill_id:
-                    self.active_skills.remove(skill)
-            # add skill with timestamp to start of skill_list
-            self.active_skills.insert(0, [skill_id, time.time()])
-            self.bus.emit(
-                Message("intent.service.skills.activated",
-                        {"skill_id": skill_id}))
-        else:
-            LOG.warning('Skill ID was empty, won\'t add to list of '
-                        'active skills.')
+        # NOTE: can not delete method for backwards compat with upstream
+        LOG.warning("self.add_active_skill has been deprecated!\n"
+                    "use self.converse.activate_skill instead")
+        self.converse.activate_skill(skill_id)
 
     def send_metrics(self, intent, context, stopwatch):
         """Send timing metrics to the backend.
@@ -392,7 +297,7 @@ class IntentService:
             # List of functions to use to match the utterance with intent.
             # These are listed in priority order.
             match_funcs = [
-                self._converse, padatious_matcher.match_high,
+                self.converse.converse_with_skills, padatious_matcher.match_high,
                 self.adapt_service.match_intent, self.fallback.high_prio,
                 padatious_matcher.match_medium, self.fallback.medium_prio,
                 padatious_matcher.match_low, self.fallback.low_prio
@@ -407,7 +312,7 @@ class IntentService:
                         break
             if match:
                 if match.skill_id:
-                    self.add_active_skill(match.skill_id)
+                    self.converse.activate_skill(match.skill_id)
                     # If the service didn't report back the skill_id it
                     # takes on the responsibility of making the skill "active"
 
@@ -427,35 +332,6 @@ class IntentService:
             self.send_metrics(match, message.context, stopwatch)
         except Exception as err:
             LOG.exception(err)
-
-    def _converse(self, utterances, lang, message):
-        """Give active skills a chance at the utterance
-
-        Args:
-            utterances (list):  list of utterances
-            lang (string):      4 letter ISO language code
-            message (Message):  message to use to generate reply
-
-        Returns:
-            IntentMatch if handled otherwise None.
-        """
-        utterances = [item for tup in utterances for item in tup]
-
-        # check for conversation time-out
-        skill_timeouts = self.converse_config.get("skill_timeouts") or {}
-        default_timeout = self.converse_config.get("timeout", 300)
-        self.active_skills = [
-            skill for skill in self.active_skills
-            if time.time() - skill[1] <= skill_timeouts.get(skill[0],
-                                                            default_timeout)]
-
-        # check if any skill wants to handle utterance
-        for skill in copy(self.active_skills):
-            if self.do_converse(utterances, skill[0], lang, message):
-                # update timestamp, or there will be a timeout where
-                # intent stops conversing whether its being used or not
-                return IntentMatch('Converse', None, None, skill[0])
-        return None
 
     def send_complete_intent_failure(self, message):
         """Send a message that no skill could handle the utterance.
@@ -608,7 +484,7 @@ class IntentService:
             message: query message to reply to.
         """
         self.bus.emit(message.reply("intent.service.active_skills.reply",
-                                    {"skills": self.active_skills}))
+                                    {"skills": self.converse.active_skills}))
 
     def handle_get_adapt(self, message):
         """handler getting the adapt response for an utterance.

--- a/mycroft/skills/intent_services/__init__.py
+++ b/mycroft/skills/intent_services/__init__.py
@@ -4,3 +4,4 @@ from mycroft.skills.intent_services.base import IntentMatch
 from mycroft.skills.intent_services.fallback_service import FallbackService
 from mycroft.skills.intent_services.padatious_service \
     import PadatiousService, PadatiousMatcher
+from mycroft.skills.intent_services.converse_service import ConverseService

--- a/mycroft/skills/intent_services/converse_service.py
+++ b/mycroft/skills/intent_services/converse_service.py
@@ -1,0 +1,215 @@
+import time
+
+from mycroft.configuration import Configuration
+from mycroft.messagebus.message import Message
+from mycroft.skills.intent_services import (
+    IntentMatch
+)
+from mycroft.skills.permissions import ConverseMode, ConverseActivationMode
+from mycroft.util.log import LOG
+
+
+class ConverseService:
+    """Intent Service handling conversational skills."""
+
+    def __init__(self, bus):
+        self.bus = bus
+        self._consecutive_activations = {}
+        self.active_skills = []  # [skill_id , timestamp]
+
+    @property
+    def config(self):
+        return Configuration.get().get("skills", {}).get("converse") or {}
+
+    def get_active_skills(self):
+        return [skill[0] for skill in self.active_skills]
+
+    def deactivate_skill(self, skill_id, source_skill=None):
+        """Remove a skill from being targetable by converse.
+
+        Args:
+            skill_id (str): skill to remove
+            source_skill (str): skill requesting the removal
+        """
+        source_skill = source_skill or skill_id
+        if self._deactivate_allowed(skill_id, source_skill):
+            active_skills = self.get_active_skills()
+            if skill_id in active_skills:
+                idx = active_skills.index(skill_id)
+                self.active_skills.pop(idx)
+                self.bus.emit(
+                    Message("intent.service.skills.deactivated",
+                            {"skill_id": skill_id}))
+                if skill_id in self._consecutive_activations:
+                    self._consecutive_activations[skill_id] = 0
+
+    def activate_skill(self, skill_id, source_skill=None):
+        """Add a skill or update the position of an active skill.
+
+        The skill is added to the front of the list, if it's already in the
+        list it's removed so there is only a single entry of it.
+
+        Args:
+            skill_id (str): identifier of skill to be added.
+            source_skill (str): skill requesting the removal
+        """
+        source_skill = source_skill or skill_id
+        if self._activate_allowed(skill_id, source_skill):
+            # NOTE: do not call self.remove_active_skill
+            # do not want to send the deactivation bus event!
+            active_skills = self.get_active_skills()
+            if skill_id in active_skills:
+                idx = active_skills.index(skill_id)
+                self.active_skills.pop(idx)
+
+            # add skill with timestamp to start of skill_list
+            self.active_skills.insert(0, [skill_id, time.time()])
+            self.bus.emit(
+                Message("intent.service.skills.activated",
+                        {"skill_id": skill_id}))
+
+            self._consecutive_activations[skill_id] += 1
+
+    def _activate_allowed(self, skill_id, source_skill=None):
+        # cross activation control if skills can activate each other
+        if not self.config.get("cross_activation"):
+            source_skill = source_skill or skill_id
+            if skill_id != source_skill:
+                # different skill is trying to activate this skill
+                return False
+
+        # mode of activation dictates under what conditions a skill is
+        # allowed to activate itself
+        acmode = self.config.get("converse_activation") or \
+                 ConverseActivationMode.ACCEPT_ALL
+        if acmode == ConverseActivationMode.PRIORITY:
+            prio = self.config.get("converse_priorities") or {}
+            # only allowed to activate if no skill with higher priority is
+            # active, currently there is no api for skills to
+            # define their default priority, this is a user/developer setting
+            priority = prio.get(skill_id, 50)
+            if any(p > priority for p in
+                   [prio.get(s[0], 50) for s in self.active_skills]):
+                return False
+        elif acmode == ConverseActivationMode.BLACKLIST:
+            if skill_id in self.config.get("converse_blacklist", []):
+                return False
+        elif acmode == ConverseActivationMode.WHITELIST:
+            if skill_id not in self.config.get("converse_whitelist", []):
+                return False
+
+        # limit of consecutive activations
+        default_max = self.config.get("max_activations", -1)
+        # per skill override limit of consecutive activations
+        skill_max = self.config.get("skill_activations", {}).get(skill_id)
+        max_activations = skill_max or default_max
+        if skill_id not in self._consecutive_activations:
+            self._consecutive_activations[skill_id] = 0
+        if max_activations < 0:
+            pass  # no limit (mycroft-core default)
+        elif max_activations == 0:
+            return False  # skill activation disabled
+        elif self._consecutive_activations.get(skill_id, 0) > max_activations:
+            return False  # skill exceeded authorized consecutive number of activations
+        return True
+
+    def _deactivate_allowed(self, skill_id, source_skill=None):
+        # cross activation control if skills can deactivate each other
+        if not self.config.get("cross_activation"):
+            source_skill = source_skill or skill_id
+            if skill_id != source_skill:
+                # different skill is trying to deactivate this skill
+                return False
+        return True
+
+    def _converse_allowed(self, skill_id):
+        """ check if skill_id is not blacklisted from using converse """
+        opmode = self.config.get("converse_mode",
+                                 ConverseMode.ACCEPT_ALL)
+        if opmode == ConverseMode.BLACKLIST and skill_id in \
+                self.config.get("converse_blacklist", []):
+            return False
+        elif opmode == ConverseMode.WHITELIST and skill_id not in \
+                self.config.get("converse_whitelist", []):
+            return False
+        return True
+
+    def _collect_converse_skills(self):
+        """use the messagebus api to determine which skills want to converse
+        This includes all skills and external applications"""
+        skill_ids = []
+        want_converse = []
+        active_skills = self.get_active_skills()
+
+        def handle_ack(message):
+            skill_id = message.data["skill_id"]
+            if message.data.get("can_handle", True):
+                if skill_id in active_skills:
+                    want_converse.append(skill_id)
+            skill_ids.append(skill_id)
+
+        self.bus.on("mycroft.skill.converse.pong", handle_ack)
+
+        # wait for all skills to acknowledge they want to converse
+        self.bus.emit(Message("mycroft.skill.converse.ping"))
+        start = time.time()
+        while not all(s in skill_ids for s in active_skills) \
+                and time.time() - start <= 0.5:
+            time.sleep(0.02)
+
+        self.bus.remove("mycroft.skill.converse.pong", handle_ack)
+        return want_converse
+
+    def _check_converse_timeout(self):
+        """ filter active skill list based on timestamps """
+        timeouts = self.config.get("skill_timeouts") or {}
+        def_timeout = self.config.get("timeout", 300)
+        self.active_skills = [
+            skill for skill in self.active_skills
+            if time.time() - skill[1] <= timeouts.get(skill[0], def_timeout)]
+
+    def converse(self, utterances, skill_id, lang, message):
+        """Call skill and ask if they want to process the utterance.
+
+        Args:
+            utterances (list of tuples): utterances paired with normalized
+                                         versions.
+            skill_id: skill to query.
+            lang (str): current language
+            message (Message): message containing interaction info.
+        """
+        if self._converse_allowed(skill_id):
+            converse_msg = message.reply("skill.converse.request",
+                                         {"skill_id": skill_id,
+                                          "utterances": utterances,
+                                          "lang": lang})
+            result = self.bus.wait_for_response(converse_msg,
+                                                'skill.converse.response')
+            if result and 'error' in result.data:
+                error_msg = result.data['error']
+                LOG.error(f"{skill_id}: {error_msg}")
+                return False
+            elif result is not None:
+                return result.data.get('result', False)
+        return False
+
+    def converse_with_skills(self, utterances, lang, message):
+        """Give active skills a chance at the utterance
+
+        Args:
+            utterances (list):  list of utterances
+            lang (string):      4 letter ISO language code
+            message (Message):  message to use to generate reply
+
+        Returns:
+            IntentMatch if handled otherwise None.
+        """
+        utterances = [item for tup in utterances for item in tup]
+        # filter allowed skills
+        self._check_converse_timeout()
+        # check if any skill wants to handle utterance
+        for skill_id in self._collect_converse_skills():
+            if self.converse(utterances, skill_id, lang, message):
+                return IntentMatch('Converse', None, None, skill_id)
+        return None
+

--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -398,8 +398,8 @@ class MycroftSkill:
         # Only register stop if it's been implemented
         if self.stop_is_implemented:
             self.add_event('mycroft.stop', self.__handle_stop)
-        self.add_event('mycroft.skill.converse.ping', self.handle_converse_ack)
-        self.add_event('mycroft.skill.converse.request', self.handle_converse_request)
+        self.add_event('mycroft.skill.converse.ping', self._handle_converse_ack)
+        self.add_event('mycroft.skill.converse.request', self._handle_converse_request)
         self.add_event(f"{self.skill_id}.activate", self.handle_activate)
         self.add_event(f"{self.skill_id}.deactivate", self.handle_deactivate)
         self.add_event("intent.service.skills.deactivated", self._handle_skill_deactivated)
@@ -503,16 +503,17 @@ class MycroftSkill:
         self.bus.emit(msg.forward(f"intent.service.skills.deactivate",
                                   data={"skill_id": self.skill_id}))
 
-    def handle_converse_ack(self, message):
+    def _handle_converse_ack(self, message):
+        """Inform skills service if we want to handle converse.
+        individual skills may override the property self.converse_is_implemented"""
         self.bus.emit(message.reply(
             "mycroft.skill.converse.pong",
             data={"skill_id": self.skill_id,
                   "can_handle": self.converse_is_implemented},
             context={"skill_id": self.skill_id}))
 
-    def handle_converse_request(self, message):
+    def _handle_converse_request(self, message):
         """Check if the targeted skill id can handle conversation
-
         If supported, the conversation is invoked.
         """
         skill_id = message.data['skill_id']

--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -18,6 +18,7 @@ import re
 import sys
 import traceback
 from copy import deepcopy
+from inspect import signature
 from itertools import chain
 from os import walk, listdir
 from os.path import join, abspath, dirname, basename, exists, isdir
@@ -382,46 +383,32 @@ class MycroftSkill:
             self.add_event('{}.public_api'.format(self.skill_id),
                            self._send_public_api)
 
+    @property
+    def stop_is_implemented(self):
+        return self.__class__.stop is not MycroftSkill.stop
+
+    @property
+    def converse_is_implemented(self):
+        return self.__class__.converse is not MycroftSkill.converse
+
     def _register_system_event_handlers(self):
         """Add all events allowing the standard interaction with the Mycroft
         system.
         """
-
-        def stop_is_implemented():
-            return self.__class__.stop is not MycroftSkill.stop
-
         # Only register stop if it's been implemented
-        if stop_is_implemented():
+        if self.stop_is_implemented:
             self.add_event('mycroft.stop', self.__handle_stop)
-
-        self.add_event(
-            'mycroft.skill.enable_intent',
-            self.handle_enable_intent
-        )
-        self.add_event(
-            'mycroft.skill.disable_intent',
-            self.handle_disable_intent
-        )
-        self.add_event(
-            'mycroft.skill.set_cross_context',
-            self.handle_set_cross_context
-        )
-        self.add_event(
-            'mycroft.skill.remove_cross_context',
-            self.handle_remove_cross_context
-        )
-        self.events.add(
-            'mycroft.skills.settings.changed',
-            self.handle_settings_change
-        )
-        self.events.add(f"{self.skill_id}.deactivate",
-                        self.handle_deactivate)
-        self.events.add("intent.service.skills.deactivated",
-                        self._handle_skill_deactivated)
-        self.events.add(f"{self.skill_id}.activate",
-                        self.handle_activate)
-        self.events.add("intent.service.skills.activated",
-                        self._handle_skill_activated)
+        self.add_event('mycroft.skill.converse.ping', self.handle_converse_ack)
+        self.add_event('mycroft.skill.converse.request', self.handle_converse_request)
+        self.add_event(f"{self.skill_id}.activate", self.handle_activate)
+        self.add_event(f"{self.skill_id}.deactivate", self.handle_deactivate)
+        self.add_event("intent.service.skills.deactivated", self._handle_skill_deactivated)
+        self.add_event("intent.service.skills.activated", self._handle_skill_activated)
+        self.add_event('mycroft.skill.enable_intent', self.handle_enable_intent)
+        self.add_event('mycroft.skill.disable_intent', self.handle_disable_intent)
+        self.add_event('mycroft.skill.set_cross_context', self.handle_set_cross_context)
+        self.add_event('mycroft.skill.remove_cross_context', self.handle_remove_cross_context)
+        self.add_event('mycroft.skills.settings.changed', self.handle_settings_change)
 
     def handle_settings_change(self, message):
         """Update settings if the remote settings changes apply to this skill.
@@ -515,6 +502,36 @@ class MycroftSkill:
             msg.context["skill_id"] = self.skill_id
         self.bus.emit(msg.forward(f"intent.service.skills.deactivate",
                                   data={"skill_id": self.skill_id}))
+
+    def handle_converse_ack(self, message):
+        self.bus.emit(message.reply(
+            "mycroft.skill.converse.pong",
+            data={"skill_id": self.skill_id,
+                  "can_handle": self.converse_is_implemented},
+            context={"skill_id": self.skill_id}))
+
+    def handle_converse_request(self, message):
+        """Check if the targeted skill id can handle conversation
+
+        If supported, the conversation is invoked.
+        """
+        skill_id = message.data['skill_id']
+        if skill_id == self.skill_id:
+            try:
+                # converse can have multiple signatures
+                params = signature(self.converse).parameters
+                kwargs = {"message": message,
+                          "utterances": message.data['utterances'],
+                          "lang": message.data['lang']}
+                kwargs = {k: v for k, v in kwargs.items() if k in params}
+                result = self.converse(**kwargs)
+                self.bus.emit(message.reply('skill.converse.response',
+                                            {"skill_id": self.skill_id,
+                                             "result": result}))
+            except Exception:
+                self.bus.emit(message.reply('skill.converse.response',
+                                            {"skill_id": self.skill_id,
+                                             "result": False}))
 
     def converse(self, message=None):
         """Handle conversation.


### PR DESCRIPTION
make converse event based, it was a little odd because it was the only code from MycroftSkill called outside of the skill itself

The event based approach also adds support for external skills, eg, Hivemind and OVOSAbstractApp

refactored converse process into a single class like adapt/padatious/fallbacks

added a new converse acknowledge bus message, now converse is only called for skills where converse is implemented. 

skills are removed from active skill list if
- skill does not have converse capabilities
- skill was unloaded/disconnected
- skill does not want to converse at this time