### PR TITLE
refactor/gui_cleanup

### DIFF
--- a/mycroft/gui/bus.py
+++ b/mycroft/gui/bus.py
@@ -56,7 +56,7 @@ def create_gui_service(enclosure) -> Application:
     parse_command_line(['--logging=None'])
 
     routes = [(websocket_config['route'], GUIWebsocketHandler)]
-    application = Application(routes, debug=True)
+    application = Application(routes)
     application.enclosure = enclosure
     application.listen(
         websocket_config['base_port'], websocket_config['host']

--- a/mycroft/gui/namespace.py
+++ b/mycroft/gui/namespace.py
@@ -46,13 +46,13 @@ from typing import List, Union
 from ovos_config.config import Configuration
 from mycroft.messagebus import Message, MessageBusClient
 from mycroft.util.log import LOG
-from .bus import (
+from mycroft.gui.bus import (
     create_gui_service,
     determine_if_gui_connected,
     get_gui_websocket_config,
     send_message_to_gui
 )
-from .page import GuiPage
+from mycroft.gui.page import GuiPage
 import sys
 
 namespace_lock = Lock()
@@ -209,7 +209,7 @@ class Namespace:
         new_pages = list()
 
         for page in pages:
-            if page.url not in [page.url for page in self.pages]:
+            if page.url not in [p.url for p in self.pages]:
                 new_pages.append(page)
 
         self.pages.extend(new_pages)
@@ -287,7 +287,7 @@ class Namespace:
         Args:
             positions: page position to remove
         """
-        print(f"Removing pages from GUI namespace {self.name}: {positions}")
+        LOG.info(f"Removing pages from GUI namespace {self.name}: {positions}")
         for position in positions:
             page = self.pages.pop(position)
             LOG.info(f"Deleting {page} from GUI namespace {self.name}")

--- a/mycroft/gui/service.py
+++ b/mycroft/gui/service.py
@@ -1,7 +1,7 @@
 from mycroft.messagebus.client import MessageBusClient
 from mycroft.util import start_message_bus_client
 from mycroft.util.log import LOG
-from .namespace import NamespaceManager
+from mycroft.gui.namespace import NamespaceManager
 from mycroft.gui.extensions import ExtensionsManager
 from mycroft.util.process_utils import ProcessStatus, StatusCallbackMap, ProcessState
 


### PR DESCRIPTION
- fix bus in load_pages due to variable name collision
- remove debug flag from tornado listener (makes websocket reload and crash during dev when unrelated files change, very annoying)
- use explicit imports for consistency
- replace print with log