### PR TITLE
Add GUI Extensions Support

### DIFF
--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -401,6 +401,22 @@
     "extension": "Generic"
   },
 
+  "gui": {
+    // Override: SYSTEM (set by specific enclosures)
+    // Uncomment or add "idle_display_skill" to set initial homescreen
+    // "idle_display_skill": "skill-ovos-homescreen.openvoiceos",
+
+    // Extensions provide additional GUI platform support for specific devices
+    // Currently supported devices: SmartSpeaker, Bigscreen or Generic
+    "extension": "Generic",
+
+    // Generic extension can additionaly provide homescreen functionality
+    // homescreen support is disabled by default for generic extension
+    "generic": {
+        "homescreen_supported": false
+    }
+  },
+
   // Level of logs to store, one of  "CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"
   // NOTE: This configuration setting is special and can only be changed in the
   // SYSTEM or USER configuration file, it will not be read if defined in the

--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -391,14 +391,7 @@
     // ('mycroft_mark_1', 'picroft', 'mycroft_mark_2pi')
     // to disable forced ntp_sync in official mycroft platforms
     // set this to false
-    "force_mycroft_ntp": true,
-
-    // Uncomment or add "idle_display_skill" to set initial homescreen
-    // "idle_display_skill": "skill-ovos-homescreen.openvoiceos",
-
-    // Extensions provide additional GUI platform support for specific devices
-    // Currently supported devices: SmartSpeaker, Bigscreen or Generic
-    "extension": "Generic"
+    "force_mycroft_ntp": true
   },
 
   "gui": {

--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -391,8 +391,14 @@
     // ('mycroft_mark_1', 'picroft', 'mycroft_mark_2pi')
     // to disable forced ntp_sync in official mycroft platforms
     // set this to false
-    "force_mycroft_ntp": true
+    "force_mycroft_ntp": true,
 
+    // Uncomment or add "idle_display_skill" to set initial homescreen
+    // "idle_display_skill": "skill-ovos-homescreen.openvoiceos",
+
+    // Extensions provide additional GUI platform support for specific devices
+    // Currently supported devices: SmartSpeaker, Bigscreen or Generic
+    "extension": "Generic"
   },
 
   // Level of logs to store, one of  "CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"

--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -400,8 +400,8 @@
     // "idle_display_skill": "skill-ovos-homescreen.openvoiceos",
 
     // Extensions provide additional GUI platform support for specific devices
-    // Currently supported devices: SmartSpeaker, Bigscreen or Generic
-    "extension": "Generic",
+    // Currently supported devices: smartspeaker, bigscreen or generic
+    "extension": "generic",
 
     // Generic extension can additionaly provide homescreen functionality
     // homescreen support is disabled by default for generic extension

--- a/mycroft/gui/extensions.py
+++ b/mycroft/gui/extensions.py
@@ -219,9 +219,9 @@ class GenericExtension():
         self.bus = bus
         self.gui = gui
         config = Configuration.get()
-        enclosure_config = config.get("enclosure")
+        enclosure_config = config.get("enclosure", {})
         self.homescreen_supported = enclosure_config.get(
-            "extension").get("generic").get("homescreen_supported", False)
+            "extension", {}).get("generic", {}).get("homescreen_supported", False)
 
         if self.homescreen_supported:
             self.homescreen_manager = HomescreenManager(self.bus, self.gui)

