### PR TITLE
Update default cache directory to `XDG_CACHE_HOME`

### DIFF
--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -95,7 +95,7 @@
   // by default, files persist across reboots, but be careful with space usage!
   // TIP: use "/dev/shm/mycroft/cache" if you want to keep the cache in RAM or
   // use "/tmp/mycroft/cache" to remove files upon reboot
-  // default to $XDG_DATA_DIRS/mycroft
+  // default to $XDG_DATA_DIRS/$BASE_FOLDER where BASE_FOLDER is read from ovos.conf (default "mycroft")
   // "cache_path": "/tmp/mycroft/cache",
 
   # emit mycroft.ready signal when all these conditions are met

--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -92,13 +92,11 @@
   // default to $XDG_DATA_DIRS/mycroft
   // "data_dir": "/opt/mycroft",
 
-  // whenever core needs to cache some files this directory will be used,
-  // the main use case is for TTS files to avoid synthesizing the same thing
-  // more than once, you may set this to a permanent directory to keep these
-  // files across reboots, but be careful with space usage!
-  // if not set defaults to "/tmp/mycroft/cache"
-  // TIP: use "/dev/shm/mycroft/cache" if you want to keep the cache in RAM
-  "cache_path": "/tmp/mycroft/cache",
+  // by default, files persist across reboots, but be careful with space usage!
+  // TIP: use "/dev/shm/mycroft/cache" if you want to keep the cache in RAM or
+  // use "/tmp/mycroft/cache" to remove files upon reboot
+  // default to $XDG_DATA_DIRS/mycroft
+  // "cache_path": "/tmp/mycroft/cache",
 
   # emit mycroft.ready signal when all these conditions are met
   # different setups will have different needs

--- a/mycroft/util/file_utils.py
+++ b/mycroft/util/file_utils.py
@@ -26,7 +26,8 @@ from watchdog.observers import Observer
 from watchdog.events import FileSystemEventHandler
 
 from ovos_utils.file_utils import get_temp_path
-from ovos_utils.configuration import get_xdg_base, get_xdg_data_dirs, get_xdg_data_save_path
+from ovos_utils.configuration import get_xdg_base, get_xdg_data_dirs, \
+    get_xdg_data_save_path, get_xdg_cache_save_path
 import mycroft.configuration
 from mycroft.util.log import LOG
 # do not delete these imports, here for backwards compat!
@@ -156,9 +157,7 @@ def get_cache_directory(domain=None):
         (str) a path to the directory where you can cache data
     """
     config = mycroft.configuration.Configuration()
-    directory = config.get("cache_path")
-    if not directory:
-        directory = os.path.join(get_xdg_data_save_path(), "cache")
+    directory = config.get("cache_path") or get_xdg_cache_save_path()
     return ensure_directory_exists(directory, domain)
 
 

--- a/requirements/minimal.txt
+++ b/requirements/minimal.txt
@@ -2,6 +2,6 @@ requests~=2.26
 mycroft-messagebus-client~=0.9,!=0.9.2,!=0.9.3
 combo-lock~=0.2
 ovos-utils~=0.0, >=0.0.22
-ovos-plugin-manager~=0.0, >=0.0.17
+ovos-plugin-manager~=0.0, >=0.0.18a8
 python-dateutil~=2.6
 watchdog

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -9,7 +9,7 @@ PyYAML~=5.4
 watchdog
 
 ovos-utils~=0.0, >=0.0.22
-ovos-plugin-manager~=0.0, >=0.0.17
+ovos-plugin-manager~=0.0, >=0.0.18a8
 ovos-stt-plugin-server~=0.0, >=0.0.2
 ovos-tts-plugin-mimic~=0.2, >=0.2.6
 ovos-tts-plugin-mimic2~=0.1, >=0.1.5


### PR DESCRIPTION
Updates default behavior to use XDG cache spec
Updated annotations in default config

TODO:
- [x] Update TTS caching to use `/tmp` by default https://github.com/OpenVoiceOS/OVOS-plugin-manager/blob/dev/ovos_plugin_manager/utils/tts_cache.py#L225