### PR TITLE
refactor/no_adapt

### DIFF
--- a/mycroft/__init__.py
+++ b/mycroft/__init__.py
@@ -17,17 +17,10 @@ import mycroft.configuration
 from mycroft.api import Api
 from mycroft.messagebus.message import Message
 
-# don't require adapt to be installed to import non-skill stuff
-try:
-    from mycroft.skills.context import adds_context, removes_context
-    from mycroft.skills import (MycroftSkill, FallbackSkill,
-                                intent_handler, intent_file_handler)
-    from mycroft.skills.intent_services.adapt_service import AdaptIntent
-except ImportError:
-    # skills requirements not installed
-    # i would remove this completely, but some skills in the wild import
-    # from the top level module instead of mycroft.skills
-    pass
+from ovos_workshop.helpers import AdaptIntent, IntentBuilder, Intent
+from mycroft.skills.context import adds_context, removes_context
+from mycroft.skills import (MycroftSkill, FallbackSkill,
+                            intent_handler, intent_file_handler)
 from mycroft.util.log import LOG
 
 MYCROFT_ROOT_PATH = abspath(join(dirname(__file__), '..'))
@@ -36,7 +29,7 @@ __all__ = ['MYCROFT_ROOT_PATH',
            'Api',
            'Message']
 
-from mycroft.configuration import  Configuration
+from mycroft.configuration import Configuration
 _cfg = Configuration.get()
 _log_level = _cfg.get("log_level", "INFO")
 _logs_conf = _cfg.get("logs") or {}

--- a/mycroft/skills/intent_service_interface.py
+++ b/mycroft/skills/intent_service_interface.py
@@ -16,7 +16,7 @@
 Intent Service. Including both adapt and padatious.
 """
 from os.path import exists, isfile
-from adapt.intent import Intent
+from ovos_workshop.helpers import Intent
 
 from mycroft.messagebus.message import Message, dig_for_message
 from mycroft.messagebus.client import MessageBusClient

--- a/mycroft/skills/intent_services/adapt_service.py
+++ b/mycroft/skills/intent_services/adapt_service.py
@@ -18,8 +18,7 @@ import time
 
 from adapt.context import ContextManagerFrame
 from adapt.engine import IntentDeterminationEngine
-from adapt.intent import IntentBuilder
-
+from ovos_workshop.helpers import AdaptIntent, IntentBuilder, Intent
 from mycroft.configuration import Configuration
 from mycroft.util.log import LOG
 from mycroft.skills.intent_services.base import IntentMatch
@@ -38,17 +37,6 @@ def _entity_skill_id(skill_id):
     skill_id = skill_id.replace('.', '_')
     skill_id = skill_id.replace('-', '_')
     return skill_id
-
-
-class AdaptIntent(IntentBuilder):
-    """Wrapper for IntentBuilder setting a blank name.
-
-    Args:
-        name (str): Optional name of intent
-    """
-
-    def __init__(self, name=''):
-        super().__init__(name)
 
 
 def _strip_result(context_features):

--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -22,10 +22,9 @@ from inspect import signature
 from itertools import chain
 from os import walk, listdir
 from os.path import join, abspath, dirname, basename, exists, isdir
-import shutil
 from threading import Event
 
-from adapt.intent import Intent, IntentBuilder
+from ovos_workshop.helpers import Intent, IntentBuilder
 from json_database import JsonStorage
 
 from mycroft import dialog

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -15,7 +15,7 @@ ovos-tts-plugin-mimic2~=0.1, >=0.1.5
 ovos-tts-plugin-google-tx~=0.0, >=0.0.3
 ovos-ww-plugin-pocketsphinx~=0.1
 ovos-ww-plugin-precise~=0.1
-ovos_workshop~=0.0, >=0.0.7a4
+ovos_workshop~=0.0, >=0.0.7a6
 ovos_PHAL~=0.0, >=0.0.2a8
 ovos-lingua-franca~=0.4, >=0.4.2
 


### PR DESCRIPTION
some helper classes providing only syntactic sugar required adapt-parser, these have been refactored and moved into ovos_workshop to avoid dragging adapt-parser dependency (except for skills service)