--- a/mycroft/gui/extensions.py
+++ b/mycroft/gui/extensions.py
@@ -1,0 +1,244 @@
+import threading
+from mycroft.configuration import Configuration
+from mycroft.messagebus import Message
+from mycroft.util.log import LOG
+from mycroft.api import is_paired
+from ovos_utils.system import system_reboot, system_shutdown, ssh_enable, ssh_disable
+
+from json_database import JsonStorageXDG
+from mycroft.gui.homescreen import HomescreenManager
+
+
+class ExtensionsManager():
+    def __init__(self, name, bus, gui):
+        """ Constructor for the Extension Manager. The Extension Manager is responsible for
+        managing the extensions that define additional GUI behaviours for specific platforms.
+
+        Args:
+            name: Name of the extension manager
+            bus: MessageBus instance
+            gui: GUI instance
+        """
+
+        self.name = name
+        self.bus = bus
+        self.gui = gui
+        config = Configuration.get()
+        enclosure_config = config.get("enclosure")
+        self.active_extension = enclosure_config.get("extension", "Generic")
+
+        # ToDo: Add Exclusive Support For "Desktop", "Mobile" Extensions
+        self.supported_extensions = ["SmartSpeaker", "Bigscreen", "Generic"]
+
+        if self.active_extension not in self.supported_extensions:
+            self.active_extension = "Generic"
+
+        LOG.info(
+            f"Extensions Manager: Initializing {self.name} with active extension {self.active_extension}")
+        self.activate_extension(self.active_extension)
+
+    def activate_extension(self, extension_id):
+        LOG.info(f"Extensions Manager: Activating Extension {extension_id}")
+
+        # map extension_id to class
+        if extension_id == "SmartSpeaker":
+            self.extension = SmartSpeakerExtension(self.bus, self.gui)
+        elif extension_id == "Bigscreen":
+            self.extension = BigscreenExtension(self.bus, self.gui)
+        else:
+            self.extension = GenericExtension(self.bus, self.gui)
+
+        LOG.info(f"Extensions Manager: Activated Extension {extension_id}")
+        self.bus.emit(
+            Message("extension.manager.activated", {"id": extension_id}))
+
+
+class SmartSpeakerExtension():
+    """ Smart Speaker Extension: This extension is responsible for managing the Smart Speaker
+    specific GUI behaviours. This extension adds support for Homescreens and Homescreen Mangement.
+
+    Args:
+        name: Name of the extension manager
+        bus: MessageBus instance
+        gui: GUI instance
+    """
+
+    def __init__(self, bus, gui):
+        LOG.info("SmartSpeaker: Initializing")
+
+        self.bus = bus
+        self.gui = gui
+        self.homescreen_manager = HomescreenManager(self.bus, self.gui)
+
+        self.homescreen_thread = threading.Thread(
+            target=self.homescreen_manager.run)
+        self.homescreen_thread.start()
+
+        self.device_paired = is_paired()
+        store_conf = ('skill_conf.json')
+
+        self.skill_conf = JsonStorageXDG(store_conf)
+        if not "selected_backend" in self.skill_conf:
+            self.skill_conf["selected_backend"] = "unknown"
+            self.skill_conf.store()
+        else:
+            self.skill_conf = JsonStorageXDG(store_conf)
+
+        try:
+            self.bus.on("ovos.pairing.process.completed",
+                        self.start_homescreen_process)
+            self.bus.on("ovos.pairing.set.backend", self.set_backend_type)
+            self.bus.on("mycroft.gui.screen.close",
+                        self.handle_remove_namespace)
+            self.bus.on("system.reboot", self.handle_system_reboot)
+            self.bus.on("system.shutdown", self.handle_system_shutdown)
+            self.bus.on("system.display.homescreen",
+                        self.handle_system_display_homescreen)
+
+        except Exception as e:
+            LOG.error(f"SmartSpeaker: Init Bus Exception: {e}")
+
+    def set_backend_type(self, message):
+        backend = message.data.get("backend", "unknown")
+        if not backend == "unknown":
+            self.skill_conf["selected_backend"] = backend
+            self.skill_conf.store()
+            self.device_backend = self.skill_conf["selected_backend"]
+
+    def start_homescreen_process(self, message):
+        self.device_paired = is_paired()
+        self.homescreen_manager.show_homescreen()
+
+    def handle_remove_namespace(self, message):
+        LOG.info("Got Clear Namespace Event In Skill")
+        get_skill_namespace = message.data.get("skill_id", "")
+        if get_skill_namespace:
+            self.bus.emit(Message("gui.clear.namespace",
+                                  {"__from": get_skill_namespace}))
+
+    def handle_system_reboot(self, message):
+        system_reboot()
+
+    def handle_system_shutdown(self, message):
+        system_shutdown()
+
+    def handle_system_ssh_enable(self, message):
+        ssh_enable()
+
+    def handle_system_ssh_disable(self, message):
+        ssh_disable()
+
+    def handle_system_display_homescreen(self, message):
+        self.homescreen_manager.show_homescreen()
+
+
+class BigscreenExtension():
+    """ Bigscreen Platform Extension: This extension is responsible for managing the Bigscreen
+    specific GUI behaviours. The bigscreen extension does not support Homescreens. It includes
+    support for Window managment and Window behaviour.
+
+    Args:
+        name: Name of the extension manager
+        bus: MessageBus instance
+        gui: GUI instance
+    """
+
+    def __init__(self, bus, gui):
+        LOG.info("Bigscreen: Initializing")
+
+        self.bus = bus
+        self.gui = gui
+        self.interaction_without_idle = True
+        self.interaction_skill_id = None
+
+        try:
+            self.bus.on('mycroft.gui.screen.close', self.close_window_by_event)
+            self.bus.on('mycroft.gui.force.screenclose',
+                        self.close_window_by_force)
+            self.bus.on('gui.page.show', self.on_gui_page_show)
+            self.bus.on('gui.page_interaction', self.on_gui_page_interaction)
+            self.bus.on('gui.namespace.removed', self.close_current_window)
+
+        except Exception as e:
+            LOG.error(f"Bigscreen: Init Bus Exception: {e}")
+
+    def on_gui_page_show(self, message):
+        override_idle = message.data.get('__idle')
+        if override_idle is True:
+            self.interaction_without_idle = True
+        elif isinstance(override_idle, int) and not (override_idle, bool) and override_idle is not False:
+            self.interaction_without_idle = True
+        elif (message.data['page']):
+            if not isinstance(override_idle, bool) or not isinstance(override_idle, int):
+                self.interaction_without_idle = False
+
+    def on_gui_page_interaction(self, message):
+        skill_id = message.data.get('skill_id')
+        self.interaction_skill_id = skill_id
+
+    def handle_remove_namespace(self, message):
+        get_skill_namespace = message.data.get("skill_id", "")
+        LOG.info(f"Got Clear Namespace Event In Skill {get_skill_namespace}")
+        if get_skill_namespace:
+            self.bus.emit(Message("gui.clear.namespace",
+                                  {"__from": get_skill_namespace}))
+
+    def close_current_window(self, message):
+        skill_id = message.data.get('skill_id')
+        LOG.info(f"Bigscreen: Closing Current Window For Skill {skill_id}")
+        self.bus.emit(Message('screen.close.idle.event',
+                              data={"skill_idle_event_id": skill_id}))
+
+    def close_window_by_event(self, message):
+        self.interaction_without_idle = False
+        self.bus.emit(Message('screen.close.idle.event',
+                              data={"skill_idle_event_id": self.interaction_skill_id}))
+        self.handle_remove_namespace(message)
+
+    def close_window_by_force(self, message):
+        skill_id = message.data.get('skill_id')
+        self.bus.emit(Message('screen.close.idle.event',
+                              data={"skill_idle_event_id": skill_id}))
+        self.handle_remove_namespace(message)
+
+
+class GenericExtension():
+    """ Generic Platform Extension: This extension is responsible for managing the generic GUI behaviours
+    for non specific platforms. The generic extension does optionally support Homescreen and Homescreen
+    Management but it needs to be exclusively enabled in the configuration file.
+
+    Args:
+        name: Name of the extension manager
+        bus: MessageBus instance
+        gui: GUI instance
+    """
+
+    def __init__(self, bus, gui):
+        LOG.info("Generic: Initializing")
+
+        self.bus = bus
+        self.gui = gui
+        config = Configuration.get()
+        enclosure_config = config.get("enclosure")
+        self.homescreen_supported = enclosure_config.get(
+            "extension").get("generic").get("homescreen_supported", False)
+
+        if self.homescreen_supported:
+            self.homescreen_manager = HomescreenManager(self.bus, self.gui)
+            self.homescreen_thread = threading.Thread(
+                target=self.homescreen_manager.run)
+            self.homescreen_thread.start()
+
+        try:
+            self.bus.on("mycroft.gui.screen.close",
+                        self.handle_remove_namespace)
+
+        except Exception as e:
+            LOG.error(f"Generic: Init Bus Exception: {e}")
+
+    def handle_remove_namespace(self, message):
+        LOG.info("Got Clear Namespace Event In Skill")
+        get_skill_namespace = message.data.get("skill_id", "")
+        if get_skill_namespace:
+            self.bus.emit(Message("gui.clear.namespace",
+                                  {"__from": get_skill_namespace}))

