### PR TITLE
feat/listening_modes

### DIFF
--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -382,7 +382,16 @@
     // continuous listen is an experimental setting, it removes the need for
     // wake words and uses VAD only, a streaming STT is strongly recommended
     // this setting might downgrade STT accuracy depending on engine used
-    "continuous_listen": false
+    "continuous_listen": false,
+
+    // hybrid listen is an experimental setting,
+    // it will not require a wake word for X seconds after a user interaction
+    // this means you dont need to say "hey mycroft" for follow up questions
+    // NOTE: depending on hardware this may cause mycroft to hear its own TTS responses as questions,
+    // in devices like the mark2 this should be safe to turn on
+    "hybrid_listen": false,
+    // number of seconds to wait for an interaction before requiring wake word again
+    "listen_timeout": 45
   },
 
   // DEPRECATED - Settings used for any precise wake words

--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -376,8 +376,13 @@
 
     // instant listen is an experimental setting, it removes the need for
     // the pause between "hey mycroft" and starting to speak the utterance,
-    //however it might slightly downgrade STT accuracy depending on engine used
-    "instant_listen": false
+    // this setting might slightly downgrade STT accuracy depending on engine used
+    "instant_listen": false,
+
+    // continuous listen is an experimental setting, it removes the need for
+    // wake words and uses VAD only, a streaming STT is strongly recommended
+    // this setting might downgrade STT accuracy depending on engine used
+    "continuous_listen": false
   },
 
   // DEPRECATED - Settings used for any precise wake words
@@ -398,7 +403,7 @@
         "lang": "en-us",
         "listen": true,
         "sound": "snd/start_listening.wav",
-        // when in continuous listening mode (no wake word)
+        // when in CONTINUOUS listening mode (no wake word)
         // these will be filtered from the start of the utterance
         "stt_strings": [
             "mycroft", "minecraft", "microsoft",
@@ -411,8 +416,9 @@
         "phonemes": "W EY K . AH P",
         "threshold": 1e-20,
         "lang": "en-us",
+        // wakeupwords are only used in SLEEPING mode
         "wakeup": true
-        }
+    }
   },
 
    // DEPRECATED: the concept of enclosure will no longer exist in ovos-core

--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -397,8 +397,14 @@
         "threshold": 1e-90,
         "lang": "en-us",
         "listen": true,
-        "sound": "snd/start_listening.wav"
-        },
+        "sound": "snd/start_listening.wav",
+        // when in continuous listening mode (no wake word)
+        // these will be filtered from the start of the utterance
+        "stt_strings": [
+            "mycroft", "minecraft", "microsoft",
+            "hey mycroft", "hey minecraft", "hey microsoft"
+        ]
+    },
 
     "wake up": {
         "module": "ovos-ww-plugin-pocketsphinx",

--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -402,13 +402,7 @@
         "threshold": 1e-90,
         "lang": "en-us",
         "listen": true,
-        "sound": "snd/start_listening.wav",
-        // when in CONTINUOUS listening mode (no wake word)
-        // these will be filtered from the start of the utterance
-        "stt_strings": [
-            "mycroft", "minecraft", "microsoft",
-            "hey mycroft", "hey minecraft", "hey microsoft"
-        ]
+        "sound": "snd/start_listening.wav"
     },
 
     "wake up": {

--- a/mycroft/listener/__init__.py
+++ b/mycroft/listener/__init__.py
@@ -126,14 +126,6 @@ class AudioConsumer(Thread):
         self.daemon = True
         self.loop = loop
 
-    @property
-    def listening_state(self):
-        return self.loop.responsive_recognizer.listener_state
-
-    @property
-    def listen_mode(self):
-        return self.loop.responsive_recognizer.listen_mode
-
     def run(self):
         while self.loop.state.running:
             self.read()
@@ -199,7 +191,7 @@ class AudioConsumer(Thread):
     def transcribe(self, audio, lang):
         def send_unknown_intent():
             """ Send message that nothing was transcribed. """
-            if self.listening_state == ListenerState.WAKEWORD:
+            if self.loop.responsive_recognizer.listen_state == ListenerState.WAKEWORD:
                 self.loop.emit('recognizer_loop:speech.recognition.unknown')
 
         try:
@@ -298,12 +290,12 @@ class RecognizerLoop(EventEmitter):
                 if not v.get("stopword") and not v.get("wakeup")}
 
     @property
