### PR TITLE
port of the resource file handling refactor from mk2

### DIFF
--- a/mycroft/deprecated/skills.py
+++ b/mycroft/deprecated/skills.py
@@ -5,11 +5,16 @@ in case someone is importing from here
 This is only meant for 3rd party code expecting ovos-core
 to be a drop in replacement for mycroft-core
 """
-
+import collections
+import csv
+from os import walk
+import re
+from os.path import splitext, join
 from mycroft.api import is_paired
 from mycroft.enclosure.api import EnclosureAPI
+from mycroft.util.format import expand_options
 from ovos_utils.log import LOG
-
+import mycroft.skills.skill_data
 
 RASPBERRY_PI_PLATFORMS = ('mycroft_mark_1', 'picroft', 'mycroft_mark_2pi')
 
@@ -44,4 +49,163 @@ class DevicePrimer:
     def prepare_device(self):
         """Internet dependent updates of various aspects of the device."""
         LOG.warning("DevicePrimer has been deprecated!")
+
+
+def read_vocab_file(path):
+    """ Read voc file.
+
+        This reads a .voc file, stripping out empty lines comments and expand
+        parentheses. It returns each line as a list of all expanded
+        alternatives.
+
+        Args:
+            path (str): path to vocab file.
+
+        Returns:
+            List of Lists of strings.
+    """
+    LOG.warning("read_vocab_file is deprecated! "
+                "use SkillResources class instead")
+    vocab = []
+    with open(path, 'r', encoding='utf8') as voc_file:
+        for line in voc_file.readlines():
+            if line.startswith('#') or line.strip() == '':
+                continue
+            vocab.append(expand_options(line.lower()))
+    return vocab
+
+
+def load_regex_from_file(path, skill_id):
+    """Load regex from file
+    The regex is sent to the intent handler using the message bus
+
+    Args:
+        path:       path to vocabulary file (*.voc)
+        skill_id:   skill_id to the regex is tied to
+    """
+    LOG.warning("read_regex_from_file is deprecated! "
+                "use SkillResources class instead")
+    regexes = []
+    if path.endswith('.rx'):
+        with open(path, 'r', encoding='utf8') as reg_file:
+            for line in reg_file.readlines():
+                if line.startswith("#"):
+                    continue
+                LOG.debug('regex pre-munge: ' + line.strip())
+                regex = mycroft.skills.skill_data.munge_regex(line.strip(),
+                                                              skill_id)
+                LOG.debug('regex post-munge: ' + regex)
+                # Raise error if regex can't be compiled
+                try:
+                    re.compile(regex)
+                    regexes.append(regex)
+                except Exception as e:
+                    LOG.warning(f'Failed to compile regex {regex}: {e}')
+
+    return regexes
+
+
+def load_vocabulary(basedir, skill_id):
+    """Load vocabulary from all files in the specified directory.
+
+    Args:
+        basedir (str): path of directory to load from (will recurse)
+        skill_id: skill the data belongs to
+    Returns:
+        dict with intent_type as keys and list of list of lists as value.
+    """
+    LOG.warning("load_vocabulary is deprecated! "
+                "use SkillResources class instead")
+    vocabs = {}
+    for path, _, files in walk(basedir):
+        for f in files:
+            if f.endswith(".voc"):
+                vocab_type = to_alnum(skill_id) + splitext(f)[0]
+                vocs = read_vocab_file(join(path, f))
+                if vocs:
+                    vocabs[vocab_type] = vocs
+    return vocabs
+
+
+def load_regex(basedir, skill_id):
+    """Load regex from all files in the specified directory.
+
+    Args:
+        basedir (str): path of directory to load from
+        bus (messagebus emitter): messagebus instance used to send the vocab to
+                                  the intent service
+        skill_id (str): skill identifier
+    """
+    LOG.warning("load_regex is deprecated! "
+                "use SkillResources class instead")
+    regexes = []
+    for path, _, files in walk(basedir):
+        for f in files:
+            if f.endswith(".rx"):
+                regexes += load_regex_from_file(join(path, f), skill_id)
+    return regexes
+
+
+def read_value_file(filename, delim):
+    """Read value file.
+
+    The value file is a simple csv structure with a key and value.
+
+    Args:
+        filename (str): file to read
+        delim (str): csv delimiter
+
+    Returns:
+        OrderedDict with results.
+    """
+    LOG.warning("read_value_file is deprecated! "
+                "use SkillResources class instead")
+    result = collections.OrderedDict()
+
+    if filename:
+        with open(filename) as f:
+            reader = csv.reader(f, delimiter=delim)
+            for row in reader:
+                # skip blank or comment lines
+                if not row or row[0].startswith("#"):
+                    continue
+                if len(row) != 2:
+                    continue
+
+                result[row[0]] = row[1]
+    return result
+
+
+def read_translated_file(filename, data):
+    """Read a file inserting data.
+
+    Args:
+        filename (str): file to read
+        data (dict): dictionary with data to insert into file
+
+    Returns:
+        list of lines.
+    """
+    LOG.warning("read_translated_file is deprecated! "
+                "use SkillResources class instead")
+    if filename:
+        with open(filename) as f:
+            text = f.read().replace('{{', '{').replace('}}', '}')
+            return text.format(**data or {}).rstrip('\n').split('\n')
+    else:
+        return None
+
+
+def to_alnum(skill_id):
+    """Convert a skill id to only alphanumeric characters
+
+     Non alpha-numeric characters are converted to "_"
+
+    Args:
+        skill_id (str): identifier to be converted
+    Returns:
+        (str) String of letters
+    """
+    return ''.join(c if c.isalnum() else '_' for c in str(skill_id))
+
 

--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -49,7 +49,9 @@ from mycroft.skills.skill_data import (
     munge_intent_parser,
     read_vocab_file,
     read_value_file,
-    read_translated_file
+    read_translated_file,
+    ResourceFile,
+    SkillResources
 )
 from mycroft.util import (
     resolve_resource_file,
@@ -414,6 +416,18 @@ class MycroftSkill:
                 if isdir(path):
                     return path
         return join(base_path, lang)
+
+    @property
+    def alphanumeric_skill_id(self):
+        return "".join(
+            char if char.isalnum() else "_" for char in str(self.skill_id)
+        )
+
+    @property
+    def resources(self):
+        """Lazily instantiates a ResourceFileLocator instance when needed."""
+        return SkillResources(self.root_dir, self.lang,
+                              self.dialog_renderer)
 
     def bind(self, bus):
         """Register messagebus emitter with skill.
