### PR TITLE
fix/skill_manager_events

### DIFF
--- a/mycroft/__init__.py
+++ b/mycroft/__init__.py
@@ -22,7 +22,7 @@ try:
     from mycroft.skills.context import adds_context, removes_context
     from mycroft.skills import (MycroftSkill, FallbackSkill,
                                 intent_handler, intent_file_handler)
-    from mycroft.skills.intent_service import AdaptIntent
+    from mycroft.skills.intent_services.adapt_service import AdaptIntent
 except ImportError:
     # skills requirements not installed
     # i would remove this completely, but some skills in the wild import

--- a/mycroft/skills/skill_manager.py
+++ b/mycroft/skills/skill_manager.py
@@ -103,11 +103,9 @@ def _shutdown_skill(instance):
 
         shutdown_time = monotonic() - ref_time
         if shutdown_time > 1:
-            LOG.warning('{} shutdown took {} seconds'.format(instance.skill_id,
-                                                             shutdown_time))
+            LOG.warning(f'{instance.skill_id} shutdown took {shutdown_time} seconds')
     except Exception:
-        LOG.exception('Failed to shut down skill: '
-                      '{}'.format(instance.skill_id))
+        LOG.exception(f'Failed to shut down skill: {instance.skill_id}')
 
 
 class SkillManager(Thread):
@@ -210,8 +208,8 @@ class SkillManager(Thread):
                 # not implemented
                 services[ser] = True
                 continue
-            response = self.bus.wait_for_response(Message(
-                'mycroft.{}.is_ready'.format(ser)))
+            response = self.bus.wait_for_response(
+                Message(f'mycroft.{ser}.is_ready'))
             if response and response.data['status']:
                 services[ser] = True
         return all([services[ser] for ser in services])
@@ -334,16 +332,14 @@ class SkillManager(Thread):
 
     def _reload_modified_skills(self):
         """Handle reload of recently changed skill(s)"""
-        for skill_dir in self._get_skill_directories():
+        for skill_dir, skill_loader in self.skill_loaders.items():
             try:
-                skill_loader = self.skill_loaders.get(skill_dir)
                 if skill_loader is not None and skill_loader.reload_needed():
                     # If reload succeed add settingsmeta to upload queue
                     if skill_loader.reload():
                         self.upload_queue.put(skill_loader)
             except Exception:
-                LOG.exception('Unhandled exception occured while '
-                              'reloading {}'.format(skill_dir))
+                LOG.exception(f'Unhandled exception occured while reloading {skill_dir}')
 
     def _load_new_skills(self):
         """Handle load of skills installed since startup."""
@@ -387,7 +383,7 @@ class SkillManager(Thread):
         try:
             load_status = skill_loader.load()
         except Exception:
-            LOG.exception('Load of skill {} failed!'.format(skill_directory))
+            LOG.exception(f'Load of skill {skill_directory} failed!')
             load_status = False
         finally:
             self.skill_loaders[skill_directory] = skill_loader
@@ -503,7 +499,6 @@ class SkillManager(Thread):
             for skill in skills.values():
                 if skill.skill_id != skill_to_keep:
                     skill.deactivate()
-                    return
             LOG.info('Couldn\'t find skill ' + message.data['skill'])
         except Exception:
             LOG.exception('An error occurred during skill deactivation!')
@@ -517,7 +512,6 @@ class SkillManager(Thread):
                 if (message.data['skill'] in ('all', skill_loader.skill_id)
                         and not skill_loader.active):
                     skill_loader.activate()
-                    return
         except Exception:
             LOG.exception('Couldn\'t activate skill')
 

--- a/test/unittests/mocks.py
+++ b/test/unittests/mocks.py
@@ -71,3 +71,6 @@ class MessageBusMock:
 
     def on(self, event, _):
         self.event_handlers.append(event)
+
+    def once(self, event, _):
+        self.event_handlers.append(event)

