### PR TITLE
Prevent duplicate language intent registration

### DIFF
--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -402,7 +402,9 @@ class MycroftSkill:
         NOTE: this should be public, but since if a skill uses this it wont
         work in regular mycroft-core it was made private!
         """
-        return [self._core_lang] + self._secondary_langs
+        valid = set([l.lower() for l in self._secondary_langs
+                 if '-' in l and l != self._core_lang] + [self._core_lang])
+        return list(valid)
 
     @property
     def _alphanumeric_skill_id(self):

--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -388,8 +388,10 @@ class MycroftSkill:
     @property
     def _secondary_langs(self):
         """Get the configured secondary languages, mycroft is not
-        considered to be in these languages but i will load it's resource
-        files. This provides initial support for multilingual input
+        considered to be in these languages, but will load its resource
+        files. This provides initial support for multilingual input. A skill
+        may override this method to specify which languages intents are
+        registered in.
         NOTE: this should be public, but since if a skill uses this it wont
         work in regular mycroft-core it was made private!"""
         return [l.lower() for l in self.config_core.get('secondary_langs', [])
@@ -403,7 +405,7 @@ class MycroftSkill:
         work in regular mycroft-core it was made private!
         """
         valid = set([l.lower() for l in self._secondary_langs
-                 if '-' in l and l != self._core_lang] + [self._core_lang])
+                     if '-' in l and l != self._core_lang] + [self._core_lang])
         return list(valid)
 
     @property

--- a/test/unittests/skills/test_mycroft_skill.py
+++ b/test/unittests/skills/test_mycroft_skill.py
@@ -601,6 +601,17 @@ class TestMycroftSkill(unittest.TestCase):
         # Restore lang to en-us
         s.config_core['lang'] = 'en-us'
 
+    def test_native_langs(self):
+        s = SimpleSkill1()
+        s.config_core['lang'] = 'en-US'
+        s.config_core['secondary_langs'] = ['en', 'en-us', 'en-AU',
+                                            'es', 'pt-PT']
+        self.assertEqual(s.lang, 'en-us')
+        self.assertEqual(s._secondary_langs, ['en', 'en-au', 'es',
+                                              'pt-pt'])
+        self.assertEqual(len(s._native_langs), len(set(s._native_langs)))
+        self.assertEqual(set(s._native_langs), {'en-us', 'en-au', 'pt-pt'})
+
 
 class _TestSkill(MycroftSkill):
     def __init__(self):

--- a/test/unittests/skills/test_mycroft_skill.py
+++ b/test/unittests/skills/test_mycroft_skill.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
 import json
 import sys
 import unittest
@@ -22,7 +23,7 @@ from re import error
 from unittest.mock import MagicMock, patch
 
 from adapt.intent import IntentBuilder
-
+from copy import deepcopy
 from mycroft.configuration import Configuration
 from mycroft.messagebus.message import Message
 from mycroft.skills.core import MycroftSkill, resting_screen_handler
@@ -602,7 +603,10 @@ class TestMycroftSkill(unittest.TestCase):
         s.config_core['lang'] = 'en-us'
 
     def test_native_langs(self):
-        s = SimpleSkill1()
+        s = _TestSkill()
+        lang = s.config_core['lang']
+        secondary = s.config_core['secondary_langs']
+
         s.config_core['lang'] = 'en-US'
         s.config_core['secondary_langs'] = ['en', 'en-us', 'en-AU',
                                             'es', 'pt-PT']
@@ -611,6 +615,8 @@ class TestMycroftSkill(unittest.TestCase):
                                               'pt-pt'])
         self.assertEqual(len(s._native_langs), len(set(s._native_langs)))
         self.assertEqual(set(s._native_langs), {'en-us', 'en-au', 'pt-pt'})
+        s.config_core['lang'] = lang
+        s.config_core['secondary_langs'] = secondary
 
 
 class _TestSkill(MycroftSkill):


### PR DESCRIPTION
Update `_native_langs` to ensure a list of unique full language codes is returned

**This enforces full language codes and tosses anything without a region (i.e. en is invalid). Should this try to use default regions from LF?**