@@ -893,33 +907,23 @@ class MycroftSkill:
         Returns:
             bool: True if the utterance has the given vocabulary it
         """
+        match = False
         lang = lang or self.lang
         cache_key = lang + voc_filename
         if cache_key not in self.voc_match_cache:
-            # Check for both skill resources and mycroft-core resources
-            voc = self.find_resource(voc_filename + '.voc', 'vocab')
-            if not voc:  # Check for vocab in mycroft core resources
-                voc = resolve_resource_file(join('text', lang,
-                                                 voc_filename + '.voc'))
-                if voc:
-                    LOG.info(f"Found global resource: '{voc_filename}.voc' "
-                             f"for lang '{lang}'")
-            if not voc or not exists(voc):
-                raise FileNotFoundError(f'Could not find {voc_filename}.voc file')
-            # load vocab and flatten into a simple list
-            vocab = read_vocab_file(voc)
+            vocab = self.resources.load_vocabulary_file(voc_filename)
             self.voc_match_cache[cache_key] = list(chain(*vocab))
         if utt:
             if exact:
                 # Check for exact match
-                return any(i.strip() == utt
-                           for i in self.voc_match_cache[cache_key])
+                match = any(i.strip() == utt
+                            for i in self.voc_match_cache[cache_key])
             else:
                 # Check for matches against complete words
-                return any([re.match(r'.*\b' + i + r'\b.*', utt)
+                match = any([re.match(r'.*\b' + i + r'\b.*', utt)
                             for i in self.voc_match_cache[cache_key]])
-        else:
-            return False
+
+        return match
 
     def report_metric(self, name, data):
         """Report a skill metric to the Mycroft servers.
@@ -1007,43 +1011,21 @@ class MycroftSkill:
                     self.register_intent_file(intent_file, method)
 
     def translate(self, text, data=None):
-        """Load a translatable single string resource
-
-        The string is loaded from a file in the skill's dialog subdirectory
-        'dialog/<lang>/<text>.dialog'
-
-        The string is randomly chosen from the file and rendered, replacing
-        mustache placeholders with values found in the data dictionary.
-
-        Args:
-            text (str): The base filename  (no extension needed)
-            data (dict, optional): a JSON dictionary
-
-        Returns:
-            str: A randomly chosen string from the file
-        """
-        if not self.dialog_renderer:
-            return ""
-        return self.dialog_renderer.render(text, data or {})
+        """Deprecated method for translating a dialog file."""
+        return self.resources.render_dialog(text, data)
 
     def find_resource(self, res_name, res_dirname=None, lang=None):
         """Find a resource file.
 
         Searches for the given filename using this scheme:
+            1. Search the resource lang directory:
+                <skill>/<res_dirname>/<lang>/<res_name>
+            2. Search the resource directory:
+                <skill>/<res_dirname>/<res_name>
 
-        1. Search the resource lang directory:
-
-           <skill>/<res_dirname>/<lang>/<res_name>
-
-        2. Search the resource directory:
-
-           <skill>/<res_dirname>/<res_name>
-
-        3. Search the locale lang directory or other subdirectory:
-
-           <skill>/locale/<lang>/<res_name> or
-
-           <skill>/locale/<lang>/.../<res_name>
+            3. Search the locale lang directory or other subdirectory:
+                <skill>/locale/<lang>/<res_name> or
+                <skill>/locale/<lang>/.../<res_name>
 
         Args:
             res_name (string): The resource name to be found
@@ -1090,73 +1072,16 @@ class MycroftSkill:
         return None
 
     def translate_namedvalues(self, name, delim=','):
-        """Load translation dict containing names and values.
-
-        This loads a simple CSV from the 'dialog' folders.
-        The name is the first list item, the value is the
-        second.  Lines prefixed with # or // get ignored
-
-        Args:
-            name (str): name of the .value file, no extension needed
-            delim (char): delimiter character used, default is ','
-
-        Returns:
-            dict: name and value dictionary, or empty dict if load fails
-        """
-
-        if not name.endswith('.value'):
-            name += '.value'
-
-        try:
-            filename = self.find_resource(name, 'dialog')
-            return read_value_file(filename, delim)
-
-        except Exception:
-            return {}
-
-    def translate_template(self, template_name, data=None):
-        """Load a translatable template.
-
-        The strings are loaded from a template file in the skill's dialog
-        subdirectory.
-        'dialog/<lang>/<template_name>.template'
-
-        The strings are loaded and rendered, replacing mustache placeholders
-        with values found in the data dictionary.
-
-        Args:
-            template_name (str): The base filename (no extension needed)
-            data (dict, optional): a JSON dictionary
-
-        Returns:
-            list of str: The loaded template file
-        """
-        return self.__translate_file(template_name + '.template', data)
+        """Deprecated method for translating a name/value file."""
+        return self.resources.load_named_value_file(name, delim)
 
     def translate_list(self, list_name, data=None):
-        """Load a list of translatable string resources
+        """Deprecated method for translating a list."""
+        return self.resources.load_list_file(list_name, data)
 
