### PR TITLE
call device prepare after skill manager has started

### DIFF
--- a/mycroft/skills/__main__.py
+++ b/mycroft/skills/__main__.py
@@ -211,8 +211,8 @@ def main(alive_hook=on_alive, started_hook=on_started, ready_hook=on_ready,
                                  error_hook=error_hook)
 
     device_primer = DevicePrimer(bus)
-    device_primer.prepare_device()
     skill_manager.start()
+    device_primer.prepare_device()
 
     wait_for_exit_signal()
 


### PR DESCRIPTION
- Call device_primer.prepare_device() after skill manager has started. Fix for https://github.com/OpenVoiceOS/ovos-core/issues/79