### PR TITLE
Fix/plugins shutdown

### DIFF
--- a/mycroft/skills/__main__.py
+++ b/mycroft/skills/__main__.py
@@ -54,7 +54,7 @@ def main(alive_hook=on_alive, started_hook=on_started, ready_hook=on_ready,
     bus = start_message_bus_client("SKILLS")
     _register_intent_services(bus)
     event_scheduler = EventScheduler(bus, autostart=False)
-    event_scheduler.setDaemon(True)
+    event_scheduler.daemon = True
     event_scheduler.start()
     SkillApi.connect_bus(bus)
     skill_manager = SkillManager(bus, watchdog,

--- a/mycroft/skills/skill_manager.py
+++ b/mycroft/skills/skill_manager.py
@@ -576,5 +576,5 @@ class SkillManager(Thread):
                 _shutdown_skill(skill_loader.instance)
 
         # Do a clean shutdown of all plugin skills
-        for skill_id in self.plugin_skills:
+        for skill_id in list(self.plugin_skills.keys()):
             self._unload_plugin_skill(skill_id)


### PR DESCRIPTION
fix shutdown of plugins skills when stopping skill manager, it would throw an exception 

also fixes a deprecation warning in py3.10