--- a/test/unittests/skills/test_skill_manager.py
+++ b/test/unittests/skills/test_skill_manager.py
@@ -1,0 +1,199 @@
+# Copyright 2019 Mycroft AI Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from unittest import TestCase
+from unittest.mock import Mock, patch
+
+from mycroft.skills.skill_loader import SkillLoader
+from mycroft.skills.skill_manager import SkillManager, UploadQueue
+from ..base import MycroftUnitTestBase
+
+
+class TestUploadQueue(TestCase):
+
+    def test_upload_queue_create(self):
+        queue = UploadQueue()
+        self.assertFalse(queue.started)
+        queue.start()
+        self.assertTrue(queue.started)
+
+    def test_upload_queue_use(self):
+        queue = UploadQueue()
+        queue.start()
+        specific_loader = Mock(spec=SkillLoader, instance=Mock())
+        loaders = [Mock(), specific_loader, Mock(), Mock()]
+        # Check that putting items on the queue makes it longer
+        for i, l in enumerate(loaders):
+            queue.put(l)
+            self.assertEqual(len(queue), i + 1)
+        # Check that adding an existing item replaces that item
+        queue.put(specific_loader)
+        self.assertEqual(len(queue), len(loaders))
+        # Check that sending items empties the queue
+        queue.send()
+        self.assertEqual(len(queue), 0)
+
+    def test_upload_queue_preloaded(self):
+        queue = UploadQueue()
+        loaders = [Mock(), Mock(), Mock(), Mock()]
+        for i, l in enumerate(loaders):
+            queue.put(l)
+            self.assertEqual(len(queue), i + 1)
+        # Check that starting the queue will send all the items in the queue
+        queue.start()
+        self.assertEqual(len(queue), 0)
+        for l in loaders:
+            l.instance.settings_meta.upload.assert_called_once_with()
+
+
+class TestSkillManager(MycroftUnitTestBase):
+    mock_package = 'mycroft.skills.skill_manager.'
+
+    def setUp(self):
+        super().setUp()
+        self._mock_skill_updater()
+        self._mock_skill_settings_downloader()
+        self.skill_manager = SkillManager(self.message_bus_mock)
+        self._mock_skill_loader_instance()
+
+    def _mock_skill_settings_downloader(self):
+        settings_download_patch = patch(
+            self.mock_package + 'SkillSettingsDownloader',
+            spec=True
+        )
+        self.addCleanup(settings_download_patch.stop)
+        self.settings_download_mock = settings_download_patch.start()
+
+    def _mock_skill_updater(self):
+        skill_updater_patch = patch(
+            self.mock_package + 'SkillUpdater',
+            spec=True
+        )
+        self.addCleanup(skill_updater_patch.stop)
+        self.skill_updater_mock = skill_updater_patch.start()
+
+    def _mock_skill_loader_instance(self):
+        self.skill_dir = self.temp_dir.joinpath('test_skill')
+        self.skill_loader_mock = Mock(spec=SkillLoader)
+        self.skill_loader_mock.instance = Mock()
+        self.skill_loader_mock.instance.default_shutdown = Mock()
+        self.skill_loader_mock.instance.converse = Mock()
+        self.skill_loader_mock.instance.converse.return_value = True
+        self.skill_loader_mock.skill_id = 'test_skill'
+        self.skill_manager.skill_loaders = {
+            str(self.skill_dir): self.skill_loader_mock
+        }
+
+    def test_instantiate(self):
+        self.assertEqual(
+            self.skill_manager.config['data_dir'],
+            str(self.temp_dir)
+        )
+        expected_result = [
+            'mycroft.internet.connected',
+            'skillmanager.list',
+            'skillmanager.deactivate',
+            'skillmanager.keep',
+            'skillmanager.activate',
+            'mycroft.paired',
+            'mycroft.skills.settings.update',
+            'mycroft.skills.trained'
+        ]
+        self.assertListEqual(
+            expected_result,
+            self.message_bus_mock.event_handlers
+        )
+
+    def test_unload_removed_skills(self):
+        self.skill_manager._unload_removed_skills()
+
+        self.assertDictEqual({}, self.skill_manager.skill_loaders)
+        self.skill_loader_mock.unload.assert_called_once_with()
+
+    def test_send_skill_list(self):
+        self.skill_loader_mock.active = True
+        self.skill_loader_mock.loaded = True
+        self.skill_manager.send_skill_list(None)
+
+        self.assertListEqual(
+            ['mycroft.skills.list'],
+            self.message_bus_mock.message_types
+        )
+        message_data = self.message_bus_mock.message_data[0]
+        self.assertIn('test_skill', message_data.keys())
+        skill_data = message_data['test_skill']
+        self.assertDictEqual(dict(active=True, id='test_skill'), skill_data)
+
+    def test_stop(self):
+        self.skill_manager.stop()
+
+        self.assertTrue(self.skill_manager._stop_event.is_set())
+        instance = self.skill_loader_mock.instance
+        instance.default_shutdown.assert_called_once_with()
+
+    def test_handle_paired(self):
+        self.skill_updater_mock.next_download = 0
+        self.skill_manager.handle_paired(None)
+        updater = self.skill_manager.skill_updater
+        updater.post_manifest.assert_called_once_with(
+            reload_skills_manifest=True)
+
+    def test_deactivate_skill(self):
+        message = Mock()
+        message.data = dict(skill='test_skill')
+        self.skill_manager.deactivate_skill(message)
+        self.skill_loader_mock.deactivate.assert_called_once_with()
+
+    def test_deactivate_except(self):
+        message = Mock()
+        message.data = dict(skill='test_skill')
+        self.skill_loader_mock.active = True
+        foo_skill_loader = Mock(spec=SkillLoader)
+        foo_skill_loader.skill_id = 'foo'
+        foo2_skill_loader = Mock(spec=SkillLoader)
+        foo2_skill_loader.skill_id = 'foo2'
+        test_skill_loader = Mock(spec=SkillLoader)
+        test_skill_loader.skill_id = 'test_skill'
+        self.skill_manager.skill_loaders['foo'] = foo_skill_loader
+        self.skill_manager.skill_loaders['foo2'] = foo2_skill_loader
+        self.skill_manager.skill_loaders['test_skill'] = test_skill_loader
+
+        self.skill_manager.deactivate_except(message)
+        foo_skill_loader.deactivate.assert_called_once_with()
+        foo2_skill_loader.deactivate.assert_called_once_with()
+        self.assertFalse(test_skill_loader.deactivate.called)
+
+    def test_activate_skill(self):
+        message = Mock()
+        message.data = dict(skill='test_skill')
+        test_skill_loader = Mock(spec=SkillLoader)
+        test_skill_loader.skill_id = 'test_skill'
+        test_skill_loader.active = False
+
+        self.skill_manager.skill_loaders = {}
+        self.skill_manager.skill_loaders['test_skill'] = test_skill_loader
+
+        self.skill_manager.activate_skill(message)
+        test_skill_loader.activate.assert_called_once_with()
+
+    def test_reload_modified(self):
+        self.skill_dir.mkdir(parents=True)
+        self.skill_dir.joinpath('__init__.py').touch()
+        self.skill_loader_mock.reload_needed.return_value = True
+        self.skill_manager._reload_modified_skills()
+        self.skill_loader_mock.reload.assert_called_once_with()
+        self.assertEqual(
+            self.skill_loader_mock,
+            self.skill_manager.skill_loaders[str(self.skill_dir)]
+        )


### PR DESCRIPTION
- fix bug where activate/deactivate a loaded skill exited the loop early. "all" and deactivate_except would exit after 1st skill
- fixes AdaptIntent import in __init__.py , lots of skills in the wild doing `from mycroft import AdaptIntent` started failing after a autopep8 refactor
- ports skill manager unittests from mycroft-core
- refactor to use fstrings everywhere in skill_manager.py