### PR TITLE
feat/neon_transformers

### DIFF
--- a/.github/workflows/pipaudit.yml
+++ b/.github/workflows/pipaudit.yml
@@ -1,14 +1,9 @@
-name: Run Build Tests
+name: Run PipAudit
 on:
   push:
     branches:
       - master
-  pull_request:
-    branches:
       - dev
-    paths:
-      - 'requirements/**'
-      - 'setup.py'
   workflow_dispatch:
 
 jobs:
@@ -30,13 +25,14 @@ jobs:
       - name: Install System Dependencies
         run: |
           sudo apt-get update
-          sudo apt install python3-dev swig libssl-dev libfann-dev portaudio19-dev libpulse-dev
-      - name: Build Source Packages
-        run: |
-          python setup.py sdist
-      - name: Build Distribution Packages
-        run: |
-          python setup.py bdist_wheel
+          sudo apt install python3-dev swig libssl-dev
       - name: Install package
         run: |
-          pip install .[mycroft,lgpl,deprecated,skills-essential]
+          pip install .[skills-essential]
+      - uses: pypa/gh-action-pip-audit@v1.0.0
+        with:
+          # Ignore setuptools vulnerability we can't do much about
+          # Ignore numpy vulnerability affecting latest version for Py3.7
+          ignore-vulns: |
+            GHSA-r9hx-vwmv-q579
+            GHSA-fpfv-jqm9-f5jm

--- a/ovos_core/intent_services/adapt_service.py
+++ b/ovos_core/intent_services/adapt_service.py
@@ -19,7 +19,6 @@ import time
 from adapt.context import ContextManagerFrame
 from adapt.engine import IntentDeterminationEngine
 from ovos_config.config import Configuration
-
 import ovos_core.intent_services
 from ovos_utils import flatten_list
 from ovos_utils.log import LOG

--- a/ovos_core/intent_services/adapt_service.py
+++ b/ovos_core/intent_services/adapt_service.py
@@ -13,14 +13,15 @@
 # limitations under the License.
 #
 """An intent parsing service using the Adapt parser."""
-import time
 from threading import Lock
 
+import time
 from adapt.context import ContextManagerFrame
 from adapt.engine import IntentDeterminationEngine
 from ovos_config.config import Configuration
 
 import ovos_core.intent_services
+from ovos_utils import flatten_list
 from ovos_utils.log import LOG
 
 
@@ -211,6 +212,8 @@ class AdaptService:
         Returns:
             Intent structure, or None if no match was found.
         """
+        # we call flatten in case someone is sending the old style list of tuples
+        utterances = flatten_list(utterances)
         lang = lang or self.lang
         if lang not in self.engines:
             return None
@@ -226,21 +229,20 @@ class AdaptService:
                 # TODO - Shouldn't Adapt do this?
                 best_intent['utterance'] = utt
 
-        for utt_tup in utterances:
-            for utt in utt_tup:
-                try:
-                    intents = [i for i in self.engines[lang].determine_intent(
-                        utt, 100,
-                        include_tags=True,
-                        context_manager=self.context_manager)]
-                    if intents:
-                        utt_best = max(
-                            intents, key=lambda x: x.get('confidence', 0.0)
-                        )
-                        take_best(utt_best, utt_tup[0])
+        for utt in utterances:
+            try:
+                intents = [i for i in self.engines[lang].determine_intent(
+                    utt, 100,
+                    include_tags=True,
+                    context_manager=self.context_manager)]
+                if intents:
+                    utt_best = max(
+                        intents, key=lambda x: x.get('confidence', 0.0)
+                    )
+                    take_best(utt_best, utt)
 
-                except Exception as err:
-                    LOG.exception(err)
+            except Exception as err:
+                LOG.exception(err)
 
         if best_intent:
             self.update_context(best_intent)

--- a/ovos_core/intent_services/converse_service.py
+++ b/ovos_core/intent_services/converse_service.py
@@ -1,9 +1,9 @@
 import time
-
+from ovos_bus_client.message import Message
 from ovos_config.config import Configuration
 
 import ovos_core.intent_services
-from ovos_bus_client.message import Message
+from ovos_utils import flatten_list
 from ovos_utils.log import LOG
 from ovos_workshop.permissions import ConverseMode, ConverseActivationMode
 
@@ -252,7 +252,8 @@ class ConverseService:
         Returns:
             IntentMatch if handled otherwise None.
         """
