### PR TITLE
fix/filesystem_path

### DIFF
--- a/mycroft/filesystem/__init__.py
+++ b/mycroft/filesystem/__init__.py
@@ -34,15 +34,15 @@ class FileSystemAccess:
         if not isinstance(path, str) or len(path) == 0:
             raise ValueError("path must be initialized as a non empty string")
 
-        path = expanduser(f'~/.{get_xdg_base()}/{path}')
+        old_path = expanduser(f'~/.{get_xdg_base()}/{path}')
         xdg_path = expanduser(f'{get_xdg_config_save_path()}/{path}')
         # Migrate from the old location if it still exists
-        if isdir(path) and not isdir(xdg_path):
-            shutil.move(path, xdg_path)
+        if isdir(old_path) and not isdir(xdg_path):
+            shutil.move(old_path, xdg_path)
 
-        if not isdir(path):
-            os.makedirs(path)
-        return path
+        if not isdir(xdg_path):
+            os.makedirs(xdg_path)
+        return xdg_path
 
     def open(self, filename, mode):
         """Open a file in the provided namespace.

--- a/mycroft/filesystem/__init__.py
+++ b/mycroft/filesystem/__init__.py
@@ -15,7 +15,7 @@
 import os
 import shutil
 from os.path import join, expanduser, isdir
-from ovos_utils.configuration import get_xdg_base, get_xdg_config_save_path
+from ovos_utils.configuration import get_xdg_data_save_path, get_xdg_base
 
 
 class FileSystemAccess:
@@ -35,7 +35,7 @@ class FileSystemAccess:
             raise ValueError("path must be initialized as a non empty string")
 
         old_path = expanduser(f'~/.{get_xdg_base()}/{path}')
-        xdg_path = expanduser(f'{get_xdg_config_save_path()}/{path}')
+        xdg_path = expanduser(f'{get_xdg_data_save_path()}/{path}')
         # Migrate from the old location if it still exists
         if isdir(old_path) and not isdir(xdg_path):
             shutil.move(old_path, xdg_path)

--- a/mycroft/identity/__init__.py
+++ b/mycroft/identity/__init__.py
@@ -15,9 +15,10 @@
 import json
 import time
 import os
-from os.path import isfile, dirname
+from os.path import isfile, dirname, expanduser
+import shutil
 
-from ovos_utils.configuration import get_xdg_config_save_path
+from ovos_utils.configuration import get_xdg_config_save_path, get_xdg_base
 from mycroft.util.log import LOG
 from combo_lock import ComboLock
 
@@ -40,10 +41,14 @@ class DeviceIdentity:
 
 class IdentityManager:
     IDENTITY_FILE = f"{get_xdg_config_save_path()}/identity/identity2.json"
+    OLD_IDENTITY_FILE = expanduser(f"~/.{get_xdg_base()}/identity/identity2.json")
     __identity = None
 
     @staticmethod
     def _load():
+        if isfile(IdentityManager.OLD_IDENTITY_FILE) and \
+                not isfile(IdentityManager.IDENTITY_FILE):
+            shutil.move(IdentityManager.OLD_IDENTITY_FILE, IdentityManager.IDENTITY_FILE)
         if isfile(IdentityManager.IDENTITY_FILE):
             LOG.debug('Loading identity')
             try:

--- a/test/unittests/util/test_xdg.py
+++ b/test/unittests/util/test_xdg.py
@@ -17,6 +17,8 @@ class TestXdg(TestCase):
 
     def test_identity(self):
         self.assertTrue(IdentityManager.IDENTITY_FILE.startswith(get_xdg_config_save_path()))
+        self.assertTrue(IdentityManager.IDENTITY_FILE.endswith("/identity/identity2.json"))
+        self.assertTrue(IdentityManager.OLD_IDENTITY_FILE not in IdentityManager.IDENTITY_FILE)
 
     def test_filesystem(self):
         self.assertTrue(FileSystemAccess("test").path.startswith(get_xdg_data_save_path()))

--- a/test/unittests/util/test_xdg.py
+++ b/test/unittests/util/test_xdg.py
@@ -1,0 +1,25 @@
+from unittest import TestCase, mock
+
+from ovos_utils.configuration import get_xdg_config_save_path, get_xdg_data_save_path, get_xdg_cache_save_path
+from mycroft.identity import IdentityManager
+from mycroft.filesystem import FileSystemAccess
+from mycroft.skills.settings import REMOTE_CACHE
+
+
+class TestXdg(TestCase):
+
+    @mock.patch('ovos_utils.configuration.get_xdg_base')
+    def test_base_folder(self, mock_folder):
+        mock_folder.return_value = "testcroft"
+        self.assertTrue(get_xdg_config_save_path().endswith("/testcroft"))
+        self.assertTrue(get_xdg_data_save_path().endswith("/testcroft"))
+        self.assertTrue(get_xdg_cache_save_path().endswith("/testcroft"))
+
+    def test_identity(self):
+        self.assertTrue(IdentityManager.IDENTITY_FILE.startswith(get_xdg_config_save_path()))
+
+    def test_filesystem(self):
+        self.assertTrue(FileSystemAccess("test").path.startswith(get_xdg_data_save_path()))
+
+    def test_remote_config(self):
+        self.assertTrue(REMOTE_CACHE.startswith(get_xdg_cache_save_path()))

--- a/test/unittests/util/test_xdg.py
+++ b/test/unittests/util/test_xdg.py
@@ -24,4 +24,4 @@ class TestXdg(TestCase):
         self.assertTrue(FileSystemAccess("test").path.startswith(get_xdg_data_save_path()))
 
     def test_remote_config(self):
-        self.assertTrue(REMOTE_CACHE.startswith(get_xdg_cache_save_path()))
+        self.assertTrue(str(REMOTE_CACHE).startswith(get_xdg_cache_save_path()))


### PR DESCRIPTION

- the path from filesystem was wrong due to a variable name collision, this affected skill data and identity file location
- filesystem was wrongly using xdg_config instead of xdg_data
- refactor identity manager to not use filesystem helper class, that class is meant for skills and now that we are XDG compliant it can not be used or it will move the location of the identity file


point 2 and 3 are bugs that canceled each other out