--- a/mycroft/gui/extensions.py
+++ b/mycroft/gui/extensions.py
@@ -25,25 +25,25 @@ class ExtensionsManager():
         self.gui = gui
         config = Configuration.get()
         enclosure_config = config.get("gui")
-        self.active_extension = enclosure_config.get("extension", "Generic")
+        self.active_extension = enclosure_config.get("extension", "generic")
 
         # ToDo: Add Exclusive Support For "Desktop", "Mobile" Extensions
-        self.supported_extensions = ["SmartSpeaker", "Bigscreen", "Generic"]
+        self.supported_extensions = ["smartspeaker", "bigscreen", "generic"]
 
-        if self.active_extension not in self.supported_extensions:
-            self.active_extension = "Generic"
+        if self.active_extension.lower() not in self.supported_extensions:
+            self.active_extension = "generic"
 
         LOG.info(
             f"Extensions Manager: Initializing {self.name} with active extension {self.active_extension}")
-        self.activate_extension(self.active_extension)
+        self.activate_extension(self.active_extension.lower())
 
     def activate_extension(self, extension_id):
         LOG.info(f"Extensions Manager: Activating Extension {extension_id}")
 
         # map extension_id to class
-        if extension_id == "SmartSpeaker":
+        if extension_id == "smartspeaker":
             self.extension = SmartSpeakerExtension(self.bus, self.gui)
-        elif extension_id == "Bigscreen":
+        elif extension_id == "bigscreen":
             self.extension = BigscreenExtension(self.bus, self.gui)
         else:
             self.extension = GenericExtension(self.bus, self.gui)
@@ -120,12 +120,6 @@ class SmartSpeakerExtension():
         if get_skill_namespace:
             self.bus.emit(Message("gui.clear.namespace",
                                   {"__from": get_skill_namespace}))
-
-    def handle_system_ssh_enable(self, message):
-        ssh_enable()
-
-    def handle_system_ssh_disable(self, message):
-        ssh_disable()
 
     def handle_system_display_homescreen(self, message):
         self.homescreen_manager.show_homescreen()

--- a/mycroft/gui/extensions.py
+++ b/mycroft/gui/extensions.py
@@ -219,9 +219,8 @@ class GenericExtension():
         self.bus = bus
         self.gui = gui
         config = Configuration.get()
-        enclosure_config = config.get("enclosure", {})
-        self.homescreen_supported = enclosure_config.get(
-            "extension", {}).get("generic", {}).get("homescreen_supported", False)
+        generic_config = config.get("generic", {})
+        self.homescreen_supported = generic_config.get("homescreen_supported", False)
 
         if self.homescreen_supported:
             self.homescreen_manager = HomescreenManager(self.bus, self.gui)