-    def listening_state(self):
-        return self.responsive_recognizer.listener_state
+    def listen_state(self):
+        return self.responsive_recognizer.listen_state
 
-    @listening_state.setter
-    def listening_state(self, val):
-        self.responsive_recognizer.listener_state = val
+    @listen_state.setter
+    def listen_state(self, val):
+        self.responsive_recognizer.listen_state = val
 
     @property
     def listen_mode(self):

--- a/mycroft/listener/__init__.py
+++ b/mycroft/listener/__init__.py
@@ -298,6 +298,14 @@ class RecognizerLoop(EventEmitter):
         if fallback_stt:
             self.fallback_stt = fallback_stt
 
+    @property
+    def listening_mode(self):
+        return self.responsive_recognizer.listening_mode
+
+    @listening_mode.setter
+    def listening_mode(self, val):
+        self.responsive_recognizer.listening_mode = val
+
     def _load_config(self):
         """Load configuration parameters from configuration."""
         config = Configuration()

--- a/mycroft/listener/__init__.py
+++ b/mycroft/listener/__init__.py
@@ -256,7 +256,6 @@ def recognizer_conf_hash(config):
     return hash(json.dumps(c, sort_keys=True))
 
 
-
 class RecognizerLoop(EventEmitter):
     """ EventEmitter loop running speech recognition.
 

--- a/mycroft/listener/mic.py
+++ b/mycroft/listener/mic.py
@@ -624,6 +624,7 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
         For example when we are in a dialog with the user.
         """
         if self._listen_triggered:
+            self._listen_triggered = False
             return True
 
         # Pressing the Mark 1 button can start recording (unless

--- a/mycroft/listener/mic.py
+++ b/mycroft/listener/mic.py
@@ -865,7 +865,7 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
                 return None, lang
 
             audio_data = self._listen_phrase(source, sec_per_buffer, stream)
-            if self.hybrid_listening:
+            if self.hybrid_listening or self.continuous_mode:
                 self.listening_mode = ListeningMode.CONTINUOUS
                 self._listen_ts = time.time()
 
@@ -874,7 +874,9 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
             audio_data = self._listen_phrase(source, sec_per_buffer, stream)
 
             # reset to wake word mode if 15 seconds elapsed
-            if self.hybrid_listening and time.time() - self._listen_ts > self.listen_timeout:
+            if not self.continuous_mode and \
+                    self.hybrid_listening and \
+                    time.time() - self._listen_ts > self.listen_timeout:
                 self.listening_mode = ListeningMode.WAKEWORD
 
         elif self.listening_mode == ListeningMode.RECORDING:

--- a/mycroft/listener/mic.py
+++ b/mycroft/listener/mic.py
@@ -515,8 +515,8 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
          recording can be interrupted by:
          - button press
          - bus event
-         - timeout defined in trigger message (TODO)
-         - configured wake words (stop recording, end recording, the end) TODO
+         - max timeout defined in trigger message (TODO)
+         - configured wake words (stop recording, end recording, the end...)
 
         Args:
             source (AudioSource):  Source producing the audio chunks

--- a/mycroft/listener/mic.py
+++ b/mycroft/listener/mic.py
@@ -271,7 +271,7 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
         self.instant_listen = listener_config.get("instant_listen", False)
         self.continuous_mode = listener_config.get("continuous_listen", False)
         self.hybrid_listening = listener_config.get("hybrid_listen", False)
-        self.listen_timeout = listener_config.get("listen_timeout", 15)
+        self.listen_timeout = listener_config.get("listen_timeout", 45)
         self._listen_ts = 0
         # experimental setting, no wake word needed
         if self.continuous_mode:

--- a/mycroft/listener/mic.py
+++ b/mycroft/listener/mic.py
@@ -869,6 +869,11 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
         """
         return AudioData(raw_data, source.SAMPLE_RATE, source.SAMPLE_WIDTH)
 
+    def extend_listening(self):
+        """ reset the timeout until wakeword is needed again
+         only used when in hybrid listening mode """
+        self._listen_ts = time.time()
+
     def listen(self, source, stream):
         """Listens for chunks of audio that Mycroft should perform STT on.
 
