### PR TITLE
deprecate/optional_xdg

### DIFF
--- a/mycroft/configuration/__init__.py
+++ b/mycroft/configuration/__init__.py
@@ -17,4 +17,4 @@ from mycroft.configuration.locale import set_default_lf_lang, setup_locale, \
     set_default_tz, set_default_lang, get_default_tz, get_default_lang, \
     get_config_tz, get_primary_lang_code, load_languages, load_language
 from mycroft.configuration.locations import SYSTEM_CONFIG, USER_CONFIG, DEFAULT_CONFIG
-from ovos_utils.configuration import get_ovos_config, is_using_xdg, get_xdg_config_locations
+from ovos_utils.configuration import get_ovos_config, get_xdg_config_locations

--- a/mycroft/configuration/config.py
+++ b/mycroft/configuration/config.py
@@ -17,7 +17,7 @@ import re
 from os.path import isfile
 
 from mycroft.configuration.locations import *
-from ovos_utils.configuration import is_using_xdg, get_xdg_config_locations, get_xdg_config_save_path
+from ovos_utils.configuration import get_xdg_config_locations, get_xdg_config_save_path
 from mycroft.util import camel_case_split
 from mycroft.util.json_helper import load_commented_json, merge_dict
 from mycroft.util.log import LOG
@@ -254,15 +254,11 @@ class Configuration:
             if not skip_remote and remote:
                 configs.append(RemoteConf())
             if not skip_user:
-                if is_using_xdg():
-                    # deprecation warning
-                    if isfile(OLD_USER_CONFIG):
-                        _log_old_location_deprecation(OLD_USER_CONFIG)
-                        configs.append(LocalConf(OLD_USER_CONFIG))
-                    configs += [LocalConf(p) for p in xdg_locations]
-                else:
-                    # just load the pre defined old locations
+                # deprecation warning
+                if isfile(OLD_USER_CONFIG):
+                    _log_old_location_deprecation(OLD_USER_CONFIG)
                     configs.append(LocalConf(OLD_USER_CONFIG))
+                configs += [LocalConf(p) for p in xdg_locations]
             configs.append(Configuration.__patch)
         else:
             # Handle strings in stack