--- a/mycroft/gui/homescreen.py
+++ b/mycroft/gui/homescreen.py
@@ -1,0 +1,138 @@
+from mycroft.messagebus import Message
+from mycroft.configuration import Configuration, LocalConf, USER_CONFIG
+from mycroft.util.log import LOG
+from .namespace import NamespaceManager
+
+
+class HomescreenManager:
+
+    def __init__(self, bus, gui):
+        self.bus = bus
+        self.gui = gui
+        self.homescreens = []
+        self.mycroft_ready = False
+        self.bus.on('homescreen.manager.add', self.add_homescreen)
+        self.bus.on('homescreen.manager.remove', self.remove_homescreen)
+        self.bus.on('homescreen.manager.list', self.get_homescreens)
+        self.bus.on("homescreen.manager.get_active",
+                    self.get_active_homescreen)
+        self.bus.on("homescreen.manager.set_active",
+                    self.set_active_homescreen)
+        self.bus.on("homescreen.manager.disable_active",
+                    self.disable_active_homescreen)
+        self.bus.on("mycroft.mark2.register_idle",
+                    self.register_old_style_homescreen)
+        self.bus.on("homescreen.manager.show_active", self.show_homescreen)
+        self.bus.on("mycroft.ready", self.set_mycroft_ready)
+
+    def run(self):
+        """Start the Manager after it has been constructed."""
+        self.reload_homescreens_list()
+
+    def add_homescreen(self, homescreen):
+        # if homescreen[id] not in self.homescreens then add it
+        homescreen_id = homescreen.data["id"]
+        homescreen_class = homescreen.data["class"]
+        LOG.info(f"Homescreen Manager: Adding Homescreen {homescreen_id}")
+        # check if the list is empty
+        if len(self.homescreens) == 0:
+            self.homescreens.append(homescreen.data)
+        else:
+            # check if id is in list of homescreen dicts in self.homescreens
+            for h in self.homescreens:
+                if homescreen_id != h["id"]:
+                    self.homescreens.append(homescreen.data)
+
+        self.show_homescreen_on_add(homescreen_id, homescreen_class)
+
+    def remove_homescreen(self, homescreen):
+        homescreen_id = homescreen.data["id"]
+        LOG.info(f"Homescreen Manager: Removing Homescreen {homescreen_id}")
+        for h in self.homescreens:
+            if homescreen_id == h["id"]:
+                self.homescreens.pop(h)
+
+    def get_homescreens(self):
+        return self.homescreens
+
+    def get_active_homescreen(self):
+        config = Configuration.get()
+        enclosure_config = config.get("enclosure")
+        active_homescreen = enclosure_config.get("idle_display_skill")
+        LOG.debug(f"Homescreen Manager: Active Homescreen {active_homescreen}")
+        for h in self.homescreens:
+            if h["id"] == active_homescreen:
+                return active_homescreen
+
+    def set_active_homescreen(self, homescreen):
+        homescreen_id = homescreen.data["id"]
+        conf = LocalConf(USER_CONFIG)
+        conf["enclosure"] = {
+            "idle_display_skill": homescreen_id,
+        }
+        conf.store()
+        self.bus.emit(Message("configuration.patch", {"config": conf}))
+
+    def reload_homescreens_list(self):
+        LOG.info("Homescreen Manager: Reloading Homescreen List")
+        self.collect_old_style_homescreens()
+        self.bus.emit(Message("homescreen.manager.reload.list"))
+
+    def show_homescreen_on_add(self, homescreen_id, homescreen_class):
+        if self.mycroft_ready == True:
+            active_homescreen = self.get_active_homescreen()
+            if active_homescreen == homescreen_id:
+                if homescreen_class == "IdleDisplaySkill":
+                    LOG.debug(
+                        f"Homescreen Manager: Displaying Homescreen {active_homescreen}")
+                    self.bus.emit(Message("homescreen.manager.activate.display", {
+                                  "homescreen_id": active_homescreen}))
+                elif homescreen_class == "MycroftSkill":
+                    LOG.debug(
+                        f"Homescreen Manager: Displaying Homescreen {active_homescreen}")
+                    self.bus.emit(Message("{}.idle".format(homescreen_id)))
+
+    def disable_active_homescreen(self, message):
+        conf = LocalConf(USER_CONFIG)
+        conf["enclosure"] = {
+            "idle_display_skill": None,
+        }
+        conf.store()
+        self.bus.emit(Message("configuration.patch", {"config": conf}))
+
+    def show_homescreen(self, message=None):
+        active_homescreen = self.get_active_homescreen()
+        for h in self.homescreens:
+            if h["id"] == active_homescreen:
+                if h["class"] == "IdleDisplaySkill":
+                    LOG.debug(
+                        f"Homescreen Manager: Displaying Homescreen {active_homescreen}")
+                    self.bus.emit(Message("homescreen.manager.activate.display", {
+                                  "homescreen_id": active_homescreen}))
+                elif h["class"] == "MycroftSkill":
+                    LOG.debug(
+                        f"Homescreen Manager: Displaying Homescreen {active_homescreen}")
+                    self.bus.emit(Message("{}.idle".format(active_homescreen)))
+
+    def set_mycroft_ready(self, message):
+        self.mycroft_ready = True
+        self.show_homescreen()
+
+    # Add compabitility with older versions of the Resting Screen Class
+
+    def collect_old_style_homescreens(self):
+        """Trigger collection of older resting screens."""
+        self.bus.emit(Message("mycroft.mark2.collect_idle"))
+
+    def register_old_style_homescreen(self, message):
+        if "name" in message.data and "id" in message.data:
+            super_class_name = "MycroftSkill"
+            super_class_object = message.data["name"]
+            skill_id = message.data["id"]
+            _homescreen_entry = {"class": super_class_name,
+                                 "name": super_class_object, "id": skill_id}
+            LOG.debug("Homescreen Manager: Adding OLD Homescreen {skill_id}")
+            self.add_homescreen(
+                Message("homescreen.manager.add", _homescreen_entry))
+        else:
+            LOG.error("Malformed idle screen registration received")

--- a/mycroft/gui/homescreen.py
+++ b/mycroft/gui/homescreen.py
@@ -57,7 +57,7 @@ class HomescreenManager:
 
     def get_active_homescreen(self):
         config = Configuration.get()
-        enclosure_config = config.get("enclosure")
+        enclosure_config = config.get("gui")
         active_homescreen = enclosure_config.get("idle_display_skill")
         LOG.debug(f"Homescreen Manager: Active Homescreen {active_homescreen}")
         for h in self.homescreens:
@@ -67,7 +67,7 @@ class HomescreenManager:
     def set_active_homescreen(self, homescreen):
         homescreen_id = homescreen.data["id"]
         conf = LocalConf(USER_CONFIG)
