### PR TITLE
speech client systemd hooks

### DIFF
--- a/mycroft/client/speech/__main__.py
+++ b/mycroft/client/speech/__main__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from mycroft.client.speech.service import SpeechClient
+from mycroft.client.speech.service import SpeechClient, on_error, on_stopping, on_ready
 from mycroft.configuration import setup_locale
 from mycroft.lock import Lock as PIDLock  # Create/Support PID locking file
 from mycroft.util import (
@@ -21,11 +21,15 @@ from mycroft.util import (
 )
 
 
-def main():
+def main(ready_hook=on_ready, error_hook=on_error, stopping_hook=on_stopping,
+         watchdog=lambda: None):
     reset_sigint_handler()
     PIDLock("voice")
     setup_locale()
-    service = SpeechClient()
+    service = SpeechClient(on_ready=ready_hook,
+                           on_error=error_hook,
+                           on_stopping=stopping_hook,
+                           watchdog=watchdog)
     service.setDaemon(True)
     service.start()
     wait_for_exit_signal()

--- a/mycroft/client/speech/service.py
+++ b/mycroft/client/speech/service.py
@@ -188,7 +188,7 @@ class SpeechClient(Thread):
     def handle_open(self):
         # TODO: Move this into the Enclosure (not speech client)
         # Reset the UI to indicate ready for speech processing
-        EnclosureAPI(bus).reset()
+        EnclosureAPI(self.bus).reset()
 
     def connect_loop_events(self):
         self.loop.on('recognizer_loop:utterance', self.handle_utterance)
@@ -230,6 +230,3 @@ class SpeechClient(Thread):
             self.status.set_error(e)
         self.status.set_stopping()
 
-
-if __name__ == "__main__":
-    main()


### PR DESCRIPTION
reported in latest OVOS buildroot image 

#2 accidentally removed the systemd hooks argument from main

this only impacts custom launchers importing main, eg https://github.com/j1nx/mycroft-systemd/tree/master/scripts