### PR TITLE
feat/speak_error_flag

### DIFF
--- a/mycroft/skills/common_iot_skill.py
+++ b/mycroft/skills/common_iot_skill.py
@@ -369,10 +369,13 @@ class CommonIoTSkill(MycroftSkill, ABC):
         """
         if bus:
             super().bind(bus)
-            self.add_event(_BusKeys.TRIGGER, self._handle_trigger)
-            self.add_event(_BusKeys.RUN + self.skill_id, self._run_request)
+            self.add_event(_BusKeys.TRIGGER, self._handle_trigger,
+                               speak_errors=False)
+            self.add_event(_BusKeys.RUN + self.skill_id, self._run_request,
+                               speak_errors=False)
             self.add_event(_BusKeys.CALL_FOR_REGISTRATION,
-                           self._handle_call_for_registration)
+                           self._handle_call_for_registration,
+                               speak_errors=False)
 
     @contextmanager
     def _current_request(self, id: str):

--- a/mycroft/skills/common_iot_skill.py
+++ b/mycroft/skills/common_iot_skill.py
@@ -369,13 +369,15 @@ class CommonIoTSkill(MycroftSkill, ABC):
         """
         if bus:
             super().bind(bus)
-            self.add_event(_BusKeys.TRIGGER, self._handle_trigger,
-                               speak_errors=False)
-            self.add_event(_BusKeys.RUN + self.skill_id, self._run_request,
-                               speak_errors=False)
+            self.add_event(_BusKeys.TRIGGER,
+                           self._handle_trigger,
+                           speak_errors=False)
+            self.add_event(_BusKeys.RUN + self.skill_id,
+                           self._run_request,
+                           speak_errors=False)
             self.add_event(_BusKeys.CALL_FOR_REGISTRATION,
                            self._handle_call_for_registration,
-                               speak_errors=False)
+                           speak_errors=False)
 
     @contextmanager
     def _current_request(self, id: str):

--- a/mycroft/skills/common_play_skill.py
+++ b/mycroft/skills/common_play_skill.py
@@ -80,10 +80,8 @@ class CommonPlaySkill(MycroftSkill, ABC):
         if bus:
             super().bind(bus)
             self.audioservice = AudioService(self.bus)
-            self.add_event('play:query', self.__handle_play_query,
-                               speak_errors=False)
-            self.add_event('play:start', self.__handle_play_start,
-                               speak_errors=False)
+            self.add_event('play:query', self.__handle_play_query, speak_errors=False)
+            self.add_event('play:start', self.__handle_play_start, speak_errors=False)
 
     def __handle_play_query(self, message):
         """Query skill if it can start playback from given phrase."""

--- a/mycroft/skills/common_play_skill.py
+++ b/mycroft/skills/common_play_skill.py
@@ -80,8 +80,10 @@ class CommonPlaySkill(MycroftSkill, ABC):
         if bus:
             super().bind(bus)
             self.audioservice = AudioService(self.bus)
-            self.add_event('play:query', self.__handle_play_query)
-            self.add_event('play:start', self.__handle_play_start)
+            self.add_event('play:query', self.__handle_play_query,
+                               speak_errors=False)
+            self.add_event('play:start', self.__handle_play_start,
+                               speak_errors=False)
 
     def __handle_play_query(self, message):
         """Query skill if it can start playback from given phrase."""

--- a/mycroft/skills/common_query_skill.py
+++ b/mycroft/skills/common_query_skill.py
@@ -93,8 +93,10 @@ class CommonQuerySkill(MycroftSkill, ABC):
         """
         if bus:
             super().bind(bus)
-            self.add_event('question:query', self.__handle_question_query)
-            self.add_event('question:action', self.__handle_query_action)
+            self.add_event('question:query', self.__handle_question_query,
+                               speak_errors=False)
+            self.add_event('question:action', self.__handle_query_action,
+                               speak_errors=False)
 
     def __handle_question_query(self, message):
         search_phrase = message.data["phrase"]

--- a/mycroft/skills/common_query_skill.py
+++ b/mycroft/skills/common_query_skill.py
@@ -93,10 +93,8 @@ class CommonQuerySkill(MycroftSkill, ABC):
         """
         if bus:
             super().bind(bus)