@@ -914,13 +919,13 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
             audio_data = self._listen_phrase(source, sec_per_buffer, stream)
             if self.listen_mode != ListeningMode.WAKEWORD:
                 self.listen_state = ListenerState.CONTINUOUS
-                self._listen_ts = time.time()
+                self.extend_listening()
 
         elif self.listen_state == ListenerState.CONTINUOUS:
             LOG.debug("Listening...")
             audio_data = self._listen_phrase(source, sec_per_buffer, stream)
 
-            # reset to wake word mode if 15 seconds elapsed
+            # reset to wake word mode if 45 seconds elapsed
             if self.listen_mode == ListeningMode.HYBRID and \
                     time.time() - self._listen_ts > self.listen_timeout:
                 self.listen_state = ListenerState.WAKEWORD

--- a/mycroft/listener/service.py
+++ b/mycroft/listener/service.py
@@ -70,12 +70,12 @@ class SpeechService(Thread):
                    'source': 'audio'}
         self.bus.emit(Message('recognizer_loop:record_begin', context=context))
 
-    def handle_record_end(self):
+    def handle_record_end(self, event):
         """Forward internal bus message to external bus."""
         LOG.info("End Recording...")
         context = {'client_name': 'mycroft_listener',
                    'source': 'audio'}
-        self.bus.emit(Message('recognizer_loop:record_end', context=context))
+        self.bus.emit(Message('recognizer_loop:record_end', event, context=context))
 
     def handle_no_internet(self):
         LOG.debug("Notifying enclosure of no internet connection")

--- a/mycroft/listener/service.py
+++ b/mycroft/listener/service.py
@@ -91,12 +91,20 @@ class SpeechService(Thread):
         self.bus.emit(Message('mycroft.awoken', context=context))
 
     def handle_wakeword(self, event):
-        LOG.info("Wakeword Detected: " + event['utterance'])
+        LOG.info("Wakeword Detected: " + event['hotword'])
         self.bus.emit(Message('recognizer_loop:wakeword', event))
 
     def handle_hotword(self, event):
         LOG.info("Hotword Detected: " + event['hotword'])
         self.bus.emit(Message('recognizer_loop:hotword', event))
