### PR TITLE
fix/loop_race_condition

### DIFF
--- a/mycroft/client/speech/service.py
+++ b/mycroft/client/speech/service.py
@@ -53,12 +53,13 @@ class SpeechClient(Thread):
 
         self.config = Configuration.get()
         self.bus = start_message_bus_client("VOICE")
-        self.connect_bus_events()
+
         self.status.bind(self.bus)
 
         # Register handlers on internal RecognizerLoop bus
         self.loop = RecognizerLoop(self.bus, watchdog)
         self.connect_loop_events()
+        self.connect_bus_events()
 
     # loop events
     def handle_record_begin(self):

--- a/mycroft/skills/skill_manager.py
+++ b/mycroft/skills/skill_manager.py
@@ -319,8 +319,6 @@ class SkillManager(Thread):
             else:
                 LOG.error(f'Priority skill {skill_id} can\'t be found')
 
-        self.status.set_alive()
-
     def handle_initial_training(self, message):
         self.initial_load_complete = True
 
@@ -329,6 +327,8 @@ class SkillManager(Thread):
         self._remove_git_locks()
 
         self.load_priority()
+
+        self.status.set_alive()
 
         if self.skills_config.get("wait_for_internet", True):
             while not connected() and not self._connected_event.is_set():

--- a/test/unittests/skills/test_skill_manager.py
+++ b/test/unittests/skills/test_skill_manager.py
@@ -109,8 +109,8 @@ class TestSkillManager(MycroftUnitTestBase):
             'mycroft.paired',
             'mycroft.skills.settings.update',
             'mycroft.skills.initialized',
-            'mycroft.skills.is_alive',
             'mycroft.skills.trained',
+            'mycroft.skills.is_alive',
             'mycroft.skills.is_ready',
             'mycroft.skills.all_loaded'
         ]

--- a/test/unittests/skills/test_skill_manager.py
+++ b/test/unittests/skills/test_skill_manager.py
@@ -108,7 +108,7 @@ class TestSkillManager(MycroftUnitTestBase):
             'skillmanager.activate',
             'mycroft.paired',
             'mycroft.skills.settings.update',
-            'mycroft.skills.trained',
+            'mycroft.skills.initialized',
             'mycroft.skills.is_alive',
             'mycroft.skills.is_ready',
             'mycroft.skills.all_loaded'

--- a/test/unittests/skills/test_skill_manager.py
+++ b/test/unittests/skills/test_skill_manager.py
@@ -110,6 +110,7 @@ class TestSkillManager(MycroftUnitTestBase):
             'mycroft.skills.settings.update',
             'mycroft.skills.initialized',
             'mycroft.skills.is_alive',
+            'mycroft.skills.trained',
             'mycroft.skills.is_ready',
             'mycroft.skills.all_loaded'
         ]


### PR DESCRIPTION
bus handlers could be triggered before self.loop existed throwing an exception

```
  File "/usr/lib/python3.8/site-packages/pyee/_executor.py", line 56, in _callback
    self.emit('error', exc)
  File "/usr/lib/python3.8/site-packages/pyee/_base.py", line 116, in emit
    self._emit_handle_potential_error(event, args[0] if args else None)
  File "/usr/lib/python3.8/site-packages/pyee/_base.py", line 86, in _emit_handle_potential_error
    raise error
  File "/usr/lib/python3.8/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/usr/lib/python3.8/site-packages/mycroft/client/speech/service.py", line 161, in handle_mic_get_status
    data = {'muted': self.loop.is_muted()}
AttributeError: 'SpeechClient' object has no attribute 'loop'
```