### PR TITLE
feat/feat/common_query

### DIFF
--- a/mycroft/skills/common_query_skill.py
+++ b/mycroft/skills/common_query_skill.py
@@ -70,15 +70,13 @@ class CommonQuerySkill(MycroftSkill, ABC):
 
     def __init__(self, name=None, bus=None):
         super().__init__(name, bus)
-        noise_words_filepath = "text/%s/noise_words.list" % (self.lang,)
+        noise_words_filepath = f"text/{self.lang}/noise_words.list"
         noise_words_filename = resolve_resource_file(noise_words_filepath)
         self.translated_noise_words = []
-        try:
+        if noise_words_filename:
             with open(noise_words_filename) as f:
                 self.translated_noise_words = f.read().strip()
             self.translated_noise_words = self.translated_noise_words.split()
-        except FileNotFoundError:
-            self.log.warning("Missing noise_words.list file in res/text/lang")
 
         # these should probably be configurable
         self.level_confidence = {
@@ -148,12 +146,6 @@ class CommonQuerySkill(MycroftSkill, ABC):
         # bonus for more sentences
         num_sentences = float(float(len(answer.split("."))) / float(10))
 
-        # Add bonus if match has visuals and the device supports them.
-        platform = self.config_core.get("enclosure", {}).get("platform")
-        bonus = 0.0
-        if is_CQSVisualMatchLevel(level) and handles_visuals(platform):
-            bonus = 0.1
-
         # extract topic
         topic = self.remove_noise(match)
 
@@ -177,7 +169,7 @@ class CommonQuerySkill(MycroftSkill, ABC):
         wc_mod = float(float(answer_size) / float(WORD_COUNT_DIVISOR)) * 2
 
         confidence = self.level_confidence[level] + \
-                     consumed_pct + bonus + num_sentences + relevance + wc_mod
+                     consumed_pct + num_sentences + relevance + wc_mod
 
         return confidence
 

--- a/mycroft/skills/intent_services/__init__.py
+++ b/mycroft/skills/intent_services/__init__.py
@@ -5,3 +5,4 @@ from mycroft.skills.intent_services.fallback_service import FallbackService
 from mycroft.skills.intent_services.padatious_service \
     import PadatiousService, PadatiousMatcher
 from mycroft.skills.intent_services.converse_service import ConverseService
+from mycroft.skills.intent_services.commonqa_service import CommonQAService

--- a/mycroft/skills/intent_services/commonqa_service.py
+++ b/mycroft/skills/intent_services/commonqa_service.py
@@ -1,0 +1,179 @@
+from mycroft.skills.intent_services.base import IntentMatch
+from ovos_utils.log import LOG
+from ovos_utils.enclosure.api import EnclosureAPI
+from mycroft_bus_client.message import Message, dig_for_message
+from threading import Lock, Event
+import time
+
+EXTENSION_TIME = 10
+
+
+class CommonQAService:
+    """Intent Service handling common query skills.
+    All common query skills answer and the best answer is selected
+    This is in contrast to triggering best intent directly.
+    """
+
+    def __init__(self, bus):
+        self.bus = bus
+        self.skill_id = "common_query.openvoiceos"  # fake skill
+        self.query_replies = {}  # cache of received replies
+        self.query_extensions = {}  # maintains query timeout extensions
+        self.lock = Lock()
+        self.searching = Event()
+        self.waiting = True
+        self.answered = False
+        self._lang = "en-us"
+        self.enclosure = EnclosureAPI()
+        self.bus.on('question:query.response', self.handle_query_response)
+
+    def match(self, utterances, lang, message):
+        """Send common query request and select best response
+
+        Args:
+            utterances (list): List of tuples,
+                               utterances and normalized version
+            lang (str): Language code
+            message: Message for session context
+        Returns:
+            IntentMatch or None
+        """
+        self._lang = message.data["lang"] = lang  # only used for speak
+        answered = self.handle_question(message)
+        if answered:
+            ret = IntentMatch('CommonQuery', None, {}, None)
+        else:
+            ret = None
+        return ret
+
+    def handle_question(self, message):
+        """ Send the phrase to the CommonQuerySkills and prepare for handling
+            the replies.
+        """
+        self.searching.set()
+        self.waiting = True
+        self.answered = False
+        utt = message.data.get('utterance')
+        self.enclosure.mouth_think()
+
+        self.query_replies[utt] = []
+        self.query_extensions[utt] = []
+        LOG.info(f'Searching for {utt}')
+        # Send the query to anyone listening for them
+        msg = message.reply('question:query', data={'phrase': utt})
+        if "skill_id" not in msg.context:
+            msg.context["skill_id"] = self.skill_id
+        self.bus.emit(msg)
+
+        self.timeout_time = time.time() + 1
+        while self.searching.is_set():
+            if not self.waiting or time.time() > self.timeout_time + 1:
+                break
+            time.sleep(0.2)
+
+        # forcefully timeout if search is still going
+        self._query_timeout(message)
+        return self.answered
+
+    def handle_query_response(self, message):
+        search_phrase = message.data['phrase']
+        skill_id = message.data['skill_id']
+        searching = message.data.get('searching')
+        answer = message.data.get('answer')
+
+        # Manage requests for time to complete searches
+        if searching:
+            # extend the timeout by 5 seconds
+            self.timeout_time = time.time() + EXTENSION_TIME
+            # TODO: Perhaps block multiple extensions?
+            if (search_phrase in self.query_extensions and
+                    skill_id not in self.query_extensions[search_phrase]):
+                self.query_extensions[search_phrase].append(skill_id)
+        elif search_phrase in self.query_extensions:
+            # Search complete, don't wait on this skill any longer
+            if answer and search_phrase in self.query_replies:
+                LOG.info(f'Answer from {skill_id}')
+                self.query_replies[search_phrase].append(message.data)
+
+            # Remove the skill from list of timeout extensions
+            if skill_id in self.query_extensions[search_phrase]:
+                self.query_extensions[search_phrase].remove(skill_id)
+
+            # not waiting for any more skills
+            if not self.query_extensions[search_phrase]:
+                self._query_timeout(message)
+        else:
+            LOG.warning(f'{skill_id} Answered too slowly, will be ignored.')
+
+    def _query_timeout(self, message):
+        if not self.searching.is_set():
+            return  # not searching, ignore timeout event
+        self.searching.clear()
+
+        # Prevent any late-comers from retriggering this query handler
+        with self.lock:
+            LOG.info('Timeout occured check responses')
+            search_phrase = message.data['phrase']
+            if search_phrase in self.query_extensions:
+                self.query_extensions[search_phrase] = []
+            self.enclosure.mouth_reset()
+
+            # Look at any replies that arrived before the timeout
+            # Find response(s) with the highest confidence
+            best = None
+            ties = []
+            if search_phrase in self.query_replies:
+                for handler in self.query_replies[search_phrase]:
+                    if not best or handler['conf'] > best['conf']:
+                        best = handler
+                        ties = []
+                    elif handler['conf'] == best['conf']:
+                        ties.append(handler)
+
+            if best:
+                if ties:
+                    # TODO: Ask user to pick between ties or do it automagically
+                    pass
+
+                # invoke best match
+                self.speak(best['answer'])
+                LOG.info('Handling with: ' + str(best['skill_id']))
+                cb = best.get('callback_data') or {}
+                self.bus.emit(message.forward('question:action',
+                                              data={'skill_id': best['skill_id'],
+                                                    'phrase': search_phrase,
+                                                    'callback_data': cb}))
+                self.answered = True
+            else:
+                self.answered = False
+            self.waiting = False
+            if search_phrase in self.query_replies:
+                del self.query_replies[search_phrase]
+            if search_phrase in self.query_extensions:
+                del self.query_extensions[search_phrase]
+
+    def speak(self, utterance, message=None):
+        """Speak a sentence.
+
+        Args:
+            utterance (str):        sentence mycroft should speak
+        """
+        # registers the skill as being active
+        self.enclosure.register(self.skill_id)
+        message = message or dig_for_message()
+
+        lang = self._lang
+        if message:
+            lang = message.data.get("lang") or \
+                   message.context.get("lang") or \
+                   lang
+
+        data = {'utterance': utterance,
+                'expect_response': False,
+                'meta': {"skill": self.skill_id},
+                'lang': lang}
+
+        m = message.forward("speak", data) if message \
+            else Message("speak", data)
+        m.context["skill_id"] = self.skill_id
+        self.bus.emit(m)

--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -357,7 +357,7 @@ class MycroftSkill:
         lang = self._core_lang
         message = dig_for_message()
         if message:
-            lang = message.data.get("lang") or lang
+            lang = message.data.get("lang") or message.context.get("lang") or lang
         return lang.lower()
 
     @property


### PR DESCRIPTION
moves common query from a skill to a first class intent service

instead of being the first fallback skill it is now called before fallback stage

the common query skill only listened and emited events, it doesnt do "skill things", fits better as it's own intent matcher

deprecates https://github.com/OpenVoiceOS/skill-ovos-common-query , it should be archived but can still be used in unittests and in regular mycroft