-        The strings are loaded from a list file in the skill's dialog
-        subdirectory.
-        'dialog/<lang>/<list_name>.list'
-
-        The strings are loaded and rendered, replacing mustache placeholders
-        with values found in the data dictionary.
-
-        Args:
-            list_name (str): The base filename (no extension needed)
-            data (dict, optional): a JSON dictionary
-
-        Returns:
-            list of str: The loaded list of strings with items in consistent
-                         positions regardless of the language.
-        """
-        return self.__translate_file(list_name + '.list', data)
-
-    def __translate_file(self, name, data):
-        """Load and render lines from dialog/<lang>/<name>"""
-        filename = self.find_resource(name, 'dialog')
-        return read_translated_file(filename, data)
+    def translate_template(self, template_name, data=None):
+        """Deprecated method for translating a template file"""
+        return self.resources.load_template_file(template_name, data)
 
     def add_event(self, name, handler, handler_info=None, once=False):
         """Create event handler for executing intent or other event.
@@ -1258,22 +1183,20 @@ class MycroftSkill:
         """Register an Intent file with the intent service.
 
         For example:
-
-        === food.order.intent ===
-        Order some {food}.
-        Order some {food} from {place}.
-        I'm hungry.
-        Grab some {food} from {place}.
+            food.order.intent:
+                Order some {food}.
+                Order some {food} from {place}.
+                I'm hungry.
+                Grab some {food} from {place}.
 
         Optionally, you can also use <register_entity_file>
         to specify some examples of {food} and {place}
 
         In addition, instead of writing out multiple variations
         of the same sentence you can write:
-
-        === food.order.intent ===
-        (Order | Grab) some {food} (from {place} | ).
-        I'm hungry.
+            food.order.intent:
+                (Order | Grab) some {food} (from {place} | ).
+                I'm hungry.
 
         Args:
             intent_file: name of file that contains example queries
@@ -1281,45 +1204,39 @@ class MycroftSkill:
                          '.intent'
             handler:     function to register with intent
         """
-        langs = [self._core_lang] + self._secondary_langs
-        for lang in langs:
-            name = f'{self.skill_id}:{intent_file}'
-            filename = self.find_resource(intent_file, 'vocab', lang=lang)
-            if not filename:
-                self.log.error(f'Unable to find "{intent_file}"')
-                continue
-            self.intent_service.register_padatious_intent(name, filename, lang)
-            if handler:
-                self.add_event(name, handler, 'mycroft.skill.handler')
+        name = '{}:{}'.format(self.skill_id, intent_file)
+        resource_file = ResourceFile(self.resources.types.intent, intent_file)
+        if resource_file.file_path is None:
+            raise FileNotFoundError('Unable to find "{}"'.format(intent_file))
+        self.intent_service.register_padatious_intent(
+             name, str(resource_file.file_path)
+        )
+        if handler:
+            self.add_event(name, handler, 'mycroft.skill.handler')
 
     def register_entity_file(self, entity_file):
         """Register an Entity file with the intent service.
 
         An Entity file lists the exact values that an entity can hold.
         For example:
-
-        === ask.day.intent ===
-        Is it {weekend}?
-
-        === weekend.entity ===
-        Saturday
-        Sunday
+            ask.day.intent:
+                Is it {weekend}?
+            weekend.entity:
+                Saturday
+                Sunday
 
         Args:
             entity_file (string): name of file that contains examples of an
-                                  entity.  Must end with '.entity'
+                                  entity.
         """
-        if entity_file.endswith('.entity'):
-            entity_file = entity_file.replace('.entity', '')
-        langs = [self._core_lang] + self._secondary_langs
-        for lang in langs:
-            filename = self.find_resource(entity_file + ".entity", 'vocab',
-                                          lang=lang)
-            if not filename:
-                self.log.error(f'Unable to find "{entity_file}"')
-                continue
-            name = f'{self.skill_id}:{entity_file}'
-            self.intent_service.register_padatious_entity(name, filename, lang)
+        entity = ResourceFile(self.resources.types.entity, entity_file)
+        if entity.file_path is None:
+            raise FileNotFoundError('Unable to find "{}"'.format(entity_file))
+
+        name = '{}:{}'.format(self.skill_id, entity_file)
+        self.intent_service.register_padatious_entity(
+            name, str(entity.file_path)
+        )
 
     def handle_enable_intent(self, message):
         """Listener to enable a registered intent if it belongs to this skill.
@@ -1395,7 +1312,7 @@ class MycroftSkill:
         if not isinstance(word, str):
             raise ValueError('Word should be a string')
 
-        context = to_alnum(self.skill_id) + context
+        context = self.alphanumeric_skill_id + context
         self.intent_service.set_adapt_context(context, word, origin)
 
     def handle_set_cross_context(self, message):
@@ -1439,7 +1356,7 @@ class MycroftSkill:
         """Remove a keyword from the context manager."""
         if not isinstance(context, str):
             raise ValueError('context should be a string')
-        context = to_alnum(self.skill_id) + context
+        context = self.alphanumeric_skill_id + context
         self.intent_service.remove_adapt_context(context)
 
     def register_vocabulary(self, entity, entity_type, lang=None):
@@ -1449,8 +1366,9 @@ class MycroftSkill:
             entity:         word to register
             entity_type:    Intent handler entity to tie the word to
         """
