### PR TITLE
refactor/padacioso

### DIFF
--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -483,7 +483,7 @@
     "intent_cache": "~/.local/share/mycroft/intent_cache",
     "train_delay": 4,
     "single_thread": false,
-    "padaos_only": false
+    "regex_only": false
   },
 
   "Audio": {

--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -483,7 +483,9 @@
     "intent_cache": "~/.local/share/mycroft/intent_cache",
     "train_delay": 4,
     "single_thread": false,
-    "regex_only": false
+    // fallback settings for padacioso (pure regex)
+    "regex_only": false,
+    "fuzz": true
   },
 
   "Audio": {

--- a/mycroft/skills/intent_service_interface.py
+++ b/mycroft/skills/intent_service_interface.py
@@ -146,7 +146,7 @@ class IntentServiceInterface:
         if not isinstance(filename, str):
             raise ValueError('Filename path must be a string')
         if not exists(filename):
-            raise FileNotFoundError('Unable to find "{}"'.format(filename))
+            raise FileNotFoundError(f'Unable to find "{filename}"')
 
         data = {'file_name': filename,
                 'name': intent_name,

--- a/requirements/extra-skills-lgpl.txt
+++ b/requirements/extra-skills-lgpl.txt
@@ -1,5 +1,5 @@
 adapt-parser~=0.5
-padacioso
+padacioso~=0.1.2
 ovos-lingua-franca~=0.4, >=0.4.2
 PyYAML~=5.4
 ovos_workshop~=0.0, >=0.0.7a9

--- a/requirements/extra-skills-lgpl.txt
+++ b/requirements/extra-skills-lgpl.txt
@@ -1,5 +1,5 @@
 adapt-parser~=0.5
-padaos~=0.1
+padacioso
 ovos-lingua-franca~=0.4, >=0.4.2
 PyYAML~=5.4
 ovos_workshop~=0.0, >=0.0.7a9

--- a/requirements/extra-skills.txt
+++ b/requirements/extra-skills.txt
@@ -1,5 +1,5 @@
 adapt-parser~=0.5
-padacioso
+padacioso~=0.1.2
 ovos-lingua-franca~=0.4, >=0.4.2
 PyYAML~=5.4
 ovos_workshop~=0.0, >=0.0.7a9

--- a/requirements/extra-skills.txt
+++ b/requirements/extra-skills.txt
@@ -1,5 +1,5 @@
 adapt-parser~=0.5
-padaos~=0.1
+padacioso
 ovos-lingua-franca~=0.4, >=0.4.2
 PyYAML~=5.4
 ovos_workshop~=0.0, >=0.0.7a9

--- a/test/unittests/skills/test_utterance_intents.py
+++ b/test/unittests/skills/test_utterance_intents.py
@@ -1,18 +1,16 @@
 import unittest
-
-from adapt.intent import IntentBuilder
-from mycroft.skills.intent_service_interface import IntentServiceInterface
 from mycroft.skills.intent_services.padatious_service import PadatiousService, FallbackIntentContainer
 from mycroft_bus_client.message import Message
 from ovos_utils.messagebus import FakeBus
 
 
 class UtteranceIntentMatchingTest(unittest.TestCase):
-    def get_service(self, regex_only=False):
+    def get_service(self, regex_only=False, fuzz=True):
         intent_service = PadatiousService(FakeBus(),
                                           {"regex_only": regex_only,
                                            "intent_cache": "~/.local/share/mycroft/intent_cache",
                                            "train_delay": 1,
+                                           "fuzz": fuzz,
                                            "single_thread": True,
                                            })
         # register test intents
@@ -34,7 +32,7 @@ class UtteranceIntentMatchingTest(unittest.TestCase):
         intent_service = self.get_service()
 
         # assert padatious is loaded not padacioso
-        self.assertFalse(intent_service._regex_only)
+        self.assertFalse(intent_service.is_regex_only)
         for container in intent_service.containers.values():
             self.assertFalse(isinstance(container, FallbackIntentContainer))
 
@@ -42,16 +40,31 @@ class UtteranceIntentMatchingTest(unittest.TestCase):
         intent = intent_service.calc_intent("this is a test", "en-US")
         self.assertEqual(intent.name, "test")
 
+        # fuzzy match
+        intent = intent_service.calc_intent("this test", "en-US")
+        self.assertEqual(intent.name, "test")
+        self.assertTrue(intent.conf <= 0.8)
+
         # regex match
         intent = intent_service.calc_intent("tell me about Mycroft", "en-US")
         self.assertEqual(intent.name, "test2")
         self.assertEqual(intent.matches, {'thing': 'Mycroft'})
 
+        # fuzzy regex match - success
+        intent = intent_service.calc_intent("tell me everything about Mycroft", "en-US")
+        self.assertEqual(intent.name, "test2")
+        # TODO - why are extracted entities lower case ???
+        # i think case depends on padaos vs padatious matching internally
+        # padaos (exact matches only) -> keep case
+        # padatious -> lower case
+        self.assertEqual(intent.matches, {'thing': 'mycroft'})
+        self.assertTrue(intent.conf <= 0.9)
+
     def test_regex_intent(self):
-        intent_service = self.get_service(regex_only=True)
+        intent_service = self.get_service(regex_only=True, fuzz=False)
 
         # assert padacioso is loaded not padatious
-        self.assertTrue(intent_service._regex_only)
+        self.assertTrue(intent_service.is_regex_only)
         for container in intent_service.containers.values():
             self.assertTrue(isinstance(container, FallbackIntentContainer))
 
@@ -63,4 +76,27 @@ class UtteranceIntentMatchingTest(unittest.TestCase):
         intent = intent_service.calc_intent("tell me about Mycroft", "en-US")
         self.assertEqual(intent.name, "test2")
         self.assertEqual(intent.matches, {'thing': 'Mycroft'})
+
+        # fuzzy match - failure case (no fuzz)
+        intent = intent_service.calc_intent("this is test", "en-US")
+        self.assertTrue(intent.name is None)
+
+        # fuzzy regex match - failure case (no fuzz)
+        intent = intent_service.calc_intent("tell me everything about Mycroft", "en-US")
+        self.assertTrue(intent.name is None)
+
+    def test_regex_fuzz_intent(self):
+        intent_service = self.get_service(regex_only=True, fuzz=True)
+
+        # fuzzy match - success
+        intent = intent_service.calc_intent("this is test", "en-US")
+        self.assertEqual(intent.name, "test")
+        self.assertTrue(intent.conf <= 0.8)
+
+        # fuzzy regex match - success
+        intent = intent_service.calc_intent("tell me everything about Mycroft", "en-US")
+        self.assertEqual(intent.name, "test2")
+        self.assertEqual(intent.matches, {'thing': 'Mycroft'})
+        self.assertTrue(intent.conf <= 0.8)
+
 

--- a/test/unittests/skills/test_utterance_intents.py
+++ b/test/unittests/skills/test_utterance_intents.py
@@ -1,0 +1,66 @@
+import unittest
+
+from adapt.intent import IntentBuilder
+from mycroft.skills.intent_service_interface import IntentServiceInterface
+from mycroft.skills.intent_services.padatious_service import PadatiousService, FallbackIntentContainer
+from mycroft_bus_client.message import Message
+from ovos_utils.messagebus import FakeBus
+
+
+class UtteranceIntentMatchingTest(unittest.TestCase):
+    def get_service(self, regex_only=False):
+        intent_service = PadatiousService(FakeBus(),
+                                          {"regex_only": regex_only,
+                                           "intent_cache": "~/.local/share/mycroft/intent_cache",
+                                           "train_delay": 1,
+                                           "single_thread": True,
+                                           })
+        # register test intents
+        filename = "/tmp/test.intent"
+        with open(filename, "w") as f:
+            f.write("this is a test\ntest the intent\nexecute test")
+        rxfilename = "/tmp/test2.intent"
+        with open(rxfilename, "w") as f:
+            f.write("tell me about {thing}\nwhat is {thing}")
+        data = {'file_name': filename, 'lang': 'en-US', 'name': 'test'}
+        intent_service.register_intent(Message("padatious:register_intent", data))
+        data = {'file_name': rxfilename, 'lang': 'en-US', 'name': 'test2'}
+        intent_service.register_intent(Message("padatious:register_intent", data))
+        intent_service.train()
+
+        return intent_service
+
+    def test_padatious_intent(self):
+        intent_service = self.get_service()
+
+        # assert padatious is loaded not padacioso
+        self.assertFalse(intent_service._regex_only)
+        for container in intent_service.containers.values():
+            self.assertFalse(isinstance(container, FallbackIntentContainer))
+
+        # exact match
+        intent = intent_service.calc_intent("this is a test", "en-US")
+        self.assertEqual(intent.name, "test")
+
+        # regex match
+        intent = intent_service.calc_intent("tell me about Mycroft", "en-US")
+        self.assertEqual(intent.name, "test2")
+        self.assertEqual(intent.matches, {'thing': 'Mycroft'})
+
+    def test_regex_intent(self):
+        intent_service = self.get_service(regex_only=True)
+
+        # assert padacioso is loaded not padatious
+        self.assertTrue(intent_service._regex_only)
+        for container in intent_service.containers.values():
+            self.assertTrue(isinstance(container, FallbackIntentContainer))
+
+        # exact match
+        intent = intent_service.calc_intent("this is a test", "en-US")
+        self.assertEqual(intent.name, "test")
+
+        # regex match
+        intent = intent_service.calc_intent("tell me about Mycroft", "en-US")
+        self.assertEqual(intent.name, "test2")
+        self.assertEqual(intent.matches, {'thing': 'Mycroft'})
+


### PR DESCRIPTION
because fann2 is copyleft it was made optional in ovos-core, padaos was used instead of padatious

however padaos is very rigid and made intents virtually unusable, this replaces it with padacioso which is already a dependency dragged by OCP. It should be a little more usable and a drop in replacement

this is a temporary measure until https://github.com/OpenVoiceOS/ovos-core/pull/100 is merged in version 0.0.5

companion PR https://github.com/OpenJarbas/padacioso/pull/1 

also check [padacioso unittests](https://github.com/OpenJarbas/padacioso/blob/master/test/test_padacioso.py) 