### PR TITLE
bump requests to avoid GPL transient dependency

### DIFF
--- a/requirements/minimal.txt
+++ b/requirements/minimal.txt
@@ -1,4 +1,4 @@
-requests>=2.26.0
+requests~=2.26
 pyee~=8.1
 pyxdg~=0.26
 mycroft-messagebus-client~=0.9.1,!=0.9.2,!=0.9.3

--- a/requirements/minimal.txt
+++ b/requirements/minimal.txt
@@ -1,4 +1,4 @@
-requests>=2.20.0,<2.26.0
+requests>=2.26.0
 pyee~=8.1
 pyxdg~=0.26
 mycroft-messagebus-client~=0.9.1,!=0.9.2,!=0.9.3

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,4 @@
-requests>=2.20.0,<2.26.0
+requests>=2.26.0
 PyAudio~=0.2.11
 pyee~=8.1
 SpeechRecognition~=3.8.1

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,4 @@
-requests>=2.26.0
+requests~=2.26
 PyAudio~=0.2.11
 pyee~=8.1
 SpeechRecognition~=3.8.1


### PR DESCRIPTION
partially solves #51 

need to do the same in all other ovos packages before 0.1.0 https://github.com/OpenVoiceOS/OpenVoiceOS/discussions/100