-        keyword_type = to_alnum(self.skill_id) + entity_type
-        self.intent_service.register_adapt_keyword(keyword_type, entity, lang=lang or self.lang)
+        keyword_type = self.alphanumeric_skill_id + entity_type
+        self.intent_service.register_adapt_keyword(keyword_type, entity,
+                                                   lang=lang or self.lang)
 
     def register_regex(self, regex_str, lang=None):
         """Register a new regex.
@@ -1534,96 +1452,51 @@ class MycroftSkill:
         if not process:
             LOG.warning("Unable to play 'acknowledge' audio file!")
 
-    def _load_dialog_files(self, root_directory, lang):
+
+    def load_data_files(self):
+        """Called by the skill loader to load intents, dialogs, etc."""
+        self.init_dialog()
+        self.load_vocab_files()
+        self.load_regex_files()
+
+    def init_dialog(self):
         # If "<skill>/dialog/<lang>" exists, load from there.  Otherwise
         # load dialog from "<skill>/locale/<lang>"
-        dialog_dir = self._get_language_dir(
-            join(root_directory, 'dialog'), lang)
-        locale_dir = self._get_language_dir(
-            join(root_directory, 'locale'), lang)
+        dialog_dir = join(self.root_dir, 'dialog', self.lang)
         if exists(dialog_dir):
-            self.dialog_renderers[lang] = load_dialogs(dialog_dir)
-        elif exists(locale_dir):
-            self.dialog_renderers[lang] = load_dialogs(locale_dir)
+            self.dialog_renderer = load_dialogs(dialog_dir)
+        elif exists(join(self.root_dir, 'locale', self.lang)):
+            locale_path = join(self.root_dir, 'locale', self.lang)
+            self.dialog_renderer = load_dialogs(locale_path)
         else:
-            LOG.debug(f'No dialog loaded for {lang}')
+            LOG.debug('No dialog loaded')
+        self.resources.dialog_renderer = self.dialog_renderer
 
-    def init_dialog(self, root_directory):
-        langs = [self._core_lang] + self._secondary_langs
-        for lang in langs:
-            self._load_dialog_files(root_directory, lang)
-
-    def load_data_files(self, root_directory=None):
-        """Called by the skill loader to load intents, dialogs, etc.
-
-        Args:
-            root_directory (str): root folder to use when loading files.
-        """
-        root_directory = root_directory or self.root_dir
-        self.init_dialog(root_directory)
-        self.load_vocab_files(root_directory)
-        self.load_regex_files(root_directory)
-
-    def _load_vocab_files(self, root_directory, lang):
-        keywords = []
-        vocab_dir = self._get_language_dir(join(root_directory, 'vocab'), lang)
-        locale_dir = self._get_language_dir(join(root_directory, 'locale'),
-                                            lang)
-
-        if exists(vocab_dir):
-            keywords = load_vocabulary(vocab_dir, self.skill_id)
-        elif exists(locale_dir):
-            keywords = load_vocabulary(locale_dir, self.skill_id)
+    def load_vocab_files(self):
+        """ Load vocab files found under skill's root directory."""
+        if self.resources.types.vocabulary.base_directory is None:
+            self.log.info("Skill has no vocabulary")
         else:
-            LOG.debug(f'No vocab loaded for {lang}')
+            skill_vocabulary = self.resources.load_skill_vocabulary(
+                self.alphanumeric_skill_id
+            )
+            # For each found intent register the default along with any aliases
+            for vocab_type in skill_vocabulary:
+                for line in skill_vocabulary[vocab_type]:
+                    entity = line[0]
+                    aliases = line[1:]
+                    self.intent_service.register_adapt_keyword(vocab_type,
+                                                               entity,
+                                                               aliases)
 
-        # For each found intent register the default along with any aliases
-        for vocab_type in keywords:
-            for line in keywords[vocab_type]:
-                entity = line[0]
-                aliases = line[1:]
-                self.intent_service.register_adapt_keyword(vocab_type,
-                                                           entity,
-                                                           aliases,
-                                                           lang)
-
-    def load_vocab_files(self, root_directory):
-        """ Load vocab files found under root_directory.
-
-        Args:
-            root_directory (str): root folder to use when loading files
-        """
-        langs = [self._core_lang] + self._secondary_langs
-        for lang in langs:
-            self._load_vocab_files(root_directory, lang)
-
-    def _load_regex_files(self, root_directory, lang):
-        """ Load regex files found under the skill directory.
-
-        Args:
-            root_directory (str): root folder to use when loading files
-        """
-        regexes = []
-        regex_dir = self._get_language_dir(join(root_directory, 'regex'), lang)
-        locale_dir = self._get_language_dir(join(root_directory, 'locale'), lang)
-
-        if exists(regex_dir):
-            regexes = load_regex(regex_dir, self.skill_id)
-        elif exists(locale_dir):
-            regexes = load_regex(locale_dir, self.skill_id)
-
-        for regex in regexes:
-            self.intent_service.register_adapt_regex(regex, lang)
-
-    def load_regex_files(self, root_directory):
-        """ Load regex files found under the skill directory.
-
-        Args:
-            root_directory (str): root folder to use when loading files
-        """
-        langs = [self._core_lang] + self._secondary_langs
-        for lang in langs:
-            self._load_regex_files(root_directory, lang)
+    def load_regex_files(self):
+        """ Load regex files found under the skill directory."""
+        if self.resources.types.regex.base_directory is not None:
+            regexes = self.resources.load_skill_regex(
+                self.alphanumeric_skill_id
+            )
+            for regex in regexes:
+                self.intent_service.register_adapt_regex(regex)
 
     def __handle_stop(self, message):
         """Handler for the "mycroft.stop" signal. Runs the user defined

--- a/mycroft/skills/skill_data.py
+++ b/mycroft/skills/skill_data.py
@@ -12,103 +12,591 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-"""Functions to load skill data such as intents and regular expressions."""
-
-import collections
-import csv
+"""Handling of skill data such as intents and regular expressions."""
 import re
-from os import walk
-from os.path import splitext, join
+from collections import namedtuple
 
+from os import walk
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+from mycroft.util.file_utils import resolve_resource_file
 from mycroft.util.format import expand_options
 from mycroft.util.log import LOG
 
+SkillResourceTypes = namedtuple(
+    "SkillResourceTypes",
+    [
+        "dialog",
+        "entity",
+        "intent",
+        "list",
+        "named_value",
+        "regex",
+        "template",
+        "vocabulary",
+        "word"
+    ]
+)
 
-def read_vocab_file(path):
-    """ Read voc file.
 