-        conf["enclosure"] = {
+        conf["gui"] = {
             "idle_display_skill": homescreen_id,
         }
         conf.store()
@@ -94,7 +94,7 @@ class HomescreenManager:
 
     def disable_active_homescreen(self, message):
         conf = LocalConf(USER_CONFIG)
-        conf["enclosure"] = {
+        conf["gui"] = {
             "idle_display_skill": None,
         }
         conf.store()

--- a/mycroft/gui/namespace.py
+++ b/mycroft/gui/namespace.py
@@ -372,7 +372,7 @@ def _get_idle_display_config():
     """Retrieves the current value of the idle display skill configuration."""
     LOG.info("Getting Idle Skill From Config")
     config = Configuration.get()
-    enclosure_config = config.get("enclosure")
+    enclosure_config = config.get("gui")
     idle_display_skill = enclosure_config.get("idle_display_skill")
 
     return idle_display_skill
@@ -382,7 +382,7 @@ def _get_active_gui_extension():
     """Retrieves the current value of the gui extension configuration. """
     LOG.info("Getting GUI Extension From Config")
     config = Configuration.get()
-    enclosure_config = config.get("enclosure")
+    enclosure_config = config.get("gui")
     gui_extension = enclosure_config.get("extension")
 
     return gui_extension

--- a/mycroft/gui/namespace.py
+++ b/mycroft/gui/namespace.py
@@ -40,6 +40,7 @@ code.  Changes to namespaces, and their contents, are communicated to the GUI
 over the GUI message bus.
 """
 from threading import Lock, Timer
+from time import time, sleep
 from typing import List, Union
 
 from mycroft.configuration import Configuration
@@ -57,6 +58,7 @@ import sys
 namespace_lock = Lock()
 
 RESERVED_KEYS = ['__from', '__idle']
+
 
 class Namespace:
     """A grouping mechanism for related GUI pages and data.
@@ -76,6 +78,7 @@ class Namespace:
             displayed at the same time
         data: a key/value pair representing the data used to populate the GUI
     """
+
     def __init__(self, name: str):
         self.name = name
         self.persistent = False
@@ -227,9 +230,10 @@ class Namespace:
         LOG.info(f"Current pages: {self.pages}")
         # print the attributes of the new pages
         for page in new_pages:
-            LOG.info(f"Page: {page.url}, {page.name}, {page.persistent}, {page.duration}")
+            LOG.info(
+                f"Page: {page.url}, {page.name}, {page.persistent}, {page.duration}")
 
-        #Find position of new page in self.pages
+        # Find position of new page in self.pages
         position = self.pages.index(new_pages[0])
 
         message = dict(
@@ -259,11 +263,11 @@ class Namespace:
 
         # set the page active attribute to True and update the self.pages list, mark all other pages as inactive
 
-        page.active = True;
+        page.active = True
 
         for p in self.pages:
             if p != page:
-                p.active = False;
+                p.active = False
                 # update the self.pages list with the page active status changes
                 self.pages[self.pages.index(p)] = p
 
@@ -301,13 +305,15 @@ class Namespace:
         Args:
             page_number: the page number of the page that will gain focus
         """
-        LOG.info(f"Page {page_number} gained focus in GUI namespace {self.name}")
+        LOG.info(
+            f"Page {page_number} gained focus in GUI namespace {self.name}")
         self._activate_page(self.pages[page_number])
 
     def page_update_interaction(self, page_number):
         """Update the interaction of the page_number"""
 
-        LOG.info(f"Page {page_number} update interaction in GUI namespace {self.name}")
+        LOG.info(
+            f"Page {page_number} update interaction in GUI namespace {self.name}")
         page = self.pages.index(page_number)
         if not page.persistent and page.duration > 0:
             page.duration = page.duration / 2
@@ -335,6 +341,7 @@ class Namespace:
 
     def index_in_pages_list(self, index):
         return(index < len(self.pages))
+
 
 def _validate_page_message(message: Message):
     """Validates the contents of the message data for page add/remove messages.
@@ -371,6 +378,16 @@ def _get_idle_display_config():
     return idle_display_skill
 
 
+def _get_active_gui_extension():
+    """Retrieves the current value of the gui extension configuration. """
+    LOG.info("Getting GUI Extension From Config")
+    config = Configuration.get()
+    enclosure_config = config.get("enclosure")
+    gui_extension = enclosure_config.get("extension")
+
+    return gui_extension
+
+
 class NamespaceManager:
     """Manages the active namespace stack and the content of namespaces.
 
@@ -383,6 +400,7 @@ class NamespaceManager:
             a persistence expressed in seconds
         idle_display_skill: skill ID of the skill that controls the idle screen
     """
+
     def __init__(self, core_bus: MessageBusClient):
         self.core_bus = core_bus
         self.gui_bus = create_gui_service(self)
@@ -390,6 +408,7 @@ class NamespaceManager:
         self.active_namespaces = list()
         self.remove_namespace_timers = dict()
         self.idle_display_skill = _get_idle_display_config()
+        self.active_extension = _get_active_gui_extension()
         self._define_message_handlers()
 
     def _define_message_handlers(self):
@@ -402,7 +421,8 @@ class NamespaceManager:
         self.core_bus.on("gui.value.set", self.handle_set_value)
         self.core_bus.on("mycroft.gui.connected", self.handle_client_connected)
         self.core_bus.on("gui.page_interaction", self.handle_page_interaction)
-        self.core_bus.on("gui.page_gained_focus", self.handle_page_gained_focus)
+        self.core_bus.on("gui.page_gained_focus",
+                         self.handle_page_gained_focus)
 
     def handle_clear_namespace(self, message: Message):
         """Handles a request to remove a namespace.
@@ -568,7 +588,7 @@ class NamespaceManager:
         15 seconds.  This would ensure that the namespace isn't removed while
         the skill is showing the pages.
 
-        Args:
+        Args:active_extension
             persistence: length of time the namespace should be displayed
         """
         LOG.debug(f"Setting namespace persistence to {persistence}")
@@ -585,8 +605,10 @@ class NamespaceManager:
                     # check if there is a scheduled remove_namespace_timer and cancel it
                     if namespace.persistent:
                         if namespace.name in self.remove_namespace_timers:
-                            self.remove_namespace_timers[namespace.name].cancel()
-                            self._del_namespace_in_remove_timers(namespace.name)
+                            self.remove_namespace_timers[namespace.name].cancel(
+                            )
+                            self._del_namespace_in_remove_timers(
+                                namespace.name)
 
                 if not namespace.persistent:
                     LOG.info("It is being scheduled here")
@@ -607,7 +629,8 @@ class NamespaceManager:
             self._remove_namespace_via_timer,
             args=(namespace.name,)
         )
-        LOG.debug(f"Scheduled removal of namespace {namespace.name} in duration {namespace.duration}")
+        LOG.debug(
+            f"Scheduled removal of namespace {namespace.name} in duration {namespace.duration}")
         remove_namespace_timer.start()
         self.remove_namespace_timers[namespace.name] = remove_namespace_timer
 
@@ -623,6 +646,7 @@ class NamespaceManager:
             namespace_name: namespace to remove
         """
         LOG.debug("Removing namespace {namespace_name}")
+
         # Remove all timers associated with the namespace
         if namespace_name in self.remove_namespace_timers:
             self.remove_namespace_timers[namespace_name].cancel()
@@ -630,9 +654,15 @@ class NamespaceManager:
 
         namespace = self.loaded_namespaces.get(namespace_name)
         if namespace is not None and namespace in self.active_namespaces:
+            self.core_bus.emit(Message("gui.namespace.removed", data={
+                               "skill_id": namespace.name}))
+            if self.active_extension == "Bigscreen":
+                # wait for window management in bigscreen extension to finish
+                sleep(1)
             namespace_position = self.active_namespaces.index(namespace)
             namespace.remove(namespace_position)
             self.active_namespaces.remove(namespace)
+
         self._emit_namespace_displayed_event()
 
     def _emit_namespace_displayed_event(self):
@@ -682,7 +712,8 @@ class NamespaceManager:
         namespace = self._ensure_namespace_exists(namespace_name)
         for key, value in data.items():
             if key not in RESERVED_KEYS and namespace.data.get(key) != value:
-                LOG.debug(f"Setting {key} to {value} in namespace {namespace.name}")
+                LOG.debug(
+                    f"Setting {key} to {value} in namespace {namespace.name}")
                 namespace.data[key] = value
                 if namespace in self.active_namespaces:
                     namespace.load_data(key, value)

--- a/mycroft/gui/namespace.py
+++ b/mycroft/gui/namespace.py
@@ -385,7 +385,7 @@ def _get_active_gui_extension():
     enclosure_config = config.get("gui")
     gui_extension = enclosure_config.get("extension")
 
-    return gui_extension
+    return gui_extension.lower()
 
 
 class NamespaceManager:

--- a/mycroft/gui/service.py
+++ b/mycroft/gui/service.py
@@ -4,111 +4,21 @@ from mycroft.util import create_daemon, start_message_bus_client
 from mycroft.configuration import Configuration, LocalConf, USER_CONFIG
 from mycroft.util.log import LOG
 from .namespace import NamespaceManager
+from mycroft.gui.extensions import ExtensionsManager
+
 
 class GUIService:
     def __init__(self):
         self.bus = MessageBusClient()
         self.gui = NamespaceManager(self.bus)
 
-        self.homescreens = []
-        self.bus.on('homescreen.manager.add', self.add_homescreen)
-        self.bus.on('homescreen.manager.remove', self.remove_homescreen)
-        self.bus.on('homescreen.manager.list', self.get_homescreens)
-        self.bus.on("homescreen.manager.get_active", self.get_active_homescreen)
-        self.bus.on("homescreen.manager.set_active", self.set_active_homescreen)
-        self.bus.on("homescreen.manager.disable_active", self.disable_active_homescreen)
-        self.bus.on("mycroft.mark2.register_idle", self.register_old_style_homescreen)
-
     def run(self):
         """Start the GUI after it has been constructed."""
         # Allow exceptions to be raised to the GUI Service
         # if they may cause the Service to fail.
         start_message_bus_client("GUI_SERVICE", self.bus)
-        self.reload_homescreens_list()
-
-    def add_homescreen(self, homescreen):
-        # if homescreen[id] not in self.homescreens then add it
-        homescreen_id = homescreen.data["id"]
-        homescreen_class = homescreen.data["class"]
-        LOG.info(f"Homescreen Manager: Adding Homescreen {homescreen_id}")
-        # check if the list is empty
-        if len(self.homescreens) == 0:
-            self.homescreens.append(homescreen.data)
-        else:
-            # check if id is in list of homescreen dicts in self.homescreens
-            for h in self.homescreens:
-                if homescreen_id != h["id"]:
-                    self.homescreens.append(homescreen.data)
-
-        self.show_homescreen_on_add(homescreen_id, homescreen_class)
-
-    def remove_homescreen(self, homescreen):
-        homescreen_id = homescreen.data["id"]
-        LOG.info(f"Homescreen Manager: Removing Homescreen {homescreen_id}")
-        for h in self.homescreens:
-            if homescreen_id == h["id"]:
-                self.homescreens.pop(h)
-
-    def get_homescreens(self):
-        return self.homescreens
-
-    def get_active_homescreen(self):
-        config = Configuration.get()
-        enclosure_config = config.get("enclosure")
-        active_homescreen = enclosure_config.get("idle_display_skill")
-        LOG.info(f"Homescreen Manager: Active Homescreen {active_homescreen}")
-        for h in self.homescreens:
-            if h["id"] == active_homescreen:
-                return active_homescreen
-
-    def set_active_homescreen(self, homescreen):
-        homescreen_id = homescreen.data["id"]
-        conf = LocalConf(USER_CONFIG)
-        conf["enclosure"] = {
-            "idle_display_skill": homescreen_id,
-        }
-        conf.store()
-        self.bus.emit(Message("configuration.patch", {"config": conf}))
-
-    def reload_homescreens_list(self):
-        LOG.info("Homescreen Manager: Reloading Homescreen List")
-        self.collect_old_style_homescreens()
-        self.bus.emit(Message("homescreen.manager.reload.list"))
-
-    def show_homescreen_on_add(self, homescreen_id, homescreen_class):
-        active_homescreen = self.get_active_homescreen()
-        if active_homescreen == homescreen_id:
-            if homescreen_class == "IdleDisplaySkill":
-                LOG.info(f"Homescreen Manager: Displaying Homescreen {active_homescreen}")
-                self.bus.emit(Message("homescreen.manager.activate.display", {"homescreen_id": active_homescreen}))
-            elif homescreen_class == "MycroftSkill":
-                LOG.info(f"Homescreen Manager: Displaying Homescreen {active_homescreen}")
-                self.bus.emit(Message("{}.idle".format(homescreen_id)))
-
-    def disable_active_homescreen(self, message):
-        conf = LocalConf(USER_CONFIG)
-        conf["enclosure"] = {
-            "idle_display_skill": None,
-        }
-        conf.store()
-        self.bus.emit(Message("configuration.patch", {"config": conf}))
-
-    ### Add compabitility with older versions of the Resting Screen Class
-
-    def collect_old_style_homescreens(self):
-        """Trigger collection of older resting screens."""
-        self.bus.emit(Message("mycroft.mark2.collect_idle"))
-
-    def register_old_style_homescreen(self, message):
-        if "name" in message.data and "id" in message.data:
-            super_class_name = "MycroftSkill"
-            super_class_object = message.data["name"]
-            skill_id = message.data["id"]
-            _homescreen_entry = {"class": super_class_name, "name": super_class_object , "id": skill_id}
-            LOG.debug("Homescreen Manager: Adding OLD Homescreen {skill_id}")
-            self.add_homescreen(Message("homescreen.manager.add", _homescreen_entry))
-        else:
-            LOG.error("Malformed idle screen registration received")
+        extension_manager = ExtensionsManager(
+            "EXTENSION_SERVICE", self.bus, self.gui)
 
     def stop(self):
         """Perform any GUI shutdown processes."""

--- a/test/unittests/gui/test_bigscreen_extension.py
+++ b/test/unittests/gui/test_bigscreen_extension.py
@@ -16,7 +16,7 @@ class TestBigscreenExtension:
         config = base_config()
         config.merge(
             {
-                'enclosure': {
+                'gui': {
                     'extension': 'Bigscreen'
                 }
             })
@@ -32,7 +32,7 @@ class TestBigscreenExtension:
         config = base_config()
         config.merge(
             {
-                'enclosure': {
+                'gui': {
                     'extension': 'Bigscreen'
                 }
             })

--- a/test/unittests/gui/test_bigscreen_extension.py
+++ b/test/unittests/gui/test_bigscreen_extension.py
@@ -17,7 +17,7 @@ class TestBigscreenExtension:
         config.merge(
             {
                 'gui': {
-                    'extension': 'Bigscreen'
+                    'extension': 'bigscreen'
                 }
             })
         mock_get.return_value = config
@@ -33,7 +33,7 @@ class TestBigscreenExtension:
         config.merge(
             {
                 'gui': {
-                    'extension': 'Bigscreen'
+                    'extension': 'bigscreen'
                 }
             })
         mock_get.return_value = config

--- a/test/unittests/gui/test_bigscreen_extension.py
+++ b/test/unittests/gui/test_bigscreen_extension.py
@@ -1,0 +1,44 @@
+from unittest import TestCase, mock
+from unittest.mock import patch
+from mycroft.gui.extensions import BigscreenExtension
+from ..mocks import MessageBusMock
+from mycroft.configuration import Configuration
+from test.util import base_config
+from mycroft.messagebus import Message
+
+PATCH_MODULE = "mycroft.gui.extensions"
+
+# Add Unit Tests For BigscreenExtension
+
+class TestBigscreenExtension:
+    @patch.object(Configuration, 'get')
+    def test_bigscreen_close_current_window(self, mock_get):
+        config = base_config()
+        config.merge(
+            {
+                'enclosure': {
+                    'extension': 'Bigscreen'
+                }
+            })
+        mock_get.return_value = config
+        bigscreen = BigscreenExtension(MessageBusMock(), MessageBusMock())
+        bigscreen.close_current_window = mock.Mock()
+        message_data = Message("gui.namespace.removed", {'skill_id': 'foo'})
+        bigscreen.close_current_window(message_data)
+        bigscreen.close_current_window.assert_any_call(message_data)
+
+    @patch.object(Configuration, 'get')
+    def test_bigscreen_close_window_by_event(self, mock_get):
+        config = base_config()
+        config.merge(
+            {
+                'enclosure': {
+                    'extension': 'Bigscreen'
+                }
+            })
+        mock_get.return_value = config
+        bigscreen = BigscreenExtension(MessageBusMock(), MessageBusMock())
+        bigscreen.close_window_by_event = mock.Mock()
+        message_data = Message("mycroft.gui.screen.close", {})
+        bigscreen.close_window_by_event(message_data)
+        bigscreen.close_window_by_event.assert_any_call(message_data)

--- a/test/unittests/gui/test_extensions_manager.py
+++ b/test/unittests/gui/test_extensions_manager.py
@@ -1,15 +1,31 @@
 from unittest import TestCase, mock
 from mycroft.gui.extensions import ExtensionsManager
 from ..mocks import MessageBusMock
+from mycroft.configuration import Configuration
+from test.util import base_config
 
 PATCH_MODULE = "mycroft.gui.extensions"
 
 # Add Unit Tests For ExtensionManager
 
 class TestExtensionManager:
+    @patch.object(Configuration, 'get')
 
     def test_extension_manager_activate(self):
+        config = base_config()
+        config.merge(
+            {
+                'enclosure': {
+                    'extension': 'Generic',
+                    'generic': {
+                        'homescreen_supported': False
+                    }
+                }
+            })
+        mock_get.return_value = config
+        config['enclosure']['extension'] = 'Generic'
+        config['enclosure']['extension']['generic']['homescreen_supported'] = False
         extension_manager = ExtensionsManager("ExtensionManager", MessageBusMock(), MessageBusMock())
         extension_manager.activate_extension = mock.Mock()
-        extension_manager.activate_extension("SmartSpeaker")
-        extension_manager.activate_extension.assert_any_call("SmartSpeaker")
+        extension_manager.activate_extension("Generic")
+        extension_manager.activate_extension.assert_any_call("Generic")

--- a/test/unittests/gui/test_extensions_manager.py
+++ b/test/unittests/gui/test_extensions_manager.py
@@ -1,4 +1,5 @@
 from unittest import TestCase, mock
+from unittest.mock import patch
 from mycroft.gui.extensions import ExtensionsManager
 from ..mocks import MessageBusMock
 from mycroft.configuration import Configuration

--- a/test/unittests/gui/test_extensions_manager.py
+++ b/test/unittests/gui/test_extensions_manager.py
@@ -16,7 +16,7 @@ class TestExtensionManager:
         config.merge(
             {
                 'gui': {
-                    'extension': 'Generic',
+                    'extension': 'generic',
                     'generic': {
                         'homescreen_supported': False
                     }
@@ -25,5 +25,5 @@ class TestExtensionManager:
         mock_get.return_value = config
         extension_manager = ExtensionsManager("ExtensionManager", MessageBusMock(), MessageBusMock())
         extension_manager.activate_extension = mock.Mock()
-        extension_manager.activate_extension("Generic")
-        extension_manager.activate_extension.assert_any_call("Generic")
+        extension_manager.activate_extension("generic")
+        extension_manager.activate_extension.assert_any_call("generic")

--- a/test/unittests/gui/test_extensions_manager.py
+++ b/test/unittests/gui/test_extensions_manager.py
@@ -15,7 +15,7 @@ class TestExtensionManager:
         config = base_config()
         config.merge(
             {
-                'enclosure': {
+                'gui': {
                     'extension': 'Generic',
                     'generic': {
                         'homescreen_supported': False

--- a/test/unittests/gui/test_extensions_manager.py
+++ b/test/unittests/gui/test_extensions_manager.py
@@ -23,8 +23,6 @@ class TestExtensionManager:
                 }
             })
         mock_get.return_value = config
-        config['enclosure']['extension'] = 'Generic'
-        config['enclosure']['extension']['generic']['homescreen_supported'] = False
         extension_manager = ExtensionsManager("ExtensionManager", MessageBusMock(), MessageBusMock())
         extension_manager.activate_extension = mock.Mock()
         extension_manager.activate_extension("Generic")

--- a/test/unittests/gui/test_extensions_manager.py
+++ b/test/unittests/gui/test_extensions_manager.py
@@ -11,8 +11,7 @@ PATCH_MODULE = "mycroft.gui.extensions"
 
 class TestExtensionManager:
     @patch.object(Configuration, 'get')
-
-    def test_extension_manager_activate(self):
+    def test_extension_manager_activate(self, mock_get):
         config = base_config()
         config.merge(
             {

--- a/test/unittests/gui/test_extensions_manager.py
+++ b/test/unittests/gui/test_extensions_manager.py
@@ -1,0 +1,15 @@
+from unittest import TestCase, mock
+from mycroft.gui.extensions import ExtensionsManager
+from ..mocks import MessageBusMock
+
+PATCH_MODULE = "mycroft.gui.extensions"
+
+# Add Unit Tests For ExtensionManager
+
+class TestExtensionManager:
+
+    def test_extension_manager_activate(self):
+        extension_manager = ExtensionsManager("ExtensionManager", MessageBusMock(), MessageBusMock())
+        extension_manager.activate_extension = mock.Mock()
+        extension_manager.activate_extension("SmartSpeaker")
+        extension_manager.activate_extension.assert_any_call("SmartSpeaker")

--- a/test/unittests/gui/test_smartspeaker_extension.py
+++ b/test/unittests/gui/test_smartspeaker_extension.py
@@ -17,7 +17,7 @@ class TestSmartSpeakerExtension:
         config.merge(
             {
                 'gui': {
-                    'extension': 'SmartSpeaker'
+                    'extension': 'smartspeaker'
                 }
             })
         mock_get.return_value = config
@@ -33,7 +33,7 @@ class TestSmartSpeakerExtension:
         config.merge(
             {
                 'gui': {
-                    'extension': 'SmartSpeaker'
+                    'extension': 'smartspeaker'
                 }
             })
         mock_get.return_value = config

--- a/test/unittests/gui/test_smartspeaker_extension.py
+++ b/test/unittests/gui/test_smartspeaker_extension.py
@@ -1,0 +1,44 @@
+from unittest import TestCase, mock
+from unittest.mock import patch
+from mycroft.gui.extensions import SmartSpeakerExtension
+from ..mocks import MessageBusMock
+from mycroft.configuration import Configuration
+from test.util import base_config
+from mycroft.messagebus import Message
+
+PATCH_MODULE = "mycroft.gui.extensions"
+
+# Add Unit Tests For SmartSpeakerExtension
+
+class TestSmartSpeakerExtension:
+    @patch.object(Configuration, 'get')
+    def test_smartspeaker_set_backend_type(self, mock_get):
+        config = base_config()
+        config.merge(
+            {
+                'enclosure': {
+                    'extension': 'SmartSpeaker'
+                }
+            })
+        mock_get.return_value = config
+        smartSpeaker = SmartSpeakerExtension(MessageBusMock(), MessageBusMock())
+        smartSpeaker.set_backend_type = mock.Mock()
+        message_data = Message("ovos.pairing.set.backend", {'backend': 'unknown'})
+        smartSpeaker.set_backend_type(message_data)
+        smartSpeaker.set_backend_type.assert_any_call(message_data)
+
+    @patch.object(Configuration, 'get')
+    def test_smartspeaker_start_homescreen_process(self, mock_get):
+        config = base_config()
+        config.merge(
+            {
+                'enclosure': {
+                    'extension': 'SmartSpeaker'
+                }
+            })
+        mock_get.return_value = config
+        smartSpeaker = SmartSpeakerExtension(MessageBusMock(), MessageBusMock())
+        smartSpeaker.start_homescreen_process = mock.Mock()
+        message_data = Message("ovos.pairing.process.completed", {})
+        smartSpeaker.start_homescreen_process(message_data)
+        smartSpeaker.start_homescreen_process.assert_any_call(message_data)

--- a/test/unittests/gui/test_smartspeaker_extension.py
+++ b/test/unittests/gui/test_smartspeaker_extension.py
@@ -16,7 +16,7 @@ class TestSmartSpeakerExtension:
         config = base_config()
         config.merge(
             {
-                'enclosure': {
+                'gui': {
                     'extension': 'SmartSpeaker'
                 }
             })
@@ -32,7 +32,7 @@ class TestSmartSpeakerExtension:
         config = base_config()
         config.merge(
             {
-                'enclosure': {
+                'gui': {
                     'extension': 'SmartSpeaker'
                 }
             })


### PR DESCRIPTION
- Adds GUI extensions support for specific platforms, GUI Extensions provide additional platform specific functionality needed by specific supported platforms to be usable, this is a full replacement for "Platform Skills", All GUI related required functionality should remain within the GUI service itself.

- Added Support For Following GUI Extensions:
  - SmartSpeaker Extension: Provides additional functionality required that was previously provided by the skill-ovos-mycroftgui skill to connect the mycroft embedded shell front end, this extension also provides support for homescreens and homescreen management 
  - Bigscreen Extension: Provides additional functionality that was previously provided by the bigscreen platform skill for providing control over window management, Bigscreen does not provide or support homescreens
  - Generic Extension (Default): Provides generic additional functionality for generic platforms and environments that might have no additional control requirements such as Desktops, Homescreen support and Homescreen management is optionally available for this extension and has to be exclusively enabled.
  - To-Do(In Future): Add Android and Linux Mobile Extensions.

- Homescreen Manager is now independent of Service and is now loaded by the extension
- Homescreen Manager: Improvement to old style resting screens activation time and support for "mycroft.ready" signal 
- Homescreen Manager: Added show_homescreen method and handling
- Namespace: Added _get_active_extension_method() and check if extension is bigscreen during remove_namespace method for making remove namespace not clash with window close call 