### PR TITLE
fix/config_hotreload

### DIFF
--- a/mycroft/configuration/config.py
+++ b/mycroft/configuration/config.py
@@ -424,11 +424,27 @@ class Configuration(dict):
         # reload updated config
         for cfg in Configuration.xdg_configs + [Configuration.system]:
             if cfg.path == path:
-                cfg.reload()
+                try:
+                    cfg.reload()
+                except:
+                    # got the file changed signal before write finished
+                    sleep(0.5)
+                    try:
+                        cfg.reload()
+                    except:
+                        LOG.exception("Failed to load configuration, syntax seems invalid!")
                 break
         else:
             # reload all configs
-            Configuration.reload()
+            try:
+                Configuration.reload()
+            except:
+                # got the file changed signal before write finished
+                sleep(0.5)
+                try:
+                    Configuration.reload()
+                except:
+                    LOG.exception("Failed to load configuration, syntax seems invalid!")
         
         for handler in Configuration._callbacks:
             try:


### PR DESCRIPTION
sometimes config would reload before the write finished, this commits makes it retry and if it fails gives a more useful error log about invalid syntax