-            self.add_event('question:query', self.__handle_question_query,
-                               speak_errors=False)
-            self.add_event('question:action', self.__handle_query_action,
-                               speak_errors=False)
+            self.add_event('question:query', self.__handle_question_query, speak_errors=False)
+            self.add_event('question:action', self.__handle_query_action, speak_errors=False)
 
     def __handle_question_query(self, message):
         search_phrase = message.data["phrase"]

--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -66,6 +66,7 @@ from ovos_utils.configuration import get_xdg_base, get_xdg_data_save_path, get_x
 from ovos_utils.enclosure.api import EnclosureAPI
 from ovos_utils.file_utils import get_temp_path
 from ovos_utils.messagebus import get_message_lang
+from ovos_workshop.decorators.killable import AbortEvent
 import shutil
 
 
@@ -499,13 +500,11 @@ class MycroftSkill:
                 # reused and can't be sent over the messagebus
                 func = self.public_api[key].pop('func')
                 self.add_event(self.public_api[key]['type'],
-                               wrap_method(func),
-                               speak_errors=False)
+                               wrap_method(func), speak_errors=False)
 
         if self.public_api:
             self.add_event(f'{self.skill_id}.public_api',
-                           self._send_public_api,
-                               speak_errors=False)
+                           self._send_public_api, speak_errors=False)
 
     @property
     def stop_is_implemented(self):
@@ -522,30 +521,18 @@ class MycroftSkill:
         """
         # Only register stop if it's been implemented
         if self.stop_is_implemented:
-            self.add_event('mycroft.stop', self.__handle_stop,
-                               speak_errors=False)
-        self.add_event('skill.converse.ping', self._handle_converse_ack,
-                               speak_errors=False)
-        self.add_event('skill.converse.request', self._handle_converse_request,
-                               speak_errors=False)
-        self.add_event(f"{self.skill_id}.activate", self.handle_activate,
-                               speak_errors=False)
-        self.add_event(f"{self.skill_id}.deactivate", self.handle_deactivate,
-                               speak_errors=False)
-        self.add_event("intent.service.skills.deactivated", self._handle_skill_deactivated,
-                               speak_errors=False)
-        self.add_event("intent.service.skills.activated", self._handle_skill_activated,
-                               speak_errors=False)
-        self.add_event('mycroft.skill.enable_intent', self.handle_enable_intent,
-                               speak_errors=False)
-        self.add_event('mycroft.skill.disable_intent', self.handle_disable_intent,
-                               speak_errors=False)
-        self.add_event('mycroft.skill.set_cross_context', self.handle_set_cross_context,
-                               speak_errors=False)
-        self.add_event('mycroft.skill.remove_cross_context', self.handle_remove_cross_context,
-                               speak_errors=False)
-        self.add_event('mycroft.skills.settings.changed', self.handle_settings_change,
-                               speak_errors=False)
+            self.add_event('mycroft.stop', self.__handle_stop, speak_errors=False)
+        self.add_event('skill.converse.ping', self._handle_converse_ack, speak_errors=False)
+        self.add_event('skill.converse.request', self._handle_converse_request, speak_errors=False)
+        self.add_event(f"{self.skill_id}.activate", self.handle_activate, speak_errors=False)
+        self.add_event(f"{self.skill_id}.deactivate", self.handle_deactivate, speak_errors=False)
+        self.add_event("intent.service.skills.deactivated", self._handle_skill_deactivated, speak_errors=False)
+        self.add_event("intent.service.skills.activated", self._handle_skill_activated, speak_errors=False)
+        self.add_event('mycroft.skill.enable_intent', self.handle_enable_intent, speak_errors=False)
+        self.add_event('mycroft.skill.disable_intent', self.handle_disable_intent, speak_errors=False)
+        self.add_event('mycroft.skill.set_cross_context', self.handle_set_cross_context, speak_errors=False)
+        self.add_event('mycroft.skill.remove_cross_context', self.handle_remove_cross_context, speak_errors=False)
+        self.add_event('mycroft.skills.settings.changed', self.handle_settings_change, speak_errors=False)
 
     def handle_settings_change(self, message):
         """Update settings if the remote settings changes apply to this skill.
