### PR TITLE
fix/core_resources

### DIFF
--- a/mycroft/skills/skill_data.py
+++ b/mycroft/skills/skill_data.py
@@ -490,7 +490,8 @@ class SkillResources:
             qml=ResourceType("qml", ".qml")
         )
         for resource_type in resource_types.values():
-            resource_type.locate_user_directory(self.skill_id)
+            if self.skill_id:
+                resource_type.locate_user_directory(self.skill_id)
             resource_type.locate_base_directory(self.skill_directory)
         return SkillResourceTypes(**resource_types)
 


### PR DESCRIPTION
when using CoreResources skill_id is not set and an exception was thrown when scanning the user resources override path

a check is now added for skill_id