-        utterances = [item for tup in utterances or [] for item in tup]
+        # we call flatten in case someone is sending the old style list of tuples
+        utterances = flatten_list(utterances)
         # filter allowed skills
         self._check_converse_timeout()
         # check if any skill wants to handle utterance

--- a/ovos_core/intent_services/fallback_service.py
+++ b/ovos_core/intent_services/fallback_service.py
@@ -13,12 +13,15 @@
 # limitations under the License.
 #
 """Intent service for Mycroft's fallback system."""
-from collections import namedtuple
-from ovos_config import Configuration
 import operator
+from collections import namedtuple
+
 import time
-from ovos_utils.log import LOG
+from ovos_config import Configuration
+
 import ovos_core.intent_services
+from ovos_utils import flatten_list
+from ovos_utils.log import LOG
 from ovos_workshop.skills.fallback import FallbackMode
 
 FallbackRange = namedtuple('FallbackRange', ['start', 'stop'])
@@ -81,7 +84,7 @@ class FallbackService:
 
         # filter skills outside the fallback_range
         in_range = [s for s, p in self.registered_fallbacks.items()
-                     if fb_range.start < p <= fb_range.stop]
+                    if fb_range.start < p <= fb_range.stop]
         skill_ids += [s for s in self.registered_fallbacks if s not in in_range]
 
         def handle_ack(msg):