@@ -1011,12 +998,10 @@ class MycroftSkill:
                 self.log.info(f'Registering resting screen {method} for {self.resting_name}.')
 
                 # Register for handling resting screen
-                self.add_event(f'{self.skill_id}.idle', method,
-                               speak_errors=False)
+                self.add_event(f'{self.skill_id}.idle', method, speak_errors=False)
                 # Register handler for resting screen collect message
                 self.add_event('mycroft.mark2.collect_idle',
-                               self._handle_collect_resting,
-                               speak_errors=False)
+                               self._handle_collect_resting, speak_errors=False)
 
                 # Do a send at load to make sure the skill is registered
                 # if reloaded
@@ -1088,8 +1073,44 @@ class MycroftSkill:
         """Deprecated method for translating a template file"""
         return self._resources.load_template_file(template_name, data)
 
-    def add_event(self, name, handler, handler_info=None, once=False,
-                  speak_errors=True):
+    def _on_event_start(self, message, handler_info, skill_data):
+        """Indicate that the skill handler is starting."""
+        if handler_info:
+            # Indicate that the skill handler is starting if requested
+            msg_type = handler_info + '.start'
+            message.context["skill_id"] = self.skill_id
+            self.bus.emit(message.forward(msg_type, skill_data))
+
+    def _on_event_end(self, message, handler_info, skill_data):
+        """Store settings and indicate that the skill handler has completed
+        """
+        if self.settings != self._initial_settings:
+            self.settings.store()
+            self._initial_settings = copy(self.settings)
+        if handler_info:
+            msg_type = handler_info + '.complete'
+            message.context["skill_id"] = self.skill_id
+            self.bus.emit(message.forward(msg_type, skill_data))
+
+    def _on_event_error(self, error, message, handler_info, skill_data, speak_errors):
+        """Speak and log the error."""
+        # Convert "MyFancySkill" to "My Fancy Skill" for speaking
+        handler_name = camel_case_split(self.name)
+        msg_data = {'skill': handler_name}
+        speech = dialog.get('skill.error', self.lang, msg_data)
+        if speak_errors:
+            self.speak(speech)
+        LOG.exception(error)
+        # append exception information in message
+        skill_data['exception'] = repr(error)
+        if handler_info:
+            # Indicate that the skill handler errored
+            msg_type = handler_info + '.error'
+            message = message or Message("")
+            message.context["skill_id"] = self.skill_id
+            self.bus.emit(message.forward(msg_type, skill_data))
+
+    def add_event(self, name, handler, handler_info=None, once=False, speak_errors=True):
         """Create event handler for executing intent or other event.
 
         Args:
@@ -1106,41 +1127,17 @@ class MycroftSkill:
         skill_data = {'name': get_handler_name(handler)}
 
         def on_error(error, message):
-            """Speak and log the error."""
-            # Convert "MyFancySkill" to "My Fancy Skill" for speaking
-            handler_name = camel_case_split(self.name)
-            msg_data = {'skill': handler_name}
-            speech = dialog.get('skill.error', self.lang, msg_data)
-            if speak_errors:
-                self.speak(speech)
-            LOG.exception(error)
-            # append exception information in message
-            skill_data['exception'] = repr(error)
-            if handler_info:
-                # Indicate that the skill handler errored
-                msg_type = handler_info + '.error'
-                message = message or Message("")
-                message.context["skill_id"] = self.skill_id
-                self.bus.emit(message.forward(msg_type, skill_data))
+            if isinstance(error, AbortEvent):
+                LOG.info("Skill execution aborted")
+                self._on_event_end(message, handler_info, skill_data)
+                return
+            self._on_event_error(error, message, handler_info, skill_data, speak_errors)
 
         def on_start(message):
-            """Indicate that the skill handler is starting."""
-            if handler_info:
-                # Indicate that the skill handler is starting if requested
-                msg_type = handler_info + '.start'
-                message.context["skill_id"] = self.skill_id
-                self.bus.emit(message.forward(msg_type, skill_data))
+            self._on_event_start(message, handler_info, skill_data)
 
         def on_end(message):
-            """Store settings and indicate that the skill handler has completed
-            """
-            if self.settings != self._initial_settings:
-                self.settings.store()
-                self._initial_settings = copy(self.settings)
-            if handler_info:
-                msg_type = handler_info + '.complete'
-                message.context["skill_id"] = self.skill_id
-                self.bus.emit(message.forward(msg_type, skill_data))
+            self._on_event_end(message, handler_info, skill_data)
 
         wrapper = create_wrapper(handler, self.skill_id, on_start, on_end,
                                  on_error)

--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -499,11 +499,13 @@ class MycroftSkill:
                 # reused and can't be sent over the messagebus
                 func = self.public_api[key].pop('func')
                 self.add_event(self.public_api[key]['type'],
-                               wrap_method(func))
+                               wrap_method(func),
+                               speak_errors=False)
 
         if self.public_api:
             self.add_event(f'{self.skill_id}.public_api',
-                           self._send_public_api)
+                           self._send_public_api,
+                               speak_errors=False)
 
     @property
     def stop_is_implemented(self):
@@ -520,18 +522,30 @@ class MycroftSkill:
         """
         # Only register stop if it's been implemented
         if self.stop_is_implemented:
-            self.add_event('mycroft.stop', self.__handle_stop)
-        self.add_event('skill.converse.ping', self._handle_converse_ack)
-        self.add_event('skill.converse.request', self._handle_converse_request)
-        self.add_event(f"{self.skill_id}.activate", self.handle_activate)
-        self.add_event(f"{self.skill_id}.deactivate", self.handle_deactivate)
-        self.add_event("intent.service.skills.deactivated", self._handle_skill_deactivated)
-        self.add_event("intent.service.skills.activated", self._handle_skill_activated)
-        self.add_event('mycroft.skill.enable_intent', self.handle_enable_intent)
-        self.add_event('mycroft.skill.disable_intent', self.handle_disable_intent)
-        self.add_event('mycroft.skill.set_cross_context', self.handle_set_cross_context)
-        self.add_event('mycroft.skill.remove_cross_context', self.handle_remove_cross_context)
-        self.add_event('mycroft.skills.settings.changed', self.handle_settings_change)
+            self.add_event('mycroft.stop', self.__handle_stop,
+                               speak_errors=False)
+        self.add_event('skill.converse.ping', self._handle_converse_ack,
+                               speak_errors=False)
+        self.add_event('skill.converse.request', self._handle_converse_request,
+                               speak_errors=False)
+        self.add_event(f"{self.skill_id}.activate", self.handle_activate,
+                               speak_errors=False)
+        self.add_event(f"{self.skill_id}.deactivate", self.handle_deactivate,
+                               speak_errors=False)
+        self.add_event("intent.service.skills.deactivated", self._handle_skill_deactivated,
+                               speak_errors=False)
+        self.add_event("intent.service.skills.activated", self._handle_skill_activated,
+                               speak_errors=False)
+        self.add_event('mycroft.skill.enable_intent', self.handle_enable_intent,
+                               speak_errors=False)
+        self.add_event('mycroft.skill.disable_intent', self.handle_disable_intent,
+                               speak_errors=False)
+        self.add_event('mycroft.skill.set_cross_context', self.handle_set_cross_context,
+                               speak_errors=False)
+        self.add_event('mycroft.skill.remove_cross_context', self.handle_remove_cross_context,
+                               speak_errors=False)
+        self.add_event('mycroft.skills.settings.changed', self.handle_settings_change,
+                               speak_errors=False)
 
     def handle_settings_change(self, message):
         """Update settings if the remote settings changes apply to this skill.
@@ -997,10 +1011,12 @@ class MycroftSkill:
                 self.log.info(f'Registering resting screen {method} for {self.resting_name}.')
 
                 # Register for handling resting screen
-                self.add_event(f'{self.skill_id}.idle', method)
+                self.add_event(f'{self.skill_id}.idle', method,
+                               speak_errors=False)
                 # Register handler for resting screen collect message
                 self.add_event('mycroft.mark2.collect_idle',
-                               self._handle_collect_resting)
+                               self._handle_collect_resting,
+                               speak_errors=False)
 
                 # Do a send at load to make sure the skill is registered
                 # if reloaded
@@ -1072,7 +1088,8 @@ class MycroftSkill:
         """Deprecated method for translating a template file"""
         return self._resources.load_template_file(template_name, data)
 
-    def add_event(self, name, handler, handler_info=None, once=False):
+    def add_event(self, name, handler, handler_info=None, once=False,
+                  speak_errors=True):
         """Create event handler for executing intent or other event.
 
         Args:
