### PR TITLE
fix/mycroft_ready

### DIFF
--- a/mycroft/skills/skill_manager.py
+++ b/mycroft/skills/skill_manager.py
@@ -190,8 +190,8 @@ class SkillManager(Thread):
             'mycroft.skills.settings.update',
             self.settings_downloader.download
         )
-        self.bus.on('mycroft.skills.trained',
-                    self.handle_check_device_readiness)
+        self.bus.once('mycroft.skills.initialized',
+                      self.handle_check_device_readiness)
 
     def is_device_ready(self):
         is_ready = False


### PR DESCRIPTION
mycroft.ready could be sent multiple times because it was emitted on padatious training message, this happens consistently when using OCP

padatious is not even required so this was changed to 'mycroft.skills.initialized' which is a more appropriate event

will only listen to the message once to avoid multiple triggers