-        This reads a .voc file, stripping out empty lines comments and expand
-        parentheses. It returns each line as a list of all expanded
-        alternatives.
+class ResourceType:
+    """Defines the attributes of a type of skill resource.
+
+    Examples:
+        dialog = ResourceType("dialog", ".dialog")
+        dialog.locate_base_directory(self.root_dir, self.lang)
+
+        named_value = ResourceType("named_value", ".value")
+        named_value.locate_base_directory(self.root_dir, self.lang)
+
+    Attributes:
+        resource_type: one of a predefined set of resource types for skills
+        file_extension: the file extension associated with the resource type
+        base_directory: directory containing all files for the resource type
+    """
+
+    def __init__(self, resource_type: str, file_extension: str, language: str):
+        self.resource_type = resource_type
+        self.file_extension = file_extension
+        self.language = language
+        self.base_directory = None
+
+    def locate_base_directory(self, skill_directory):
+        """Find the skill's base directory for the specified resource type.
+
+        There are three supported methodologies for storing resource files.
+        The preferred method is to use the "locale" directory but older methods
+        are included in the search for backwards compatibility.  The three
+        directory schemes are:
+           <skill>/locale/<lang>/.../<resource_type>
+           <skill>/<resource_subdirectory>/<lang>/
+           <skill>/<resource_subdirectory>
+        If the directory for the specified language doesn't exist, fall back to
+        the default "en-us".
 
         Args:
-            path (str): path to vocab file.
+            skill_directory: the root directory of a skill
+        Returns:
+            the skill's directory for the resource type or None if not found
+        """
+        resource_subdirectory = self._get_resource_subdirectory()
+        possible_directories = (
+            Path(skill_directory, "locale", self.language),
+            Path(skill_directory, "locale", "en-us"),
+            Path(skill_directory, resource_subdirectory, self.language),
+            Path(skill_directory, resource_subdirectory, "en-us"),
+            Path(skill_directory, resource_subdirectory),
+        )
+        for directory in possible_directories:
+            if directory.exists():
+                self.base_directory = directory
+                if "en-us" in str(directory) and self.language != "en-us":
+                    self.language = "en-us"
+                break
+
+    def _get_resource_subdirectory(self) -> str:
+        """Returns the subdirectory for this resource type.
+
+        In the older directory schemes, several resource types were stored
+        in the same set of three directories (dialog, regex, vocab).
+        """
+        subdirectories = dict(
+            dialog="dialog",
+            entity="vocab",
+            intent="vocab",
+            list="dialog",
+            named_value="dialog",
+            regex="regex",
+            template="dialog",
+            vocab="vocab",
+            word="dialog"
+        )
+
+        return subdirectories[self.resource_type]
+
+
+class ResourceFile:
+    """Loads a resource file for the user's configured language.
+
+    Attributes:
+        resource_type: attributes of the resource type (dialog, vocab, etc.)
+        resource_name: file name of the resource, with or without extension
+        file_path: absolute path to the file
+    """
+
+    def __init__(self, resource_type, resource_name):
+        self.resource_type = resource_type
+        self.resource_name = resource_name
+        self.file_path = self._locate()
+
+    def _locate(self):
+        """Locates a resource file in the skill's locale directory.
+
+        A skill's locale directory can contain a subdirectory structure defined
+        by the skill author.  Walk the directory and any subdirectories to
+        find the resource file.
+        """
+        file_path = None
+        if self.resource_name.endswith(self.resource_type.file_extension):
+            file_name = self.resource_name
+        else:
+            file_name = self.resource_name + self.resource_type.file_extension
+
+        walk_directory = str(self.resource_type.base_directory)
+        for directory, _, file_names in walk(walk_directory):
+            if file_name in file_names:
+                file_path = Path(directory, file_name)
+
+        if file_path is None:
+            sub_path = Path("text", self.resource_type.language, file_name)
+            file_path = resolve_resource_file(str(sub_path))
+
+        if file_path is None:
+            LOG.error(f"Could not find resource file {file_name}")
+
+        return file_path
+
+    def load(self):
+        """Override in subclass to define resource type loading behavior."""
+        pass
+
+    def _read(self) -> str:
+        """Reads the specified file, removing comment and empty lines."""
+        with open(self.file_path) as resource_file:
+            for line in [line.strip() for line in resource_file.readlines()]:
+                if not line or line.startswith("#"):
+                    continue
+                yield line
+
+
+class DialogFile(ResourceFile):
+    """Defines a dialog file, which is used instruct TTS what to speak."""
+
+    def __init__(self, resource_type, resource_name):
+        super().__init__(resource_type, resource_name)
+        self.data = None
+
+    def load(self) -> List[str]:
+        """Load and lines from a file and populate the variables.
 
         Returns:
-            List of Lists of strings.
+            Contents of the file with variables resolved.
+        """
+        dialogs = None
+        if self.file_path is not None:
+            dialogs = []
+            for line in self._read():
+                line = line.replace("{{", "{").replace("}}", "}")
+                if self.data is not None:
+                    line = line.format(**self.data)
+                dialogs.append(line)
+
+        return dialogs
+
+    def render(self, dialog_renderer):
+        """Renders a random phrase from a dialog file.
+
+        If no file is found, the requested phrase is returned as the string. This
+        will use the default language for translations.
+
+        Returns:
+            str: a randomized version of the phrase
+        """
+        return dialog_renderer.render(self.resource_name, self.data)
+
+
+class VocabularyFile(ResourceFile):
+    """Defines a vocabulary file, which skill use to form intents."""
+
+    def load(self) -> List[List[str]]:
+        """Loads a vocabulary file.
+
+        If a record in a vocabulary file contains sets of words inside
+        parentheses, generate a vocabulary item for each permutation within
+        the parentheses.
+
+        Returns:
+            List of lines in the file.  Each item in the list is a list of
+            strings that represent different options based on regular
+            expression.
+        """
+        vocabulary = []
+        if self.file_path is not None:
+            for line in self._read():
+                vocabulary.append(expand_options(line.lower()))
+
+        return vocabulary
+
+
+class NamedValueFile(ResourceFile):
+    """Defines a named value file, which maps a variable to a values."""
+    def __init__(self, resource_type, resource_name):
+        super().__init__(resource_type, resource_name)
+        self.delimiter = ","
+
+    def load(self) -> dict:
+        """Load file containing names and values.
+
+        Returns:
+            A dictionary representation of the records in the file.
+        """
+        named_values = dict()
+        if self.file_path is not None:
+            for line in self._read():
+                name, value = self._load_line(line)
+                if name is not None and value is not None:
+                    named_values[name] = value
+
+        return named_values
+
+    def _load_line(self, line: str) -> Tuple[str, str]:
+        """Attempts to split the name and value for dictionary loading.
+
+        Args:
+            line: a record in a .value file
+        Returns:
+            The name/value pair that will be loaded into a dictionary.
+        """
+        name = None
+        value = None
+        try:
+            name, value = line.split(self.delimiter)
+        except ValueError:
+            LOG.exception(
+                f"Failed to load value file {self.file_path} "
+                f"record containing {line}"
+            )
+
+        return name, value
+
+
+class ListFile(DialogFile):
+    pass
+
+
+class TemplateFile(DialogFile):
+    pass
+
+
+class RegexFile(ResourceFile):
+    def load(self):
+        regex_patterns = []
+        if self.file_path:
+            regex_patterns = [line for line in self._read()]
+
+        return regex_patterns
+
+
+class WordFile(ResourceFile):
+    """Defines a word file, which defines a word in the configured language."""
+
+    def load(self) -> Optional[str]:
+        """Load and lines from a file and populate the variables.
+
+        Returns:
+            The word contained in the file
+        """
+        word = None
+        if self.file_path is not None:
+            for line in self._read():
+                word = line
+                break
+
+        return word
+
+
+class SkillResources:
+    def __init__(self, skill_directory, language, dialog_renderer):
+        self.skill_directory = skill_directory
+        self.language = language
+        self.types = self._define_resource_types()
+        self.dialog_renderer = dialog_renderer
+        self.static = dict()
+
+    def _define_resource_types(self) -> SkillResourceTypes:
+        """Defines all known types of skill resource files.
+
+        A resource file contains information the skill needs to function.
+        Examples include dialog files to be spoken and vocab files for intent
+        matching.
+        """
+        resource_types = dict(
+            dialog=ResourceType("dialog", ".dialog", self.language),
+            entity=ResourceType("entity", ".entity", self.language),
+            intent=ResourceType("intent", ".intent", self.language),
+            list=ResourceType("list", ".list", self.language),
+            named_value=ResourceType("named_value", ".value", self.language),
+            regex=ResourceType("regex", ".rx", self.language),
+            template=ResourceType("template", ".template", self.language),
+            vocabulary=ResourceType("vocab", ".voc", self.language),
+            word=ResourceType("word", ".word", self.language)
+        )
+        for resource_type in resource_types.values():
+            resource_type.locate_base_directory(self.skill_directory)
+
+        return SkillResourceTypes(**resource_types)
+
+    def load_dialog_file(self, name, data=None) -> List[str]:
+        """Loads the contents of a dialog file into memory.
+
+        Named variables in the dialog are populated with values found in the
+        data dictionary.
+
+        Args:
+            name: name of the dialog file (no extension needed)
+            data: keyword arguments used to populate variables
+        Returns:
+            A list of phrases with variables resolved
+        """
+        dialog_file = DialogFile(self.types.dialog, name)
+        dialog_file.data = data
+
+        return dialog_file.load()
+
+    def load_list_file(self, name, data=None) -> List[str]:
+        """Load a file containing a list of words or phrases
+
+        Named variables in the dialog are populated with values found in the
+        data dictionary.
+
+        Args:
+            name: name of the list file (no extension needed)
+            data: keyword arguments used to populate variables
+        Returns:
+            List of words or phrases read from the list file.
+        """
+        list_file = ListFile(self.types.list, name)
+        list_file.data = data
+
+        return list_file.load()
+
+    def load_named_value_file(self, name, delimiter=None) -> dict:
+        """Load file containing a set names and values.
+
+        Loads a simple delimited file of name/value pairs.
+        The name is the first item, the value is the second.
+
+        Args:
+            name: name of the .value file, no extension needed
+            delimiter: delimiter character used
+        Returns:
+            File contents represented as a dictionary
+        """
+        if name in self.static:
+            named_values = self.static[name]
+        else:
+            named_value_file = NamedValueFile(self.types.named_value, name)
+            if delimiter is not None:
+                named_value_file.delimiter = delimiter
+            named_values = named_value_file.load()
+            self.static[name] = named_values
+
+        return named_values
+
+    def load_regex_file(self, name) -> List[str]:
+        """Loads a file containing regular expression patterns.
+
+        The regular expression patterns are generally used to find a value
+        in a user utterance the skill needs to properly perform the requested
+        function.
+
+        Args:
+            name: name of the regular expression file, no extension needed
+        Returns:
+            List representation of the regular expression file.
+        """
+        regex_file = RegexFile(self.types.regex, name)
+
+        return regex_file.load()
+
+    def load_template_file(self, name, data=None) -> List[str]:
+        """Loads the contents of a dialog file into memory.
+
+        Named variables in the dialog are populated with values found in the
+        data dictionary.
+
+        Args:
+            name: name of the dialog file (no extension needed)
+            data: keyword arguments used to populate variables
+        Returns:
+            A list of phrases with variables resolved
+        """
+        template_file = TemplateFile(self.types.template, name)
+        template_file.data = data
+
+        return template_file.load()
+
+    def load_vocabulary_file(self, name) -> List[List[str]]:
+        """Loads a file containing variations of words meaning the same thing.
+
+        A vocabulary file defines words a skill uses for intent matching.
+        It can also be used to match words in an utterance after intent
+        intent matching is complete.
+
+        Args:
+            name: name of the regular expression file, no extension needed
+        Returns:
+            List representation of the regular expression file.
+        """
+        vocabulary_file = VocabularyFile(self.types.vocabulary, name)
+
+        return vocabulary_file.load()
+
+    def load_word_file(self, name) -> Optional[str]:
+        """Loads a file containing a word.
+
+        Args:
+            name: name of the regular expression file, no extension needed
+        Returns:
+            List representation of the regular expression file.
+        """
+        word_file = WordFile(self.types.word, name)
+
+        return word_file.load()
+
+    def render_dialog(self, name, data=None) -> str:
+        """Selects a record from a dialog file at random for TTS purposes.
+
+        Args:
+            name: name of the list file (no extension needed)
+            data: keyword arguments used to populate variables
+        Returns:
+            Random record from the file with variables resolved.
+        """
+        resource_file = DialogFile(self.types.dialog, name)
+        resource_file.data = data
+
+        return resource_file.render(self.dialog_renderer)
+
+    def load_skill_vocabulary(self, alphanumeric_skill_id: str) -> dict:
+        skill_vocabulary = {}
+        base_directory = self.types.vocabulary.base_directory
+        for directory, _, files in walk(base_directory):
+            vocabulary_files = [
+                file_name for file_name in files if file_name.endswith(".voc")
+            ]
+            for file_name in vocabulary_files:
+                vocab_type = alphanumeric_skill_id + file_name[:-4].title()
+                vocabulary = self.load_vocabulary_file(file_name)
+                if vocabulary:
+                    skill_vocabulary[vocab_type] = vocabulary
+
+        return skill_vocabulary
+
+    def load_skill_regex(self, alphanumeric_skill_id: str) -> List[str]:
+        skill_regexes = []
+        base_directory = self.types.regex.base_directory
+        for directory, _, files in walk(base_directory):
+            regex_files = [
+                file_name for file_name in files if file_name.endswith(".rx")
+            ]
+            for file_name in regex_files:
+                skill_regexes.extend(self.load_regex_file(file_name))
+
+        skill_regexes = self._make_unique_regex_group(
+            skill_regexes, alphanumeric_skill_id
+        )
+
+        return skill_regexes
+
+    @staticmethod
+    def _make_unique_regex_group(
+            regexes: List[str], alphanumeric_skill_id: str
+    ) -> List[str]:
+        """Adds skill ID to group ID in a regular expression for uniqueness.
+
+        Args:
+            regexes: regex string
+            alphanumeric_skill_id: skill identifier
+        Returns:
+            regular expressions with uniquely named group IDs
+        Raises:
+            re.error if the regex does not compile
+        """
+        modified_regexes = []
+        for regex in regexes:
+            base = "(?P<" + alphanumeric_skill_id
+            modified_regex = base.join(regex.split("(?P<"))
+            re.compile(modified_regex)
+            modified_regexes.append(modified_regex)
+
+        return modified_regexes
+
+
+class RegexExtractor:
+    """Extracts data from an utterance using regular expressions.
+
+    Attributes:
+        group_name:
+        regex_patterns: regular expressions read from a .rx file
     """
