### PR TITLE
refactor/native_ocp

### DIFF
--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -490,7 +490,7 @@
 
   "Audio": {
     "backends": {
-      "local": {
+      "OCP": {
         "type": "ovos_common_play",
         "active": true
       },
@@ -503,7 +503,11 @@
         "active": true
       }
     },
-    "default-backend": "local"
+    // DEPRECATED - this value is only used as a fallback when OCP is not installed
+    // OCP is a full fledged media player that handles everything from video to playlists
+    // it plugs into the audio service api to capture playback and provide backwards compat
+    // OCP will delegate to the audio backends when needed
+    "default-backend": "OCP"
   },
 
   "debug": false


### PR DESCRIPTION
always use OCP as default audio backend unless it is not installed