### PR TITLE
feat/setup_events

### DIFF
--- a/test/unittests/skills/test_skill_manager.py
+++ b/test/unittests/skills/test_skill_manager.py
@@ -103,7 +103,6 @@ class TestSkillManager(MycroftUnitTestBase):
             'skillmanager.keep',
             'skillmanager.activate',
             'mycroft.paired',
-            'mycroft.setup.complete',
             'mycroft.skills.settings.update',
             'mycroft.skills.initialized',
             'mycroft.skills.trained',


### PR DESCRIPTION
refactor readiness check to handle generic setup skills and not depend specifically on pairing

this makes things event based and allows setup flows that do not require pairing

this requires latest ovos-setup skill, to test enable pairing requirement in mycroft.conf

https://github.com/OpenVoiceOS/skill-ovos-setup