### PR TITLE
Fix/qml resources

### DIFF
--- a/mycroft/gui/__init__.py
+++ b/mycroft/gui/__init__.py
@@ -185,10 +185,7 @@ class SkillGUI:
         # Convert pages to full reference
         page_urls = []
         for name in page_names:
-            if name.startswith("SYSTEM"):
-                page = resolve_resource_file(join('ui', name))
-            else:
-                page = self.skill.find_resource(name, 'ui')
+            page = self.skill._resources.locate_qml_file(name)
             if page:
                 if self.remote_url:
                     page_urls.append(self.remote_url + "/" + page)

--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -1032,8 +1032,7 @@ class MycroftSkill:
             string: The full path to the resource file or None if not found
         """
         lang = lang or self.lang
-        root_dir = f"{self.root_dir}/{res_dirname}" if res_dirname else self.root_dir
-        x = find_resource(res_name, root_dir, lang)
+        x = find_resource(res_name, self.root_dir, res_dirname, lang)
         if x:
             return str(x)
         self.log.error(f"Skill {self.skill_id} resource '{res_name}' for lang "

--- a/mycroft/skills/skill_data.py
+++ b/mycroft/skills/skill_data.py
@@ -270,6 +270,38 @@ class ResourceFile:
 
 
 class QmlFile(ResourceFile):
+    def _locate(self):
+        """ QML files are special because we do not want to walk the directory """
+        file_path = None
+        if self.resource_name.endswith(self.resource_type.file_extension):
+            file_name = self.resource_name
+        else:
+            file_name = self.resource_name + self.resource_type.file_extension
+
+        # first check for user defined resource files
+        # usually these resources are overrides
+        # eg, to change hardcoded color or text
+        if self.resource_type.user_directory:
+            for x in self.resource_type.user_directory.iterdir():
+                if x.is_file() and file_name == x.name:
+                    file_path = Path(self.resource_type.user_directory, file_name)
+
+        # check the skill resources
+        if file_path is None:
+            for x in self.resource_type.base_directory.iterdir():
+                if x.is_file() and file_name == x.name:
+                    file_path = Path(self.resource_type.base_directory, file_name)
+
+        # check the core resources
+        if file_path is None:
+            file_path = resolve_resource_file(file_name) or \
+                        resolve_resource_file(f"ui/{file_name}")
+
+        if file_path is None:
+            LOG.error(f"Could not find resource file {file_name}")
+
+        return file_path
+
     def load(self):
         return str(self.file_path)
 

--- a/mycroft/skills/skill_data.py
+++ b/mycroft/skills/skill_data.py
@@ -44,9 +44,20 @@ SkillResourceTypes = namedtuple(
         "regex",
         "template",
         "vocabulary",
-        "word"
+        "word",
+        "qml"
     ]
 )
+
+
+def locate_base_directories(skill_directory, resource_subdirectory=None):
+    base_dirs = [Path(skill_directory, resource_subdirectory)] if resource_subdirectory else []
+    base_dirs += [Path(skill_directory, "locale"), Path(skill_directory, "text")]
+    candidates = []
+    for directory in base_dirs:
+        if directory.exists():
+            candidates.append(directory)
+    return candidates
 
 
 def locate_lang_directories(lang, skill_directory, resource_subdirectory=None):
@@ -80,7 +91,7 @@ class ResourceType:
         base_directory: directory containing all files for the resource type
     """
 
-    def __init__(self, resource_type: str, file_extension: str, language: str):
+    def __init__(self, resource_type: str, file_extension: str, language=None):
         self.resource_type = resource_type
         self.file_extension = file_extension
         self.language = language
@@ -88,6 +99,8 @@ class ResourceType:
         self.user_directory = None
 
     def locate_lang_directories(self, skill_directory):
