### PR TITLE
remove pyee, version pinned by bus client directly

### DIFF
--- a/requirements/minimal.txt
+++ b/requirements/minimal.txt
@@ -1,5 +1,4 @@
 requests~=2.26
-pyee~=8.1
 mycroft-messagebus-client~=0.9,!=0.9.2,!=0.9.3
 combo-lock~=0.2
 ovos-utils~=0.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,6 +1,5 @@
 requests~=2.26
 PyAudio~=0.2
-pyee~=8.1
 SpeechRecognition~=3.8
 tornado~=6.0, >=6.0.3
 psutil~=5.6.6


### PR DESCRIPTION
remove pyee, version pinned by bus client directly

pinning it here can cause conflicts, snice no longer used directly and not a direct dependency it was removed