-    vocab = []
-    with open(path, 'r', encoding='utf8') as voc_file:
-        for line in voc_file.readlines():
-            if line.startswith('#') or line.strip() == '':
-                continue
-            vocab.append(expand_options(line.lower()))
-    return vocab
 
+    def __init__(self, group_name, regex_patterns):
+        self.group_name = group_name
+        self.regex_patterns = regex_patterns
 
-def load_regex_from_file(path, skill_id):
-    """Load regex from file
-    The regex is sent to the intent handler using the message bus
+    def extract(self, utterance) -> Optional[str]:
+        """Attempt to find a value in a user request.
 
-    Args:
-        path:       path to vocabulary file (*.voc)
-        skill_id:   skill_id to the regex is tied to
-    """
-    regexes = []
-    if path.endswith('.rx'):
-        with open(path, 'r', encoding='utf8') as reg_file:
-            for line in reg_file.readlines():
-                if line.startswith("#"):
-                    continue
-                LOG.debug('regex pre-munge: ' + line.strip())
-                regex = munge_regex(line.strip(), skill_id)
-                LOG.debug('regex post-munge: ' + regex)
-                # Raise error if regex can't be compiled
-                try:
-                    re.compile(regex)
-                    regexes.append(regex)
-                except Exception as e:
-                    LOG.warning(f'Failed to compile regex {regex}: {e}')
+        Args:
+            utterance: request spoken by the user
 
-    return regexes
+        Returns:
+            The value extracted from the utterance, if found
+        """
+        extract = None
+        pattern_match = self._match_utterance_to_patterns(utterance)
+        if pattern_match is not None:
+            extract = self._extract_group_from_match(pattern_match)
+        self._log_extraction_result(extract)
 