+        if not self.language:
+            return []
         resource_subdirectory = self._get_resource_subdirectory()
         return locate_lang_directories(self.language,
                                        skill_directory,
@@ -97,6 +110,22 @@ class ResourceType:
         skill_directory = Path(get_xdg_data_save_path(), "resources", skill_id)
         if skill_directory.exists():
             self.user_directory = skill_directory
+
+    def _locate_base_no_lang(self, skill_directory, resource_subdirectory):
+        possible_directories = (
+            Path(skill_directory, resource_subdirectory),
+            Path(skill_directory),
+        )
+        for directory in possible_directories:
+            if directory.exists():
+                self.base_directory = directory
+                return
+
+        # check for lang resources defined by the user
+        # user data is usually meant as an override for skill data
+        # but it may be the only data source in some rare instances
+        if self.user_directory:
+            self.base_directory = self.user_directory
 
     def locate_base_directory(self, skill_directory):
         """Find the skill's base directory for the specified resource type.
@@ -116,8 +145,13 @@ class ResourceType:
         Returns:
             the skill's directory for the resource type or None if not found
         """
-        # check for lang resources shipped by the skill
         resource_subdirectory = self._get_resource_subdirectory()
+
+        if not self.language:
+            self._locate_base_no_lang(skill_directory, resource_subdirectory)
+            return
+
+        # check for lang resources shipped by the skill
         possible_directories = (
             Path(skill_directory, "locale", self.language),
             Path(skill_directory, resource_subdirectory, self.language),
@@ -158,7 +192,8 @@ class ResourceType:
             regex="regex",
             template="dialog",
             vocab="vocab",
-            word="dialog"
+            word="dialog",
+            qml="ui"
         )
 
         return subdirectories[self.resource_type]
@@ -208,9 +243,13 @@ class ResourceFile:
                     file_path = Path(directory, file_name)
 
         # check the core resources
-        if file_path is None:
+        if file_path is None and self.resource_type.language:
             sub_path = Path("text", self.resource_type.language, file_name)
             file_path = resolve_resource_file(str(sub_path))
+
+        # check non-lang specific core resources
+        if file_path is None:
+            file_path = resolve_resource_file(file_path)
 
         if file_path is None:
             LOG.error(f"Could not find resource file {file_name}")
@@ -228,6 +267,11 @@ class ResourceFile:
                 if not line or line.startswith("#"):
                     continue
                 yield line
+
+
+class QmlFile(ResourceFile):
+    def load(self):
+        return str(self.file_path)
 
 
 class DialogFile(ResourceFile):
@@ -410,7 +454,8 @@ class SkillResources:
             regex=ResourceType("regex", ".rx", self.language),
             template=ResourceType("template", ".template", self.language),
             vocabulary=ResourceType("vocab", ".voc", self.language),
-            word=ResourceType("word", ".word", self.language)
+            word=ResourceType("word", ".word", self.language),
+            qml=ResourceType("qml", ".qml")
         )
         for resource_type in resource_types.values():
             resource_type.locate_user_directory(self.skill_id)
@@ -432,6 +477,10 @@ class SkillResources:
         dialog_file = DialogFile(self.types.dialog, name)
         dialog_file.data = data
         return dialog_file.load()
+
+    def locate_qml_file(self, name):
+        qml_file = QmlFile(self.types.qml, name)
+        return qml_file.load()
 
     def load_list_file(self, name, data=None) -> List[str]:
         """Load a file containing a list of words or phrases
@@ -686,7 +735,7 @@ class RegexExtractor:
             LOG.info(f"{self.group_name} extracted from utterance: " + extract)
 
 
-def find_resource(res_name, res_dirname, lang):
+def find_resource(res_name, root_dir, res_dirname, lang=None):
     """Find a resource file.
 
     Searches for the given filename using this scheme:
@@ -694,20 +743,26 @@ def find_resource(res_name, res_dirname, lang):
             <skill>/<res_dirname>/<lang>/<res_name>
         2. Search the resource directory:
             <skill>/<res_dirname>/<res_name>
-
         3. Search the locale lang directory or other subdirectory:
             <skill>/locale/<lang>/<res_name> or
             <skill>/locale/<lang>/.../<res_name>
 
     Args:
         res_name (string): The resource name to be found
-        res_dirname (string): A skill root directory
+        root_dir (string): A skill root directory
+        res_dirname (string): A skill sub directory
         lang (string): language folder to be used
 
     Returns:
         string: The full path to the resource file or None if not found
     """
-    for directory in locate_lang_directories(lang, res_dirname):
+    if lang:
+        for directory in locate_lang_directories(lang, root_dir, res_dirname):
+            for x in directory.iterdir():
+                if x.is_file() and res_name == x.name:
+                    return x
+
+    for directory in locate_base_directories(root_dir, res_dirname):
         for x in directory.iterdir():
             if x.is_file() and res_name == x.name:
                 return x

--- a/test/unittests/enclosure/test_gui.py
+++ b/test/unittests/enclosure/test_gui.py
@@ -26,9 +26,11 @@ class TestSkillGUI(TestCase):
         self.mock_skill = mock.Mock(name='Skill')
         self.mock_skill.skill_id = 'fortytwo-skill'
 
-        def find_resource(page, folder):
-            return '/test/{}/{}'.format(folder, page)
-        self.mock_skill.find_resource = find_resource
+        def find_resource(page):
+            return resolve_resource_file(f'ui/{page}') or f'/test/ui/{page}'
+
+        self.mock_skill._resources.locate_qml_file = find_resource
+
         self.gui = SkillGUI(self.mock_skill)
 
     def test_show_page(self):


### PR DESCRIPTION
fix/non_lang_resources  - follow up to #130 

the resource file refactor was not handling non-lang resources properly, it would miss top level folders that are not localized

QML files were completely ignored in the mk2 refactor, this commit adds "new style" support for handling of qml files