### PR TITLE
py3.10 compat

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -52,7 +52,7 @@ jobs:
           pip install .[audio-backend,mark1,stt,tts,skills,gui,bus,PHAL,all,deprecated]
       - name: Install test dependencies
         run: |
-          pip install pytest pytest-timeout pytest-cov
+          pip install -r requirements/tests.txt
       - name: Run unittests
         run: |
           pytest --cov=mycroft --cov-report xml test/unittests

--- a/mycroft/client/speech/__main__.py
+++ b/mycroft/client/speech/__main__.py
@@ -21,7 +21,7 @@ def main(ready_hook=on_ready, error_hook=on_error, stopping_hook=on_stopping,
                            on_error=error_hook,
                            on_stopping=stopping_hook,
                            watchdog=watchdog)
-    service.setDaemon(True)
+    service.daemon = True
     service.start()
     wait_for_exit_signal()
 

--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -378,7 +378,7 @@
     "instant_listen": false
   },
 
-  // Settings used for any precise wake words
+  // DEPRECATED - Settings used for any precise wake words
   "precise": {
     "use_precise": true,
     "dist_url": "https://github.com/MycroftAI/precise-data/raw/dist/{arch}/latest",
@@ -388,17 +388,14 @@
   // Hotword configurations
   "hotwords": {
     "hey mycroft": {
-        "module": "ovos-precise-lite",
+        "module": "ovos-ww-plugin-precise",
+        "version": "0.3",
+        "model": "https://github.com/MycroftAI/precise-data/raw/models-dev/hey-mycroft.tar.gz",
         "phonemes": "HH EY . M AY K R AO F T",
         "threshold": 1e-90,
         "lang": "en-us",
         "listen": true,
         "sound": "snd/start_listening.wav"
-        // Specify custom model via:
-        // "local_model_file": "~/.local/share/mycroft/precise/models/something.pb"
-        // Precise options:
-        // "sensitivity": 0.5,  // Higher = more sensitive
-        // "trigger_level": 3   // Higher = more delay & less sensitive
         },
 
     "wake up": {

--- a/mycroft/listener/__init__.py
+++ b/mycroft/listener/__init__.py
@@ -360,7 +360,8 @@ class RecognizerLoop(EventEmitter):
             self.stt = STTFactory.create()
         if not self.fallback_stt:
             clazz = self.get_fallback_stt()
-            self.fallback_stt = clazz()
+            if clazz:
+                self.fallback_stt = clazz()
 
         self.queue = Queue()
         self.audio_consumer = AudioConsumer(self)

--- a/mycroft/listener/__main__.py
+++ b/mycroft/listener/__main__.py
@@ -30,7 +30,7 @@ def main(ready_hook=on_ready, error_hook=on_error, stopping_hook=on_stopping,
                            on_error=error_hook,
                            on_stopping=stopping_hook,
                            watchdog=watchdog)
-    service.setDaemon(True)
+    service.daemon = True
     service.start()
     wait_for_exit_signal()
 

--- a/requirements/extra-deprecated.txt
+++ b/requirements/extra-deprecated.txt
@@ -1,4 +1,5 @@
 msm
+mock_msm~=0.9.2
 ovos_cli_client
 python-vlc>=1.1.2
 pyalsaaudio~=0.8.2

--- a/requirements/extra-stt.txt
+++ b/requirements/extra-stt.txt
@@ -1,6 +1,4 @@
 SpeechRecognition~=3.8.1
 PyAudio~=0.2.11
 ovos-ww-plugin-pocketsphinx>=0.1.2
-ovos-ww-plugin-precise-lite>=0.1.1
 ovos-ww-plugin-precise>=0.1.1
-ovos-stt-plugin-vosk>=0.1.3a2

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -14,14 +14,11 @@ ovos-tts-plugin-mimic>=0.2.6
 ovos-tts-plugin-mimic2>=0.1.4
 ovos-tts-plugin-google-tx>=0.0.3
 ovos-ww-plugin-pocketsphinx>=0.1.2
-ovos-ww-plugin-precise-lite>=0.1.1
 ovos-ww-plugin-precise>=0.1.1
-ovos-stt-plugin-vosk>=0.1.3a2
 ovos_workshop>=0.0.5
 ovos_PHAL>=0.0.1
 
 ovos-lingua-franca~=0.4.3
-mock_msm~=0.9.2
 mycroft-messagebus-client~=0.9.1,!=0.9.2,!=0.9.3
 adapt-parser~=0.5
 padatious~=0.4.8

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -5,6 +5,6 @@ pytest-cov==2.8.1
 cov-core==1.15.0
 sphinx==2.2.1
 sphinx-rtd-theme==0.4.3
-
+mock_msm~=0.9.2
 ovos-stt-plugin-vosk>=0.1.3a2
 python-vlc==1.1.2

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -6,5 +6,5 @@ cov-core==1.15.0
 sphinx==2.2.1
 sphinx-rtd-theme==0.4.3
 
-
+ovos-stt-plugin-vosk>=0.1.3a2
 python-vlc==1.1.2

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(
     include_package_data=True,
     entry_points={
         'console_scripts': [
-            'mycroft-speech-client=mycroft.client.speech.__main__:main',
+            'mycroft-speech-client=mycroft.listener.__main__:main',
             'mycroft-messagebus=mycroft.messagebus.service.__main__:main',
             'mycroft-skills=mycroft.skills.__main__:main',
             'mycroft-audio=mycroft.audio.__main__:main',


### PR DESCRIPTION
- tflite is not available, change default ww from precise-lite to precise 0.3
- vosk is not available, do not install it, by default fallback stt will fail to load and pairing is required for STT functionality

there is also a potential bug with pyaudio, i am getting it in manjaro arm but not in my laptop

```
SystemError: PY_SSIZE_T_CLEAN macro must be defined for '#' formats
Exception in thread Thread-5:
Traceback (most recent call last):
  File "/usr/lib/python3.10/threading.py", line 1009, in _bootstrap_inner
    self.run()
  File "/home/mycroft/ovos-core/mycroft/listener/__init__.py", line 71, in run
    self.loop.responsive_recognizer.adjust_for_ambient_noise(source)
  File "/home/mycroft/ovos-core/mycroft/listener/mic.py", line 784, in adjust_for_ambient_noise
    for chunk in itertools.islice(source.stream.iter_chunks(), num_chunks):
  File "/home/mycroft/ovos-core/mycroft/listener/mic.py", line 96, in iter_chunks
    self.chunk_ready.wait()
  File "/usr/lib/python3.10/threading.py", line 600, in wait
    signaled = self._cond.wait(timeout)
  File "/usr/lib/python3.10/threading.py", line 320, in wait
    waiter.acquire()
SystemError
```

using [this fork](https://git.skeh.site/skeh/pyaudio) of pyaudio solves the issue