+        return extract
 
-def load_vocabulary(basedir, skill_id):
-    """Load vocabulary from all files in the specified directory.
+    def _match_utterance_to_patterns(self, utterance: str):
+        """Match regular expressions to user request.
 
-    Args:
-        basedir (str): path of directory to load from (will recurse)
-        skill_id: skill the data belongs to
-    Returns:
-        dict with intent_type as keys and list of list of lists as value.
-    """
-    vocabs = {}
-    for path, _, files in walk(basedir):
-        for f in files:
-            if f.endswith(".voc"):
-                vocab_type = to_alnum(skill_id) + splitext(f)[0]
-                vocs = read_vocab_file(join(path, f))
-                if vocs:
-                    vocabs[vocab_type] = vocs
-    return vocabs
+        Args:
+            utterance: request spoken by the user
 
+        Returns:
+            a regular expression match object if a match is found
+        """
+        pattern_match = None
+        for pattern in self.regex_patterns:
+            pattern_match = re.search(pattern, utterance)
+            if pattern_match:
+                break
 
-def load_regex(basedir, skill_id):
-    """Load regex from all files in the specified directory.
+        return pattern_match
 
-    Args:
-        basedir (str): path of directory to load from
-        bus (messagebus emitter): messagebus instance used to send the vocab to
-                                  the intent service
-        skill_id (str): skill identifier
-    """
-    regexes = []
-    for path, _, files in walk(basedir):
-        for f in files:
-            if f.endswith(".rx"):
-                regexes += load_regex_from_file(join(path, f), skill_id)
-    return regexes
+    def _extract_group_from_match(self, pattern_match):
+        """Extract the alarm name from the utterance.
+
+        Args:
+            pattern_match: a regular expression match object
+        """
+        extract = None
+        try:
+            extract = pattern_match.group(self.group_name).strip()
+        except IndexError:
+            pass
+        else:
+            if not extract:
+                extract = None
+
+        return extract
+
+    def _log_extraction_result(self, extract: str):
+        """Log the results of the matching.
+
+        Args:
+            extract: the value extracted from the user utterance
+        """
+        if extract is None:
+            LOG.info(f"No {self.group_name.lower()} extracted from utterance")
+        else:
+            LOG.info(f"{self.group_name} extracted from utterance: " + extract)
 
 
 def to_alnum(skill_id):