+
+    def handle_stopword(self, event):
+        LOG.info("Stop word Detected: " + event['hotword'])
+        self.bus.emit(Message('recognizer_loop:stopword', event))
+
+    def handle_wakeupword(self, event):
+        LOG.info("WakeUp word Detected: " + event['hotword'])
+        self.bus.emit(Message('recognizer_loop:wakeupword', event))
 
     def handle_hotword_event(self, event):
         """ hotword configured to emit a bus event
@@ -247,6 +255,8 @@ class SpeechService(Thread):
         self.loop.on('recognizer_loop:awoken', self.handle_awoken)
         self.loop.on('recognizer_loop:wakeword', self.handle_wakeword)
         self.loop.on('recognizer_loop:hotword', self.handle_hotword)
+        self.loop.on('recognizer_loop:stopword', self.handle_stopword)
+        self.loop.on('recognizer_loop:wakeupword', self.handle_wakeupword)
         self.loop.on('recognizer_loop:record_end', self.handle_record_end)
         self.loop.on('recognizer_loop:no_internet', self.handle_no_internet)
         self.loop.on('recognizer_loop:hotword_event',

--- a/mycroft/listener/service.py
+++ b/mycroft/listener/service.py
@@ -147,6 +147,8 @@ class SpeechService(Thread):
         """Set listening state."""
         state = event.data.get("state")
         mode = event.data.get("mode")
+        needs_skip = self.loop.listen_state == ListenerState.WAKEWORD
+
         if state:
             if state == ListenerState.WAKEWORD:
                 self.loop.listen_state = ListenerState.WAKEWORD
@@ -166,6 +168,11 @@ class SpeechService(Thread):
                 self.loop.listen_mode = ListeningMode.HYBRID
             else:
                 LOG.error(f"Invalid listen mode: {mode}")
+
+        # signal the recognizer to stop waiting for a wakeword
+        # in order for it to enter the new state
+        if needs_skip:
+            self.loop.responsive_recognizer._listen_triggered = True
 
         self.handle_get_state(event)
 

--- a/mycroft/listener/service.py
+++ b/mycroft/listener/service.py
@@ -186,6 +186,13 @@ class SpeechService(Thread):
         """Stop current recording session """
         self.loop.responsive_recognizer.stop_recording()
 
+    def handle_extend_listening(self, event):
+        """ when a skill is activated (converse) reset
+        the timeout until wakeword is needed again
+        only used when in hybrid listening mode """
+        if self.loop.listen_mode == ListeningMode.HYBRID:
+            self.loop.responsive_recognizer.extend_listening()
+
     def handle_sleep(self, event):
         """Put the recognizer loop to sleep."""
         self.loop.sleep()
@@ -289,6 +296,7 @@ class SpeechService(Thread):
         self.bus.on('recognizer_loop:audio_output_end', self.handle_audio_end)
         self.bus.on('mycroft.stop', self.handle_stop)
         self.bus.on("ovos.languages.stt", self.handle_get_languages_stt)
+        self.bus.on("intent.service.skills.activated", self.handle_extend_listening)
 
     def run(self):
         self.status.set_started()

--- a/mycroft/listener/service.py
+++ b/mycroft/listener/service.py
@@ -141,11 +141,11 @@ class SpeechService(Thread):
         mode = event.data.get("mode")
         if state:
             if state == ListenerState.WAKEWORD:
-                self.loop.listening_state = ListenerState.WAKEWORD
+                self.loop.listen_state = ListenerState.WAKEWORD
             elif state == ListenerState.CONTINUOUS:
-                self.loop.listening_state = ListenerState.CONTINUOUS
+                self.loop.listen_state = ListenerState.CONTINUOUS
             elif state == ListenerState.RECORDING:
-                self.loop.listening_state = ListenerState.RECORDING
+                self.loop.listen_state = ListenerState.RECORDING
             else:
                 LOG.error(f"Invalid listening state: {state}")
 
@@ -164,7 +164,7 @@ class SpeechService(Thread):
     def handle_get_state(self, event):
         """Query listening state"""
         data = {'mode': self.loop.listen_mode,
-                "state": self.loop.listening_state}
+                "state": self.loop.listen_state}
         self.bus.emit(event.reply("recognizer_loop:state", data))
 
     def handle_stop_recording(self, event):

--- a/mycroft/listener/silence.py
+++ b/mycroft/listener/silence.py
@@ -252,11 +252,18 @@ class SilenceDetector:
 
         self.current_chunk: bytes = bytes()
 
-    def stop(self) -> bytes:
+    def stop(self, phrase_only=False) -> bytes:
         """Free any resources and return recorded audio."""
         before_buffer = bytes()
         for before_chunk in self.before_phrase_chunks:
             before_buffer += before_chunk
+
+        if phrase_only:
+            # TODO is 5 a good magic number ?
+            # the aim is to include just a tiny bit of silence
+            # and avoid super long recordings to account
+            # for non streaming STT
+            before_buffer = before_chunk[-5:]
 
         audio_data = before_buffer + self.phrase_buffer
 


### PR DESCRIPTION
adds ListenMode, this is globally set in mycroft.conf and can be one of the following
- WAKE_WORD - the classic mode, listen for wakewords and trigger actions based on them
- CONTINUOUS - use VAD to detect speech and always transcribe it, ignore STT failures
   - :warning: offline streaming STT highly recommended! :warning: 
- HYBRID - after a wake word detection switch to continuous mode for X seconds (45 by default)
   - this allows follow up question without wake word, but good AEC is needed or mycroft will hear its own TTS

adds ListeningState, this is a runtime state and can be one of the following
- WAKE_WORD - currently waiting for a wake word
- CONTINUOUS - currently using VAD to detect speech
- RECORDING - save all audio until told to stop, then reset to default mode
   - think "captain's log, stardate 184876, today the warp core exploded, bla bla bla"

other notes:
- bus events can be used to query and change the listening mode / state
- new class of hotwords, "stopwords", only used while in RECORDING state to stop recording
- wakeword/utterance save paths now respect XDG
- added filename to message.data in `"recognizer_loop:record_end"`