### PR TITLE
hotfix/deprecated_method

### DIFF
--- a/mycroft/deprecated/audio/speech.py
+++ b/mycroft/deprecated/audio/speech.py
@@ -43,7 +43,7 @@ def _get_messagebus():
 
 def handle_speak(event):
     LOG.warning("speech.handle_speak has been deprecated!")
-    _get_messagebus().emit(event)
+    LOG.error("speak message not handled")
 
 
 def mute_and_speak(utterance, ident, listen=False):


### PR DESCRIPTION
the event emiting itself would potentially cause a infinite loop if this is a bus handler (and it usually is)

simply log an error instead

