### PR TITLE
feat/converse_session

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -12,7 +12,7 @@ ovos-plugin-manager<0.1.0, >=0.0.24a5
 ovos-config~=0.0,>=0.0.11a9
 ovos-lingua-franca>=0.4.7
 ovos_backend_client>=0.1.0a6
-ovos_workshop<0.1.0, >=0.0.12a50
+ovos_workshop<0.1.0, >=0.0.13a5
 
 # provides plugins and classic machine learning framework
 ovos-classifiers<0.1.0, >=0.0.0a33

--- a/test/unittests/skills/test_mycroft_skill.py
+++ b/test/unittests/skills/test_mycroft_skill.py
@@ -603,10 +603,10 @@ class TestOVOSSkill(unittest.TestCase):
         s.config_core['secondary_langs'] = ['en', 'en-us', 'en-AU',
                                             'es', 'pt-PT']
         self.assertEqual(s.lang, 'en-us')
-        self.assertEqual(s._secondary_langs, ['en', 'en-au', 'es',
+        self.assertEqual(s.secondary_langs, ['en', 'en-au', 'es',
                                               'pt-pt'])
-        self.assertEqual(len(s._native_langs), len(set(s._native_langs)))
-        self.assertEqual(set(s._native_langs), {'en-us', 'en-au', 'pt-pt'})
+        self.assertEqual(len(s.native_langs), len(set(s.native_langs)))
+        self.assertEqual(set(s.native_langs), {'en-us', 'en-au', 'pt-pt'})
         s.config_core['lang'] = lang
         s.config_core['secondary_langs'] = secondary
 

--- a/test/unittests/skills/test_mycroft_skill_get_response.py
+++ b/test/unittests/skills/test_mycroft_skill_get_response.py
@@ -162,13 +162,13 @@ class TestMycroftSkillGetResponse(TestCase):
         skill.speak_dialog = mock.Mock()
 
         def validator(*args, **kwargs):
-            self.assertTrue(skill._converse_is_implemented)
+            self.assertTrue(skill.converse_is_implemented)
 
-        self.assertFalse(skill._converse_is_implemented)
+        self.assertFalse(skill.converse_is_implemented)
         skill.get_response('what do you want', validator=validator)
         skill._wait_response.assert_called_with(AnyCallable(), validator,
                                                 AnyCallable(), -1)
-        self.assertFalse(skill._converse_is_implemented)
+        self.assertFalse(skill.converse_is_implemented)
 
 
 class TestMycroftSkillAskYesNo(TestCase):
@@ -230,7 +230,7 @@ class TestMycroftSkillAskYesNo(TestCase):
         response = skill.ask_yesno('Do you like breakfast')
         self.assertEqual(response, 'I am a fish')
 
-    @mock.patch('ovos_workshop.skills.base.dig_for_message')
+    @mock.patch('ovos_workshop.skills.ovos.dig_for_message')
     def test_ask_yesno_german(self, dig_mock):
         """Check that when the skill is set to german it responds to "ja"."""
         # lang is session based, it comes from originating message in ovos-core

--- a/test/unittests/skills/test_mycroft_skill_get_response.py
+++ b/test/unittests/skills/test_mycroft_skill_get_response.py
@@ -1,17 +1,15 @@
 """Tests for the mycroft skill's get_response variations."""
 
+import time
 from os.path import dirname, join
 from threading import Thread
-import time
-from unittest import TestCase, mock
+from unittest import TestCase, mock, skip
 
 from lingua_franca import load_language
 
 from mycroft.skills import MycroftSkill
 from ovos_bus_client.message import Message
-
 from test.unittests.mocks import base_config, AnyCallable
-
 
 load_language("en-us")
 
@@ -57,6 +55,7 @@ def create_skill(mock_conf, lang='en-us'):
 
 
 class TestMycroftSkillWaitResponse(TestCase):
+    @skip("TODO - refactor for new event based get_response")
     def test_wait(self):
         """Ensure that _wait_response() returns the response from converse."""
         skill = create_skill()


### PR DESCRIPTION
adds the concept of Session to converse pipeline, refactors converse and get_response to be event based and per session, requires https://github.com/OpenVoiceOS/OVOS-workshop/pull/68

see session implementation here https://github.com/OpenVoiceOS/ovos-bus-client/blob/dev/ovos_bus_client/session.py

a session can be a user, a client device, or anything else providing utterances to core. immediate applications are in neon multi user setup (each klat user has a session) and in hivemind (each client has a session)