--- a/mycroft/configuration/ovos.py
+++ b/mycroft/configuration/ovos.py
@@ -62,4 +62,4 @@ Examples config:
    }
 }
 """
-from ovos_utils.configuration import get_ovos_config, is_using_xdg
+from ovos_utils.configuration import get_ovos_config

--- a/mycroft/filesystem/__init__.py
+++ b/mycroft/filesystem/__init__.py
@@ -15,7 +15,7 @@
 import os
 import shutil
 from os.path import join, expanduser, isdir
-from ovos_utils.configuration import is_using_xdg, get_xdg_base, get_xdg_config_save_path
+from ovos_utils.configuration import get_xdg_base, get_xdg_config_save_path
 
 
 class FileSystemAccess:
@@ -35,12 +35,10 @@ class FileSystemAccess:
             raise ValueError("path must be initialized as a non empty string")
 
         path = expanduser(f'~/.{get_xdg_base()}/{path}')
-
-        if is_using_xdg():
-            xdg_path = expanduser(f'{get_xdg_config_save_path()}/{path}')
-            # Migrate from the old location if it still exists
-            if isdir(path) and not isdir(xdg_path):
-                shutil.move(path, xdg_path)
+        xdg_path = expanduser(f'{get_xdg_config_save_path()}/{path}')
+        # Migrate from the old location if it still exists
+        if isdir(path) and not isdir(xdg_path):
+            shutil.move(path, xdg_path)
 
         if not isdir(path):
             os.makedirs(path)

--- a/mycroft/skills/event_scheduler.py
+++ b/mycroft/skills/event_scheduler.py
@@ -23,7 +23,7 @@ from threading import Thread, Lock
 from os.path import isfile, join, expanduser
 
 from mycroft.configuration import Configuration
-from ovos_utils.configuration import is_using_xdg, get_xdg_base, get_xdg_data_save_path, get_xdg_config_save_path
+from ovos_utils.configuration import get_xdg_base, get_xdg_data_save_path, get_xdg_config_save_path
 from mycroft.messagebus.message import Message
 from mycroft.util.log import LOG
 from mycroft.skills.mycroft_skill.event_container import EventContainer, \
@@ -69,12 +69,9 @@ class EventScheduler(Thread):
         data_dir = core_conf.get('data_dir') or get_xdg_data_save_path()
         old_schedule_path = join(expanduser(data_dir), schedule_file)
 
-        self.schedule_file = old_schedule_path
-        if is_using_xdg():
-            new_schedule_path = join(get_xdg_config_save_path(), schedule_file)
-            if isfile(old_schedule_path):
-                shutil.move(old_schedule_path, new_schedule_path)
-            self.schedule_file = new_schedule_path
+        self.schedule_file = join(get_xdg_config_save_path(), schedule_file)
+        if isfile(old_schedule_path):
+            shutil.move(old_schedule_path, self.schedule_file)
 
         if self.schedule_file:
             self.load()

--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -59,7 +59,7 @@ from mycroft.util import (
 from mycroft.util.format import pronounce_number, join_list
 from mycroft.util.log import LOG
 from mycroft.util.parse import match_one, extract_number
-from ovos_utils.configuration import is_using_xdg, get_xdg_base, get_xdg_data_save_path, get_xdg_config_save_path
+from ovos_utils.configuration import get_xdg_base, get_xdg_data_save_path, get_xdg_config_save_path
 from ovos_utils.enclosure.api import EnclosureAPI
 from ovos_utils.file_utils import get_temp_path
 import shutil
@@ -271,13 +271,10 @@ class MycroftSkill:
 
     @property
     def _settings_path(self):
-        is_xdg = is_using_xdg()
         if self.settings_write_path:
             LOG.warning("self.settings_write_path has been deprecated! "
                         "Support will be dropped in a future release")
             return join(self.settings_write_path, 'settings.json')
-        if not is_xdg:
-            return self._old_settings_path
         return join(get_xdg_config_save_path(), 'skills', self.skill_id, 'settings.json')
 
     @property

--- a/mycroft/skills/skill_loader.py
+++ b/mycroft/skills/skill_loader.py
@@ -21,7 +21,7 @@ from inspect import isclass, signature
 from os import path, makedirs
 from time import time
 
-from ovos_utils.configuration import get_xdg_base, is_using_xdg, get_xdg_data_dirs, get_xdg_data_save_path
+from ovos_utils.configuration import get_xdg_base, get_xdg_data_dirs, get_xdg_data_save_path
 from ovos_plugin_manager.skills import find_skill_plugins
 
 from mycroft.configuration import Configuration
@@ -140,11 +140,6 @@ def get_default_skills_directory(conf=None):
                     "It will no longer be supported after version 0.0.3\n"
                     "add the new path to 'extra_directories' instead")
         skills_folder = path_override
-    # if xdg is disabled, ignore it!
-    elif not is_using_xdg():
-        # old style mycroft-core skills path definition
-        data_dir = conf.get("data_dir") or "/opt/" + get_xdg_base()
-        skills_folder = path.join(data_dir, folder)
     else:
         skills_folder = os.path.join(get_xdg_data_save_path(), folder)
     # create folder if needed

--- a/mycroft/util/file_utils.py
+++ b/mycroft/util/file_utils.py
@@ -21,7 +21,7 @@ accessing and curating mycroft's cache.
 import os
 
 from ovos_utils.file_utils import get_temp_path
-from ovos_utils.configuration import is_using_xdg, get_xdg_base, get_xdg_data_dirs, get_xdg_data_save_path
+from ovos_utils.configuration import get_xdg_base, get_xdg_data_dirs, get_xdg_data_save_path
 import mycroft.configuration
 from mycroft.util.log import LOG
 # do not delete these imports, here for backwards compat!
@@ -153,11 +153,7 @@ def get_cache_directory(domain=None):
     config = mycroft.configuration.Configuration.get(remote=False)
     directory = config.get("cache_path")
     if not directory:
-        if not is_using_xdg():
-            # If not defined, use /tmp/mycroft/cache
-            directory = get_temp_path(get_xdg_base(), 'cache')
-        else:
-            directory = os.path.join(get_xdg_data_save_path(), "cache")
+        directory = os.path.join(get_xdg_data_save_path(), "cache")
     return ensure_directory_exists(directory, domain)
 
 


### PR DESCRIPTION
`is_using_xdg` was a temporary check while we waited for mycroft-core to catch up, mycroft is now mostly compliant except for skills where we already differ significantly.

This flag was used by neon during initial migration and by HolmesV which is now abandonware

# TODO also deprecate util method in ovos_utils