@@ -150,9 +153,8 @@ class FallbackService:
         Returns:
             IntentMatch or None
         """
-        # NOTE - utterances here is a list of tuple of [(ut, norm)]
-        # they have been munged along the way... TODO undo the munging at the source
-        utterances = [u[0] for u in utterances]
+        # we call flatten in case someone is sending the old style list of tuples
+        utterances = flatten_list(utterances)
         message.data["utterances"] = utterances  # all transcripts
         message.data["lang"] = lang
 

--- a/ovos_core/transformers.py
+++ b/ovos_core/transformers.py
@@ -1,0 +1,149 @@
+from typing import Optional, List
+
+from ovos_plugin_manager.metadata_transformers import find_metadata_transformer_plugins
+from ovos_plugin_manager.templates.transformers import UtteranceTransformer
+from ovos_plugin_manager.text_transformers import find_utterance_transformer_plugins
+
+from ovos_utils.json_helper import merge_dict
+from ovos_utils.log import LOG
+
+
+class UtteranceTransformersService:
+
+    def __init__(self, bus, config=None):
+        self.config_core = config or {}
+        self.loaded_plugins = {}
+        self.has_loaded = False
+        self.bus = bus
+        self.config = self.config_core.get("utterance_transformers") or {
+            "ovos-utterance-normalizer": {}
+        }
+        self.load_plugins()
+
+    def load_plugins(self):
+        for plug_name, plug in find_utterance_transformer_plugins().items():
+            if plug_name in self.config:
+                # if disabled skip it
+                if not self.config[plug_name].get("active", True):
+                    continue
+                try:
+                    self.loaded_plugins[plug_name] = plug()
+                    LOG.info(f"loaded utterance transformer plugin: {plug_name}")
+                except Exception as e:
+                    LOG.error(e)
+                    LOG.exception(f"Failed to load utterance transformer plugin: {plug_name}")
+
+    @property
+    def plugins(self):
+        """
+        Return loaded transformers in priority order, such that modules with a
+        higher `priority` rank are called first and changes from lower ranked
+        transformers are applied last
+
+        A plugin of `priority` 1 will override any existing context keys and
+        will be the last to modify utterances`
+        """
+        return sorted(self.loaded_plugins.values(),
+                      key=lambda k: k.priority, reverse=True)
+
+    def shutdown(self):
+        for module in self.plugins:
+            try:
+                module.shutdown()
+            except:
+                pass
+
+    def transform(self, utterances: List[str], context: Optional[dict] = None):
+        context = context or {}
+
+        for module in self.plugins:
+            try:
+                utterances, data = module.transform(utterances, context)
+                LOG.debug(f"{module.name}: {data}")
+                context = merge_dict(context, data)
+            except Exception as e:
+                LOG.warning(f"{module.name} transform exception: {e}")
+        return utterances, context
+
+
+class MetadataTransformersService:
+
+    def __init__(self, bus, config=None):
+        self.config_core = config or {}
+        self.loaded_plugins = {}
+        self.has_loaded = False
+        self.bus = bus
+        self.config = self.config_core.get("metadata_transformers") or {}
+        self.load_plugins()
+
+    def load_plugins(self):
+        for plug_name, plug in find_metadata_transformer_plugins().items():
+            if plug_name in self.config:
+                # if disabled skip it
+                if not self.config[plug_name].get("active", True):
+                    continue
+                try:
+                    self.loaded_plugins[plug_name] = plug()
+                    LOG.info(f"loaded metadata transformer plugin: {plug_name}")
+                except Exception as e:
+                    LOG.error(e)
+                    LOG.exception(f"Failed to load metadata transformer plugin: {plug_name}")
+
+    @property
+    def plugins(self):
+        """
+        Return loaded transformers in priority order, such that modules with a
+        higher `priority` rank are called first and changes from lower ranked
+        transformers are applied last.
+
+        A plugin of `priority` 1 will override any existing context keys
+        """
+        return sorted(self.loaded_plugins.values(),
+                      key=lambda k: k.priority, reverse=True)
+
+    def shutdown(self):
+        for module in self.plugins:
+            try:
+                module.shutdown()
+            except:
+                pass
+
+    def transform(self, context: Optional[dict] = None):
+        context = context or {}
+
+        for module in self.plugins:
+            try:
+                data = module.transform(context)
+                LOG.debug(f"{module.name}: {data}")
+                context = merge_dict(context, data)
+            except Exception as e:
+                LOG.warning(f"{module.name} transform exception: {e}")
+        return context
+
+
+class UtteranceNormalizer(UtteranceTransformer):
+
+    def __init__(self, name="ovos-utterance-normalizer", priority=1):
+        super().__init__(name, priority)
+
+    @staticmethod
+    def strip_punctuation(utterance: str):
+        return utterance.rstrip('.').rstrip('?').rstrip('!').rstrip(',').rstrip(';')
+
+    def transform(self, utterances: List[str],
+                  context: Optional[dict] = None) -> (list, dict):
+        context = context or {}
+        norm = [self.strip_punctuation(u) for u in utterances] + utterances
+        try:
+            # TODO - move to ovos-classifiers when it gets it's first stable release
+            # make ovos-lf provide this plugin with a lower priority afterwards
+            from lingua_franca.parse import normalize
+            lang = context.get("lang") or self.config.get("lang", "en-us")
+            norm += [normalize(u, lang=lang, remove_articles=False) for u in norm] + \
+                    [normalize(u, lang=lang, remove_articles=True) for u in norm]
+        except ImportError:
+            LOG.warning("lingua_franca not installed")
+        except:
+            LOG.exception("lingua_franca utterance normalization failed")
+
+        return list(set(norm)), context

--- a/ovos_core/transformers.py
+++ b/ovos_core/transformers.py
@@ -16,7 +16,7 @@ class UtteranceTransformersService:
         self.has_loaded = False
         self.bus = bus
         self.config = self.config_core.get("utterance_transformers") or {
-            "ovos-utterance-normalizer": {}
+            "ovos-lf-utterance-normalizer": {}
         }
         self.load_plugins()
 
@@ -123,7 +123,7 @@ class MetadataTransformersService:
 
 class UtteranceNormalizer(UtteranceTransformer):
 
-    def __init__(self, name="ovos-utterance-normalizer", priority=1):
+    def __init__(self, name="ovos-lf-utterance-normalizer", priority=1):
         super().__init__(name, priority)
 
     @staticmethod

--- a/ovos_core/transformers.py
+++ b/ovos_core/transformers.py
@@ -16,7 +16,8 @@ class UtteranceTransformersService:
         self.has_loaded = False
         self.bus = bus
         self.config = self.config_core.get("utterance_transformers") or {
-            "ovos-utterance-normalizer": {}
+            "ovos-utterance-normalizer": {},
+            "ovos-utterance-coref-normalizer": {}
         }
         self.load_plugins()
 

--- a/ovos_core/transformers.py
+++ b/ovos_core/transformers.py
@@ -16,7 +16,7 @@ class UtteranceTransformersService:
         self.has_loaded = False
         self.bus = bus
         self.config = self.config_core.get("utterance_transformers") or {
-            "ovos-lf-utterance-normalizer": {}
+            "ovos-utterance-normalizer": {}
         }
         self.load_plugins()
 
@@ -121,29 +121,3 @@ class MetadataTransformersService:
         return context
 
 
-class UtteranceNormalizer(UtteranceTransformer):
-
-    def __init__(self, name="ovos-lf-utterance-normalizer", priority=1):
-        super().__init__(name, priority)
-
-    @staticmethod
-    def strip_punctuation(utterance: str):
-        return utterance.rstrip('.').rstrip('?').rstrip('!').rstrip(',').rstrip(';')
-
-    def transform(self, utterances: List[str],
-                  context: Optional[dict] = None) -> (list, dict):
-        context = context or {}
-        norm = [self.strip_punctuation(u) for u in utterances] + utterances
-        try:
-            # TODO - move to ovos-classifiers when it gets it's first stable release
-            # make ovos-lf provide this plugin with a lower priority afterwards
-            from lingua_franca.parse import normalize
-            lang = context.get("lang") or self.config.get("lang", "en-us")
-            norm += [normalize(u, lang=lang, remove_articles=False) for u in norm] + \
-                    [normalize(u, lang=lang, remove_articles=True) for u in norm]
-        except ImportError:
-            LOG.warning("lingua_franca not installed")
-        except:
-            LOG.exception("lingua_franca utterance normalization failed")
-
-        return list(set(norm)), context

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -13,3 +13,6 @@ ovos-config~=0.0,>=0.0.8
 ovos-lingua-franca>=0.4.7
 ovos_backend_client<0.1.0, >=0.0.6
 ovos_workshop<0.1.0, >=0.0.12a17
+
+# provides plugins and classic machine learning framework
+ovos-classifiers<0.1.0, >=0.0.0a3

--- a/setup.py
+++ b/setup.py
@@ -87,6 +87,8 @@ setup(
             'mycroft-enclosure-client=ovos_PHAL.__main__:main',
             'mycroft-cli-client=mycroft.client.text.__main__:main',
             'mycroft-gui-service=mycroft.gui.__main__:main'
-        ]
+        ],
+        # default plugins
+        'neon.plugin.text': 'ovos-utterance-normalizer=ovos_core.transformers:UtteranceNormalizer'
     }
 )

--- a/setup.py
+++ b/setup.py
@@ -89,6 +89,6 @@ setup(
             'mycroft-gui-service=mycroft.gui.__main__:main'
         ],
         # default plugins
-        'neon.plugin.text': 'ovos-utterance-normalizer=ovos_core.transformers:UtteranceNormalizer'
+        'neon.plugin.text': 'ovos-lf-utterance-normalizer=ovos_core.transformers:UtteranceNormalizer'
     }
 )

--- a/setup.py
+++ b/setup.py
@@ -87,8 +87,6 @@ setup(
             'mycroft-enclosure-client=ovos_PHAL.__main__:main',
             'mycroft-cli-client=mycroft.client.text.__main__:main',
             'mycroft-gui-service=mycroft.gui.__main__:main'
-        ],
-        # default plugins
-        'neon.plugin.text': 'ovos-lf-utterance-normalizer=ovos_core.transformers:UtteranceNormalizer'
+        ]
     }
 )

--- a/test/unittests/skills/xformers.py
+++ b/test/unittests/skills/xformers.py
@@ -1,0 +1,112 @@
+import unittest
+from copy import deepcopy
+from unittest.mock import Mock
+
+from ovos_plugin_manager.templates.transformers import UtteranceTransformer
+
+from ovos_utils.messagebus import FakeBus
+
+
+class MockTransformer(UtteranceTransformer):
+
+    def __init__(self):
+        super().__init__("mock_transformer")
+
+    def transform(self, utterances, context=None):
+        return utterances + ["transformer"], {}
+
+
+class MockContextAdder(UtteranceTransformer):
+
+    def __init__(self):
+        super().__init__("mock_context_adder")
+
+    def transform(self, utterances, context=None):
+        return utterances, {"old_context": False,
+                            "new_context": True,
+                            "new_key": "test"}
+
+
+class TextTransformersTests(unittest.TestCase):
+    def test_utterance_transformer_service_load(self):
+        from ovos_core.transformers import UtteranceTransformersService
+        bus = FakeBus()
+        service = UtteranceTransformersService(bus)
+        self.assertIsInstance(service.config, dict)
+        self.assertEqual(service.bus, bus)
+        self.assertFalse(service.has_loaded)
+        self.assertIsInstance(service.loaded_plugins, dict)
+        for plugin in service.loaded_plugins:
+            self.assertIsInstance(service.loaded_plugins[plugin],
+                                  UtteranceTransformer)
+        self.assertIsInstance(service.plugins, list)
+        self.assertEqual(len(service.loaded_plugins), len(service.plugins))
+        service.shutdown()
+
+    def test_utterance_transformer_service_transform(self):
+        from ovos_core.transformers import UtteranceTransformersService
+        bus = FakeBus()
+        service = UtteranceTransformersService(bus)
+        service.loaded_plugins = {"mock_transformer": MockTransformer()}
+        utterances = ["test", "utterance"]
+        context = {"old_context": True,
+                   "new_context": False}
+        utterances, context = service.transform(utterances, context)
+        self.assertEqual(" ".join(utterances), "test utterance transformer")
+        self.assertEqual(context, {"old_context": True,
+                                   "new_context": False})
+
+        service.loaded_plugins["mock_context_adder"] = MockContextAdder()
+        utterances, context = service.transform(utterances, context)
+        self.assertEqual(utterances, ["test", "utterance",
+                                      "transformer", "transformer"])
+        self.assertEqual(context, {"old_context": False,
+                                   "new_context": True,
+                                   "new_key": "test"})
+        service.shutdown()
+
+    def test_utterance_transformer_service_priority(self):
+        from ovos_core.transformers import UtteranceTransformersService
+
+        utterances = ["test 1", "test one"]
+        lang = "en-us"
+
+        def mod_1_parse(utterances, lang):
+            utterances.append("mod 1 parsed")
+            return utterances, {"parser_context": "mod_1"}
+
+        def mod_2_parse(utterances, lang):
+            utterances.append("mod 2 parsed")
+            return utterances, {"parser_context": "mod_2"}
+
+        bus = FakeBus()
+        service = UtteranceTransformersService(bus)
+
+        mod_1 = Mock()
+        mod_1.priority = 2
+        mod_1.transform = mod_1_parse
+        mod_2 = Mock()
+        mod_2.priority = 1
+        mod_2.transform = mod_2_parse
+
+        service.loaded_plugins = \
+            {"test_mod_1": mod_1,
+             "test_mod_2": mod_2}
+
+        # Check transformers adding utterances
+        new_utterances, context = service.transform(deepcopy(utterances),
+                                                    {'lang': lang})
+        self.assertEqual(context["parser_context"], "mod_2")
+        self.assertNotEqual(new_utterances, utterances)
+        self.assertEqual(len(new_utterances),
+                         len(utterances) + 2)
+
+        # Check context change on priority swap
+        mod_2.priority = 100
+        _, context = service.transform(deepcopy(utterances),
+                                       {'lang': lang})
+        self.assertEqual(context["parser_context"], "mod_1")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
integrates https://github.com/NeonGeckoCom/neon-transformers

functionality originally developed over at neon-core

to use add a section to your mycroft.conf, any plugin present will be loaded, config options depend on the plugin itself

example utterance plugins 
- https://github.com/OpenVoiceOS/ovos-classifiers/commit/525641b36f13fa86a9c68eb40647dc32988e6430
- https://github.com/OpenVoiceOS/ovos-classifiers/commit/e8b87b038b447a44c10781e2eac6681a7e08d705
- https://github.com/OpenVoiceOS/ovos-lingua-franca/pull/57
- https://github.com/NeonGeckoCom/neon-utterance-plugin-cancel

sample config
```json
{
    "utterance_transformers": {
            "neon_utterance_cancel_plugin": {},
            "ovos-utterance-normalizer": {}
     }
}
```

utterance transformer plugins base class
```python
from ovos_plugin_manager.templates.transformers import UtteranceTransformer