@@ -1082,6 +1099,9 @@ class MycroftSkill:
                                    handler status on messagebus.
             once (bool, optional): Event handler will be removed after it has
                                    been run once.
+            speak_errors (bool, optional): Determines if an error dialog should be
+                                           spoken to inform the user whenever
+                                           an exception happens inside the handler
         """
         skill_data = {'name': get_handler_name(handler)}
 
@@ -1091,7 +1111,8 @@ class MycroftSkill:
             handler_name = camel_case_split(self.name)
             msg_data = {'skill': handler_name}
             speech = dialog.get('skill.error', self.lang, msg_data)
-            self.speak(speech)
+            if speak_errors:
+                self.speak(speech)
             LOG.exception(error)
             # append exception information in message
             skill_data['exception'] = repr(error)

--- a/requirements/extra-skills-lgpl.txt
+++ b/requirements/extra-skills-lgpl.txt
@@ -2,6 +2,7 @@ adapt-parser~=0.5
 padaos~=0.1
 ovos-lingua-franca~=0.4, >=0.4.2
 PyYAML~=5.4
+ovos_workshop~=0.0, >=0.0.7a9
 
 padatious~=0.4.8
 fann2==1.0.7

--- a/requirements/extra-skills.txt
+++ b/requirements/extra-skills.txt
@@ -2,3 +2,4 @@ adapt-parser~=0.5
 padaos~=0.1
 ovos-lingua-franca~=0.4, >=0.4.2
 PyYAML~=5.4
+ovos_workshop~=0.0, >=0.0.7a9

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -16,7 +16,7 @@ ovos-tts-plugin-mimic2~=0.1, >=0.1.5
 ovos-tts-plugin-google-tx~=0.0, >=0.0.3
 ovos-ww-plugin-pocketsphinx~=0.1
 ovos-ww-plugin-precise~=0.1
-ovos_workshop~=0.0, >=0.0.7a6
+ovos_workshop~=0.0, >=0.0.7a9
 ovos_PHAL~=0.0, >=0.0.2a8
 ovos-lingua-franca~=0.4, >=0.4.2
 

--- a/test/unittests/skills/test_skill_api.py
+++ b/test/unittests/skills/test_skill_api.py
@@ -12,7 +12,7 @@ class Skill(MycroftSkill):
         super().__init__()
         self.registered_methods = {}
 
-    def add_event(self, event_type, func):
+    def add_event(self, event_type, func, **kwargs):
         """Mock handler of add_event, simply storing type and method.
 
         Used in testing to verify the wrapped methods


### PR DESCRIPTION
when a skill registered an event via self.add_event (recommend) it always speaks an error message when there is an exception, most of the time this is unwanted outside intents

this commit puts this behind a flag but keeps default behavior (speak errors by default)

to test use some failing common_query or common_play skill and verify that no error is spoken, this would be previously be spoken during the search phase even if skill was not selected