### PR TITLE
feat/yaml_support

### DIFF
--- a/mycroft/configuration/config.py
+++ b/mycroft/configuration/config.py
@@ -14,6 +14,7 @@
 #
 import json
 import re
+import yaml
 from os.path import isfile
 from mycroft_bus_client.message import Message
 from mycroft.configuration.locations import *
@@ -91,6 +92,21 @@ class LocalConf(dict):
         if path:
             self.load_local(path)
 
+    @property
+    def file_format(self):
+        """The config file format
+        supported file extensions:
+        - json (.json)
+        - commented json (.conf)
+        - yaml (.yml)
+
+        returns "yaml" or "json"
+        """
+        if self.path.endswith(".yml"):
+            return "yaml"
+        else:
+            return "json"
+
     def load_local(self, path=None):
         """Load local json file into self.
 
@@ -103,7 +119,11 @@ class LocalConf(dict):
             return
         if exists(path) and isfile(path):
             try:
-                config = load_commented_json(path)
+                if self.file_format == "yaml":
+                    with open(path) as f:
+                        config = yaml.safe_load(f)
+                else:
+                    config = load_commented_json(path)
                 for key in config:
                     self.__setitem__(key, config[key])
                 LOG.debug(f"Configuration {path} loaded")
@@ -125,8 +145,13 @@ class LocalConf(dict):
         if not path:
             LOG.error(f"in memory configuration, no save location")
             return
-        with open(path, 'w') as f:
-            json.dump(self, f, indent=2)
+        if self.file_format == "yaml":
+            with open(path, 'w') as f:
+                yaml.dump(self, f, allow_unicode=True,
+                          default_flow_style=False)
+        else:
+            with open(path, 'w') as f:
+                json.dump(self, f, indent=2)
 
     def merge(self, conf):
         merge_dict(self, conf)

--- a/mycroft/configuration/ovos.py
+++ b/mycroft/configuration/ovos.py
@@ -11,7 +11,7 @@ XDG locations are then merged over the select default config (if found)
 Examples config:
 
 {
-   // check xdg directories OR only check old style hardcoded paths 
+   // check xdg directories OR only check old style hardcoded paths
    "xdg": true,
 
    // the "name of the core",
@@ -26,6 +26,10 @@ Examples config:
    //      eg, ovos.conf, chatterbox.conf, neon.conf...
    // "mycroft.conf" paths are derived from this
    //        ~/.{base_folder}/{config_filename}
+   // supported file extensions:
+   //  - json (.json)
+   //  - commented json (.conf)
+   //  - yaml (.yml) are supported
    "config_filename": "mycroft.conf",
 
    // override the default.conf location, allows changing the default values


### PR DESCRIPTION
allow downstream projects to use yaml as their config format, this can be achieved via ovos.conf