### PR TITLE
fix/skill_settings_callback

### DIFF
--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -251,9 +251,10 @@ class MycroftSkill:
     def _start_filewatcher(self):
         if self._settings_watchdog is None and isfile(self._settings.path):
             self._settings_watchdog = FileWatcher([self._settings.path],
-                                                  callback=self._handle_settings_file_change)
+                                                  callback=self._handle_settings_file_change,
+                                                  ignore_creation=True)
 
-    def _handle_settings_file_change(self):
+    def _handle_settings_file_change(self, path):
         if self._settings:
             self._settings.reload()
         if self.settings_change_callback:

--- a/mycroft/util/file_utils.py
+++ b/mycroft/util/file_utils.py
@@ -206,12 +206,12 @@ def create_file(filename):
 
 
 class FileWatcher:
-    def __init__(self, files, callback, recursive=False):
+    def __init__(self, files, callback, recursive=False, ignore_creation=False):
         self.observer = Observer()
         self.handlers = []
         for file_path in files:
             watch_dir = dirname(file_path)
-            self.observer.schedule(FileEventHandler(file_path, callback),
+            self.observer.schedule(FileEventHandler(file_path, callback, ignore_creation),
                                    watch_dir, recursive=recursive)
         self.observer.start()
 
@@ -221,17 +221,21 @@ class FileWatcher:
 
 
 class FileEventHandler(FileSystemEventHandler):
-    def __init__(self, file_path, callback):
+    def __init__(self, file_path, callback, ignore_creation=False):
         super().__init__()
         self._callback = callback
         self._file_path = file_path
         self._debounce = 1
         self._last_update = 0
+        if ignore_creation:
+            self._events = ('created', 'modified')
+        else:
+            self._events = ('modified')
 
     def on_any_event(self, event):
         if event.is_directory:
             return
-        elif event.event_type in ('created', 'modified'):
+        elif event.event_type in self._events:
             if event.src_path == self._file_path:
                 if time.time() - self._last_update >= self._debounce:
                     self._callback(event.src_path)

--- a/mycroft/util/file_utils.py
+++ b/mycroft/util/file_utils.py
@@ -228,9 +228,9 @@ class FileEventHandler(FileSystemEventHandler):
         self._debounce = 1
         self._last_update = 0
         if ignore_creation:
-            self._events = ('created', 'modified')
-        else:
             self._events = ('modified')
+        else:
+            self._events = ('created', 'modified')
 
     def on_any_event(self, event):
         if event.is_directory:


### PR DESCRIPTION
- add missing argument (introduced in #139 
- ignore settings file creation, that is dome by the skill and does not need a reload

fixes
```
Exception in thread Thread-68:
Traceback (most recent call last):
  File "/usr/lib/python3.8/threading.py", line 932, in _bootstrap_inner
    self.run()
  File "/home/d_mcknight/PycharmProjects/_.Core/venv/lib/python3.8/site-packages/watchdog/observers/api.py", line 205, in run
    self.dispatch_events(self.event_queue)
  File "/home/d_mcknight/PycharmProjects/_.Core/venv/lib/python3.8/site-packages/watchdog/observers/api.py", line 381, in dispatch_events
    handler.dispatch(event)
  File "/home/d_mcknight/PycharmProjects/_.Core/venv/lib/python3.8/site-packages/watchdog/events.py", line 271, in dispatch
    self.on_any_event(event)
  File "/home/d_mcknight/PycharmProjects/_.Core/venv/lib/python3.8/site-packages/mycroft/util/file_utils.py", line 237, in on_any_event
    self._callback(event.src_path)
TypeError: _handle_settings_file_change() takes 1 positional argument but 2 were given
```