### PR TITLE
refactor/native_sources

### DIFF
--- a/mycroft/audio/audioservice.py
+++ b/mycroft/audio/audioservice.py
@@ -330,7 +330,9 @@ class AudioService:
             return True
         destination = message.context.get("destination")
         if destination:
-            if "audio" in destination or "debug_cli" in destination:
+            native_sources = Configuration()["Audio"].get(
+                "native_sources", ["debug_cli", "audio"]) or []
+            if any(s in destination for s in native_sources):
                 # request from device
                 return True
             # external request, do not handle

--- a/mycroft/audio/service.py
+++ b/mycroft/audio/service.py
@@ -47,6 +47,8 @@ class PlaybackService(Thread):
         self.status.set_started()
 
         self.config = Configuration()
+        self.native_sources = self.config["Audio"].get("native_sources",
+                                                       ["debug_cli", "audio"]) or []
         self.tts = None
         self._tts_hash = None
         self.lock = Lock()
@@ -95,8 +97,7 @@ class PlaybackService(Thread):
         # don't synthesise speech
         message.context = message.context or {}
         if message.context.get('destination') and not \
-                ('debug_cli' in message.context['destination'] or
-                 'audio' in message.context['destination']):
+                any(s in message.context['destination'] for s in self.native_sources):
             return
 
         # Get conversation ID

--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -487,6 +487,11 @@
   },
 
   "Audio": {
+    // message.context may contains a source and destination
+    // native audio (playback / TTS) will only be played if a
+    // message destination is a native_source or if missing (considered a broadcast)
+    "native_sources": ["debug_cli", "audio"],
+
     "backends": {
       "OCP": {
         "type": "ovos_common_play",


### PR DESCRIPTION
historically "audio" and "debug_cli" have been the hardcoded message source/destinations considered native, ie, only those would trigger audio playback for TTS, more info https://github.com/JarbasHiveMind/HiveMind-core/wiki/Mycroft-Messages

nowadays alternative clients exist and this should be made configurable,

Anecdotally, I personally dislike the debug_cli triggering audio, If I am debugging I usually have my own audio playing already and don't want interruptions