### PR TITLE
fix/filesystem_path_collision

### DIFF
--- a/mycroft/filesystem/__init__.py
+++ b/mycroft/filesystem/__init__.py
@@ -35,7 +35,7 @@ class FileSystemAccess:
             raise ValueError("path must be initialized as a non empty string")
 
         old_path = expanduser(f'~/.{get_xdg_base()}/{path}')
-        xdg_path = expanduser(f'{get_xdg_data_save_path()}/{path}')
+        xdg_path = expanduser(f'{get_xdg_data_save_path()}/filesystem/{path}')
         # Migrate from the old location if it still exists
         if isdir(old_path) and not isdir(xdg_path):
             shutil.move(old_path, xdg_path)


### PR DESCRIPTION
self.file_system was using the XDG skills path, causing a reload of skill everytime it was used.

this commit moves it to a subfolder to avoid this collision

this is an instance of 2 bugs cancelling each other out, since filesystem was wrongly using XDG_CONFIG this bug was hidden during the migration of skills to the xdg spec and only surfaced after #133 