class MyUtteranceHandler(UtteranceTransformer):

    def initialize(self):
        """ perform any initialization actions """
        pass

    def transform(self, utterances: List[str],
                  context: dict = None) -> (list, dict):
        """
        Optionally transform passed utterances and/or return additional context
        :param utterances: List of str utterances to parse
        :param context: existing Message context associated with utterances
        :returns: tuple of (possibly modified utterances, additional context)
        """
        return utterances, {}

    def default_shutdown(self):
        """ perform any shutdown actions """
        pass
```

metadata transformer plugin template
```python
from ovos_plugin_manager.templates.transformers import MetadataTransformer

class MyMessageContextHandler(MetadataTransformer):

    def initialize(self):
        """ perform any initialization actions """
        pass

    def transform(self, context: dict = None) -> (dict):
        """
        Optionally transform passed context
        eg. inject default values or convert metadata format
        :param context: existing Message context from all previous transformers
        :returns: dict of possibly modified or additional context
        """
        context = context or {}
        return context

    def default_shutdown(self):
        """ perform any shutdown actions """
        pass
```

an equivalent for audio is already available in ovos-dinkum-listener, a PR is needed in ovos-listener


audio transformer plugin template
```python
from ovos_plugin_manager.templates.transformers import AudioTransformer


class MyAudioHandler(AudioTransformer):
    """process audio data and optionally transform it before STT stage"""

    def initialize(self):
        """ perform any initialization actions """
        pass

    def on_audio(self, audio_data):
        """ Take any action you want, audio_data is a non-speech chunk
        """
        return audio_data

    def on_hotword(self, audio_data):
        """ Take any action you want, audio_data is a full wake/hotword
        Common action would be to prepare to received speech chunks
        NOTE: this might be a hotword or a wakeword, listening is not assured
        """
        return audio_data

    def on_speech(self, audio_data):
        """ Take any action you want, audio_data is a speech chunk (NOT a
        full utterance) during recording
        """
        return audio_data

    def on_speech_end(self, audio_data):
        """ Take any action you want, audio_data is the full speech audio
        """
        return audio_data

    def transform(self, audio_data):
        """ return any additional message context to be passed in
        recognize_loop:utterance message, usually a streaming prediction
        Optionally make the prediction here with saved chunks from other handlers
        """
        return audio_data, {}

    def default_shutdown(self):
        """ perform any shutdown actions """
        pass
```