### PR TITLE
fix/pairing readiness

### DIFF
--- a/test/unittests/skills/test_skill_manager.py
+++ b/test/unittests/skills/test_skill_manager.py
@@ -103,6 +103,7 @@ class TestSkillManager(MycroftUnitTestBase):
             'skillmanager.keep',
             'skillmanager.activate',
             'mycroft.paired',
+            'mycroft.setup.complete',
             'mycroft.skills.settings.update',
             'mycroft.skills.initialized',
             'mycroft.skills.trained',


### PR DESCRIPTION
add a event to improve handling of mycroft.ready

pairing should only be checked after backend selection, otherwise it will detect local backend and report paired before the pairing process even starts

needs latest version of setup skill