@@ -121,20 +609,7 @@ def to_alnum(skill_id):
     Returns:
         (str) String of letters
     """
-    return ''.join(c if c.isalnum() else '_' for c in str(skill_id))
-
-
-def munge_regex(regex, skill_id):
-    """Insert skill id as letters into match groups.
-
-    Args:
-        regex (str): regex string
-        skill_id (str): skill identifier
-    Returns:
-        (str) munged regex
-    """
-    base = '(?P<' + to_alnum(skill_id)
-    return base.join(regex.split('(?P<'))
+    return "".join(c if c.isalnum() else "_" for c in str(skill_id))
 
 
 def munge_intent_parser(intent_parser, name, skill_id):
@@ -152,8 +627,8 @@ def munge_intent_parser(intent_parser, name, skill_id):
         skill_id: (int) skill identifier
     """
     # Munge parser name
-    if not name.startswith(str(skill_id) + ':'):
-        intent_parser.name = str(skill_id) + ':' + name
+    if not name.startswith(str(skill_id) + ":"):
+        intent_parser.name = str(skill_id) + ":" + name
     else:
         intent_parser.name = name
 
@@ -182,52 +657,16 @@ def munge_intent_parser(intent_parser, name, skill_id):
     # Munge at_least_one keywords
     at_least_one = []
     for i in intent_parser.at_least_one:
-        element = [skill_id + e.replace(skill_id, '') for e in i]
+        element = [skill_id + e.replace(skill_id, "") for e in i]
         at_least_one.append(tuple(element))
     intent_parser.at_least_one = at_least_one
 
-
-def read_value_file(filename, delim):
-    """Read value file.
-
-    The value file is a simple csv structure with a key and value.
-
-    Args:
-        filename (str): file to read
-        delim (str): csv delimiter
-
-    Returns:
-        OrderedDict with results.
-    """
-    result = collections.OrderedDict()
-
-    if filename:
-        with open(filename) as f:
-            reader = csv.reader(f, delimiter=delim)
-            for row in reader:
-                # skip blank or comment lines
-                if not row or row[0].startswith("#"):
-                    continue
-                if len(row) != 2:
-                    continue
-
-                result[row[0]] = row[1]
-    return result
-
-
-def read_translated_file(filename, data):
-    """Read a file inserting data.
-
-    Args:
-        filename (str): file to read
-        data (dict): dictionary with data to insert into file
-
-    Returns:
-        list of lines.
-    """
-    if filename:
-        with open(filename) as f:
-            text = f.read().replace('{{', '{').replace('}}', '}')
-            return text.format(**data or {}).rstrip('\n').split('\n')
-    else:
-        return None
+    # Munge excluded keywords
+    excludes = []
+    for i in intent_parser.excludes:
+        if not i.startswith(skill_id):
+            kw = skill_id + i
+            excludes.append(kw)
+        else:
+            excludes.append(i)
+    intent_parser.excludes = excludes


### PR DESCRIPTION
port of the resource file handling refactor https://github.com/MycroftAI/mycroft-core/blob/mark-ii/qa/mycroft/skills/skill_data.py

this PR increases compatibility with mark2 while remaining fully backwards compatible.
More mark2 exclusive skills will be able to run in ovos-core once this is merged

cherry picked commits from [mark2](https://github.com/MycroftAI/mycroft-core/tree/mark-ii/qa):

- add the logic for "template" resource files back in.
- add regex file loading for skill into resources code
- added support for .word files and fixed a regex bug
- fixes a bug where the dialog data is not passed to the renderer
- removed spurious print statements
- another iteration of improving the resource file handling
- update dialog renderer in the translator after all dialogs are loaded
- Move resource file location and translation logic into skill_data.py

credits of the original refactor go to @chrisveilleux


ovos improvements:
- port the [lang dialect support](https://github.com/MycroftAI/mycroft-core/pull/1335) code to the new style
- refactor the skill `dialog_renderer` to live in the new `SkillResources` class
- refactor generic resource file handling logic `self.find_resource` and move it to skill_data.py
- add back multi lingual support
- add "new style" helper class for core resource files
- restore backwards compat, methods + arguments api
- deprecate internal methods (lots of MycroftSkill private methods removed!)