### PR TITLE
feat/skill_settings_filewatch

### DIFF
--- a/mycroft/configuration/config.py
+++ b/mycroft/configuration/config.py
@@ -203,6 +203,9 @@ class Configuration(dict):
     # /etc/xdg/mycroft/mycroft.conf
     xdg_configs = [LocalConf(p) for p in get_xdg_config_locations()]
     _old_user = LocalConf(OLD_USER_CONFIG)
+    # deprecation warning
+    if isfile(OLD_USER_CONFIG):
+        _log_old_location_deprecation(OLD_USER_CONFIG)
     _watchdog = None
     _callbacks = []
 
@@ -330,7 +333,6 @@ class Configuration(dict):
         if not skip_user:
             # deprecation warning
             if isfile(OLD_USER_CONFIG):
-                _log_old_location_deprecation(OLD_USER_CONFIG)
                 configs.append(Configuration._old_user)
             configs += Configuration.xdg_configs
 
@@ -386,11 +388,6 @@ class Configuration(dict):
         """
         # remove any old event listeners
         Configuration.deregister_bus()
-
-        # sync any modified values from before the bind
-        if Configuration.__patch and not Configuration.bus:
-            Configuration.bus.emit(Message("configuration.patch",
-                                           {"config": Configuration.__patch}))
 
         # attach new bus and listeners
         Configuration.bus = bus

--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -62,6 +62,7 @@ from mycroft.util import (
 from mycroft.util.format import pronounce_number, join_list
 from mycroft.util.log import LOG
 from mycroft.util.parse import match_one, extract_number
+from mycroft.util.file_utils import FileWatcher
 from ovos_utils.configuration import get_xdg_base, get_xdg_data_save_path, get_xdg_config_save_path
 from ovos_utils.enclosure.api import EnclosureAPI
 from ovos_utils.file_utils import get_temp_path
@@ -122,6 +123,7 @@ class MycroftSkill:
         self._settings = None
         self._initial_settings = {}
         self.settings_write_path = None
+        self._settings_watchdog = None
 
         # old kludge from fallback skills, unused according to grep
         if use_settings is False:
@@ -244,6 +246,21 @@ class MycroftSkill:
                 if k not in self._settings:
                     self._settings[k] = v
         self._initial_settings = copy(self.settings)
+
+        self._settings_watchdog = FileWatcher(
+            [self._handle_settings_file_change],
+            self.settings_change_callback
+        )
+
+    def _handle_settings_file_change(self):
+        if self._settings:
+            self._settings.reload()
+        if self.settings_change_callback:
+            try:
+                self.settings_change_callback()
+            except:
+                self.log.exception("settings change callback failed, "
+                                   "file changes not handled!")
 
     @property
     def _old_settings_path(self):
@@ -525,8 +542,7 @@ class MycroftSkill:
         if its remote settings were among those changed
         """
         if self.settings_meta is None or self.settings_meta.skill_gid is None:
-            LOG.error('The skill_gid was not set when '
-                      '{} was loaded!'.format(self.name))
+            LOG.error(f'The skill_gid was not set when {self.name} was loaded!')
         else:
             remote_settings = message.data.get(self.settings_meta.skill_gid)
             if remote_settings is not None:
@@ -534,7 +550,11 @@ class MycroftSkill:
                 self.settings.update(**remote_settings)
                 self.settings.store()
                 if self.settings_change_callback is not None:
-                    self.settings_change_callback()
+                    try:
+                        self.settings_change_callback()
+                    except:
+                        self.log.exception("settings change callback failed, "
+                                           "remote changes not handled!")
 
     def detach(self):
         for (name, _) in self.intent_service:
@@ -1509,6 +1529,8 @@ class MycroftSkill:
             self.settings.store()
         if self.settings_meta:
             self.settings_meta.stop()
+        if self._settings_watchdog:
+            self._settings_watchdog.shutdown()
 
         # Clear skill from gui
         self.gui.shutdown()


### PR DESCRIPTION
builds up on the FileWatcher class introduced in https://github.com/OpenVoiceOS/ovos-core/pull/105 and cleans up a couple things from that PR

- makes skill settings react to file system changes
- moves the config deprecation logs so they are only printed once
- removes a unused (and buggy) patch message emit