### PR TITLE
feat/common_query_tests

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -54,7 +54,6 @@ jobs:
       - name: Install test dependencies
         run: |
           pip install -r requirements/tests.txt
-          pip install git+https://github.com/OpenVoiceOS/skill-ovos-common-query
           pip install ./test/unittests/common_query/ovos_tskill_fakewiki
       - name: Run unittests
         run: |

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -54,6 +54,8 @@ jobs:
       - name: Install test dependencies
         run: |
           pip install -r requirements/tests.txt
+          pip install git+https://github.com/OpenVoiceOS/skill-ovos-common-query
+          pip install ./test/unittests/common_query/ovos_tskill_fakewiki
       - name: Run unittests
         run: |
           pytest --cov=mycroft --cov-report xml test/unittests

--- a/mycroft/skills/intent_services/commonqa_service.py
+++ b/mycroft/skills/intent_services/commonqa_service.py
@@ -32,6 +32,7 @@ class CommonQAService:
         self.enclosure = EnclosureAPI(self.bus, self.skill_id)
         self._vocabs = {}
         self.bus.on('question:query.response', self.handle_query_response)
+        self.bus.on('common_query.question', self.handle_question)
 
     def voc_match(self, utterance, voc_filename, lang, exact=False):
         """Determine if the given utterance contains the vocabulary provided.
@@ -169,7 +170,7 @@ class CommonQAService:
 
         # Prevent any late-comers from retriggering this query handler
         with self.lock:
-            LOG.info('Timeout occured check responses')
+            LOG.info('Timeout occurred check responses')
             search_phrase = message.data.get('phrase', "")
             if search_phrase in self.query_extensions:
                 self.query_extensions[search_phrase] = []

--- a/test/unittests/common_query/ovos_tskill_fakewiki/__init__.py
+++ b/test/unittests/common_query/ovos_tskill_fakewiki/__init__.py
@@ -1,0 +1,66 @@
+from adapt.intent import IntentBuilder
+
+from mycroft.skills.common_query_skill import CommonQuerySkill, CQSMatchLevel
+from mycroft.skills.core import intent_handler
+
+
+class FakeWikiSkill(CommonQuerySkill):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.displayed = False
+        self.idx = 0
+        self.results = []
+
+    # explicit intents
+    @intent_handler("search_fakewiki.intent")
+    def handle_search(self, message):
+        query = message.data["query"]
+        self.ask_the_wiki(query)
+        if self.results:
+            self.speak_result()
+        else:
+            self.speak_dialog("no_answer")
+
+    @intent_handler(IntentBuilder("FakeWikiMore").require("More").
+                    require("FakeWikiKnows"))
+    def handle_tell_more(self, message):
+        """ Follow up query handler, "tell me more"."""
+        self.speak_result()
+
+    def speak_result(self):
+        if self.idx + 1 > len(self.results):
+            self.speak_dialog("thats all")
+            self.remove_context("FakeWikiKnows")
+            self.idx = 0
+        else:
+            self.display_fakewiki()
+            ans = self.results[self.idx]
+            self.speak(ans)
+            self.idx += 1
+
+    # common query integration
+    def CQS_match_query_phrase(self, utt):
+        self.log.debug("FakeWiki query: " + utt)
+        response = self.ask_the_wiki(utt)[0]
+        self.idx += 1  # spoken by common query framework
+        return (utt, CQSMatchLevel.GENERAL, response,
+                {'query': utt, 'answer': response})
+
+    def CQS_action(self, phrase, data):
+        """ If selected show gui """
+        self.display_fakewiki()
+
+    # fakewiki integration
+    def ask_the_wiki(self, query):
+        # context for follow up questions
+        self.set_context("FakeWikiKnows", query)
+        self.idx = 0
+        self.results = ["answer 1", "answer 2"]
+        return self.results
+
+    def display_fakewiki(self):
+        self.displayed = True
+
+
+def create_skill():
+    return FakeWikiSkill()

--- a/test/unittests/common_query/ovos_tskill_fakewiki/locale/en-us/More.voc
+++ b/test/unittests/common_query/ovos_tskill_fakewiki/locale/en-us/More.voc
@@ -1,0 +1,4 @@
+know more
+tell me more
+tell more
+continue

--- a/test/unittests/common_query/ovos_tskill_fakewiki/locale/en-us/no_answer.dialog
+++ b/test/unittests/common_query/ovos_tskill_fakewiki/locale/en-us/no_answer.dialog
@@ -1,0 +1,1 @@
+the archives are incomplete

--- a/test/unittests/common_query/ovos_tskill_fakewiki/locale/en-us/search_fakewiki.intent
+++ b/test/unittests/common_query/ovos_tskill_fakewiki/locale/en-us/search_fakewiki.intent
@@ -1,0 +1,9 @@
+search wiki for {query}
+search wiki for {query}
+ask the wiki about {query}
+ask the wiki about {query}
+what does wiki say about {query}
+what does wiki say about {query}
+ask the wiki {query}
+search the wiki for {query}
+what does the wiki say about {query}

--- a/test/unittests/common_query/ovos_tskill_fakewiki/setup.py
+++ b/test/unittests/common_query/ovos_tskill_fakewiki/setup.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+from setuptools import setup
+
+# skill_id=package_name:SkillClass
+PLUGIN_ENTRY_POINT = 'ovos-tskill-fakewiki.openvoiceos=ovos_tskill_fakewiki:FakeWikiSkill'
+
+setup(
+    # this is the package name that goes on pip
+    name='ovos-tskill-fakewiki',
+    version='0.0.1',
+    description='this is a OVOS test skill for the common query framework',
+    url='https://github.com/OpenVoiceOS/ovos-core',
+    author='JarbasAi',
+    author_email='jarbasai@mailfence.com',
+    license='Apache-2.0',
+    package_dir={"ovos_tskill_fakewiki": ""},
+    package_data={'ovos_tskill_fakewiki': ['locale/*']},
+    packages=['ovos_tskill_fakewiki'],
+    include_package_data=True,
+    install_requires=["ovos-workshop"],
+    keywords='ovos skill plugin',
+    entry_points={'ovos.plugin.skill': PLUGIN_ENTRY_POINT}
+)

--- a/test/unittests/common_query/test_common_query.py
+++ b/test/unittests/common_query/test_common_query.py
@@ -1,0 +1,137 @@
+import json
+import unittest
+
+from ovos_skill_common_query import QuestionsAnswersSkill
+
+from mycroft.skills import FallbackSkill
+from ovos_tskill_fakewiki import FakeWikiSkill
+from ovos_utils.messagebus import FakeBus, Message
+
+
+class TestCommonQuery(unittest.TestCase):
+    def setUp(self):
+        self.bus = FakeBus()
+        self.bus.emitted_msgs = []
+
+        def get_msg(msg):
+            self.bus.emitted_msgs.append(json.loads(msg))
+
+        self.bus.on("message", get_msg)
+
+        self.skill = FakeWikiSkill()
+        self.skill._startup(self.bus, "wiki.test")
+
+        self.bus.emitted_msgs = []
+
+        self.cc = QuestionsAnswersSkill()
+        self.cc._startup(self.bus, "common_query.test")
+
+    def test_skill_id(self):
+        self.assertEqual(self.cc.skill_id, "common_query.test")
+
+        # if running in ovos-core every message will have the skill_id in context
+        for msg in self.bus.emitted_msgs:
+            self.assertEqual(msg["context"]["skill_id"], "common_query.test")
+
+    def test_intent_register(self):
+        # helper .voc files only, no intents
+        self.assertTrue(isinstance(self.cc, FallbackSkill))
+
+        adapt_ents = ["common_query_testQuestion"]
+        for msg in self.bus.emitted_msgs:
+            if msg["type"] == "register_vocab":
+                self.assertTrue(msg["data"]["entity_type"] in adapt_ents)
+
+    def test_registered_events(self):
+        registered_events = [e[0] for e in self.cc.events]
+
+        # common query event handlers
+        common_query = ['question:query.response']
+        for event in common_query:
+            self.assertTrue(event in registered_events)
+
+        # base skill class events shared with mycroft-core
+        default_skill = ["mycroft.skill.enable_intent",
+                         "mycroft.skill.disable_intent",
+                         "mycroft.skill.set_cross_context",
+                         "mycroft.skill.remove_cross_context",
+                         "intent.service.skills.deactivated",
+                         "intent.service.skills.activated",
+                         "mycroft.skills.settings.changed"]
+        for event in default_skill:
+            self.assertTrue(event in registered_events)
+
+        # base skill class events exclusive to ovos-core
+        default_ovos = ["skill.converse.ping",
+                        "skill.converse.request",
+                        f"{self.cc.skill_id}.activate",
+                        f"{self.cc.skill_id}.deactivate"]
+        for event in default_ovos:
+            self.assertTrue(event in registered_events)
+
+    def test_common_query_events(self):
+        self.bus.emitted_msgs = []
+        self.cc.handle_question(Message("fallback_cycle_test",
+                                        {"utterance": "what is the speed of light"}))
+
+        expected = [
+            # thinking animation
+            {'type': 'enclosure.mouth.think',
+             'data': {},
+             'context': {'destination': ['enclosure'],
+                         'skill_id': 'common_query.test'}},
+            # send query
+            {'type': 'question:query',
+             'data': {'phrase': 'what is the speed of light'},
+             'context': {'skill_id': 'common_query.test'}},
+            # skill announces its searching
+            {'type': 'question:query.response',
+             'data': {'phrase': 'what is the speed of light',
+                      'skill_id': 'wiki.test',
+                      'searching': True},
+             'context': {'skill_id': 'wiki.test'}},
+            # skill context set by skill for continuous dialog
+            {'type': 'add_context',
+             'data': {'context': 'wiki_testFakeWikiKnows',
+                      'word': 'what is the speed of light',
+                      'origin': ''},
+             'context': {'skill_id': 'wiki.test'}},
+            # final response
+            {'type': 'question:query.response',
+             'data': {'phrase': 'what is the speed of light',
+                      'skill_id': 'wiki.test',
+                      'answer': "answer 1",
+                      'callback_data': {'query': 'what is the speed of light',
+                                        'answer': "answer 1"},
+                      'conf': 0.74},
+             'context': {'skill_id': 'wiki.test'}},
+            # stop thinking animation
+            {'type': 'enclosure.mouth.reset',
+             'data': {},
+             'context': {'destination': ['enclosure'],
+                         'skill_id': 'common_query.test'}
+             },
+            # tell enclosure about active skill (speak method)
+            {'type': 'enclosure.active_skill',
+             'data': {'skill_id': 'common_query.test'},
+             'context': {'destination': ['enclosure'],
+                         'skill_id': 'common_query.test'}},
+            # execution of speak method
+            {'type': 'speak',
+             'data': {'utterance': 'answer 1',
+                      'expect_response': False,
+                      'meta': {'skill': 'common_query.test'},
+                      'lang': 'en-us'},
+             'context': {'skill_id': 'common_query.test'}},
+            # skill callback event
+            {'type': 'question:action',
+             'data': {'skill_id': 'wiki.test',
+                      'phrase': 'what is the speed of light',
+                      'callback_data': {'query': 'what is the speed of light',
+                                        'answer': 'answer 1'}},
+             'context': {'skill_id': 'common_query.test'}}
+        ]
+
+        for ctr, msg in enumerate(expected):
+            m = self.bus.emitted_msgs[ctr]
+            self.assertEqual(msg, m)

--- a/test/unittests/common_query/test_common_query.py
+++ b/test/unittests/common_query/test_common_query.py
@@ -1,9 +1,7 @@
 import json
 import unittest
 
-from ovos_skill_common_query import QuestionsAnswersSkill
-
-from mycroft.skills import FallbackSkill
+from mycroft.skills.intent_services.commonqa_service import CommonQAService
 from ovos_tskill_fakewiki import FakeWikiSkill
 from ovos_utils.messagebus import FakeBus, Message
 
@@ -16,74 +14,34 @@ class TestCommonQuery(unittest.TestCase):
         def get_msg(msg):
             self.bus.emitted_msgs.append(json.loads(msg))
 
-        self.bus.on("message", get_msg)
-
         self.skill = FakeWikiSkill()
         self.skill._startup(self.bus, "wiki.test")
 
-        self.bus.emitted_msgs = []
+        self.cc = CommonQAService(self.bus)
 
-        self.cc = QuestionsAnswersSkill()
-        self.cc._startup(self.bus, "common_query.test")
-
-    def test_skill_id(self):
-        self.assertEqual(self.cc.skill_id, "common_query.test")
-
-        # if running in ovos-core every message will have the skill_id in context
-        for msg in self.bus.emitted_msgs:
-            self.assertEqual(msg["context"]["skill_id"], "common_query.test")
-
-    def test_intent_register(self):
-        # helper .voc files only, no intents
-        self.assertTrue(isinstance(self.cc, FallbackSkill))
-
-        adapt_ents = ["common_query_testQuestion"]
-        for msg in self.bus.emitted_msgs:
-            if msg["type"] == "register_vocab":
-                self.assertTrue(msg["data"]["entity_type"] in adapt_ents)
-
-    def test_registered_events(self):
-        registered_events = [e[0] for e in self.cc.events]
-
-        # common query event handlers
-        common_query = ['question:query.response']
-        for event in common_query:
-            self.assertTrue(event in registered_events)
-
-        # base skill class events shared with mycroft-core
-        default_skill = ["mycroft.skill.enable_intent",
-                         "mycroft.skill.disable_intent",
-                         "mycroft.skill.set_cross_context",
-                         "mycroft.skill.remove_cross_context",
-                         "intent.service.skills.deactivated",
-                         "intent.service.skills.activated",
-                         "mycroft.skills.settings.changed"]
-        for event in default_skill:
-            self.assertTrue(event in registered_events)
-
-        # base skill class events exclusive to ovos-core
-        default_ovos = ["skill.converse.ping",
-                        "skill.converse.request",
-                        f"{self.cc.skill_id}.activate",
-                        f"{self.cc.skill_id}.deactivate"]
-        for event in default_ovos:
-            self.assertTrue(event in registered_events)
+        self.bus.on("message", get_msg)
 
     def test_common_query_events(self):
         self.bus.emitted_msgs = []
-        self.cc.handle_question(Message("fallback_cycle_test",
-                                        {"utterance": "what is the speed of light"}))
+        self.assertEqual(self.cc.skill_id, "common_query.openvoiceos")
+
+        self.bus.emit(Message("common_query.question",
+                              {"utterance": "what is the speed of light"}))
 
         expected = [
+            # original query
+            {'context': {},
+             'data': {'utterance': 'what is the speed of light'},
+             'type': 'common_query.question'},
             # thinking animation
             {'type': 'enclosure.mouth.think',
              'data': {},
              'context': {'destination': ['enclosure'],
-                         'skill_id': 'common_query.test'}},
+                         'skill_id': self.cc.skill_id}},
             # send query
             {'type': 'question:query',
              'data': {'phrase': 'what is the speed of light'},
-             'context': {'skill_id': 'common_query.test'}},
+             'context': {'skill_id': self.cc.skill_id}},
             # skill announces its searching
             {'type': 'question:query.response',
              'data': {'phrase': 'what is the speed of light',
@@ -109,27 +67,27 @@ class TestCommonQuery(unittest.TestCase):
             {'type': 'enclosure.mouth.reset',
              'data': {},
              'context': {'destination': ['enclosure'],
-                         'skill_id': 'common_query.test'}
+                         'skill_id': self.cc.skill_id}
              },
             # tell enclosure about active skill (speak method)
             {'type': 'enclosure.active_skill',
-             'data': {'skill_id': 'common_query.test'},
+             'data': {'skill_id': self.cc.skill_id},
              'context': {'destination': ['enclosure'],
-                         'skill_id': 'common_query.test'}},
+                         'skill_id': self.cc.skill_id}},
             # execution of speak method
             {'type': 'speak',
              'data': {'utterance': 'answer 1',
                       'expect_response': False,
-                      'meta': {'skill': 'common_query.test'},
+                      'meta': {'skill': self.cc.skill_id},
                       'lang': 'en-us'},
-             'context': {'skill_id': 'common_query.test'}},
+             'context': {'skill_id': self.cc.skill_id}},
             # skill callback event
             {'type': 'question:action',
              'data': {'skill_id': 'wiki.test',
                       'phrase': 'what is the speed of light',
                       'callback_data': {'query': 'what is the speed of light',
                                         'answer': 'answer 1'}},
-             'context': {'skill_id': 'common_query.test'}}
+             'context': {'skill_id': self.cc.skill_id}}
         ]
 
         for ctr, msg in enumerate(expected):

--- a/test/unittests/common_query/test_continuous_dialog.py
+++ b/test/unittests/common_query/test_continuous_dialog.py
@@ -32,7 +32,7 @@ class TestDialog(unittest.TestCase):
     def test_continuous_dialog(self):
         self.bus.emitted_msgs = []
 
-        # "ask the wolf X"
+        # "ask the wiki X"
         self.assertFalse(self.skill.has_context)
         self.skill.handle_search(Message("search_fakewiki.intent",
                                          {"query": "what is the speed of light"}))

--- a/test/unittests/common_query/test_continuous_dialog.py
+++ b/test/unittests/common_query/test_continuous_dialog.py
@@ -1,0 +1,79 @@
+import json
+import unittest
+
+from ovos_tskill_fakewiki import FakeWikiSkill
+from ovos_utils.messagebus import FakeBus, Message
+
+
+class TestDialog(unittest.TestCase):
+    def setUp(self):
+        self.bus = FakeBus()
+        self.bus.emitted_msgs = []
+
+        def get_msg(msg):
+            self.bus.emitted_msgs.append(json.loads(msg))
+
+        self.bus.on("message", get_msg)
+
+        self.skill = FakeWikiSkill()
+        self.skill._startup(self.bus, "wiki.test")
+
+        self.skill.has_context = False
+
+        def set_context(message):
+            self.skill.has_context = True
+
+        def unset_context(message):
+            self.skill.has_context = False
+
+        self.bus.on('add_context', set_context)
+        self.bus.on('remove_context', unset_context)
+
+    def test_continuous_dialog(self):
+        self.bus.emitted_msgs = []
+
+        # "ask the wolf X"
+        self.assertFalse(self.skill.has_context)
+        self.skill.handle_search(Message("search_fakewiki.intent",
+                                         {"query": "what is the speed of light"}))
+
+        self.assertEqual(self.bus.emitted_msgs[0],
+                         {'context': {'skill_id': 'wiki.test'},
+                          'data': {'context': 'wiki_testFakeWikiKnows',
+                                   'origin': '',
+                                   'word': 'what is the speed of light'},
+                          'type': 'add_context'})
+        self.assertEqual(self.bus.emitted_msgs[-1],
+                         {'context': {'skill_id': 'wiki.test'},
+                          'data': {'expect_response': False,
+                                   'lang': 'en-us',
+                                   'meta': {'skill': 'wiki.test'},
+                                   'utterance': 'answer 1'},
+                          'type': 'speak'})
+
+        # "tell me more"
+        self.assertTrue(self.skill.has_context)
+        self.skill.handle_tell_more(Message("FakeWikiMore"))
+
+        self.assertEqual(self.bus.emitted_msgs[-1],
+                         {'context': {'skill_id': 'wiki.test'},
+                          'data': {'expect_response': False,
+                                   'lang': 'en-us',
+                                   'meta': {'skill': 'wiki.test'},
+                                   'utterance': 'answer 2'},
+                          'type': 'speak'})
+        self.assertTrue(self.skill.has_context)
+
+        # "tell me more" - no more data dialog
+        self.skill.handle_tell_more(Message("FakeWikiMore"))
+
+        self.assertEqual(self.bus.emitted_msgs[-2]["type"], "speak")
+        self.assertEqual(self.bus.emitted_msgs[-2]["data"]["meta"],
+                         {'data': {}, 'dialog': 'thats all', 'skill': 'wiki.test'})
+
+        # removal of context to disable "tell me more"
+        self.assertEqual(self.bus.emitted_msgs[-1],
+                         {'context': {'skill_id': 'wiki.test'},
+                          'data': {'context': 'wiki_testFakeWikiKnows'},
+                          'type': 'remove_context'})
+        self.assertFalse(self.skill.has_context)

--- a/test/unittests/common_query/test_skill.py
+++ b/test/unittests/common_query/test_skill.py
@@ -1,0 +1,73 @@
+import json
+import unittest
+
+from ovos_utils.messagebus import FakeBus
+from ovos_tskill_fakewiki import FakeWikiSkill
+from mycroft.skills import CommonQuerySkill
+
+
+class TestSkill(unittest.TestCase):
+    def setUp(self):
+        self.bus = FakeBus()
+        self.bus.emitted_msgs = []
+
+        def get_msg(msg):
+            self.bus.emitted_msgs.append(json.loads(msg))
+
+        self.bus.on("message", get_msg)
+
+        self.skill = FakeWikiSkill()
+        self.skill._startup(self.bus, "wiki.test")
+
+    def test_skill_id(self):
+        self.assertEqual(self.skill.skill_id, "wiki.test")
+        # if running in ovos-core every message will have the skill_id in context
+        for msg in self.bus.emitted_msgs:
+            self.assertEqual(msg["context"]["skill_id"], "wiki.test")
+
+    def test_intent_register(self):
+        adapt_ents = ["wiki_testMore"]  # why are you different :(
+        adapt_intents = ["wiki.test:FakeWikiMore"]
+        padatious_intents = ["wiki.test:search_fakewiki.intent"]
+        for msg in self.bus.emitted_msgs:
+            if msg["type"] == "register_vocab":
+                self.assertTrue(msg["data"]["entity_type"] in adapt_ents)
+            elif msg["type"] == "register_intent":
+                self.assertTrue(msg["data"]["name"] in adapt_intents)
+            elif msg["type"] == "padatious:register_intent":
+                self.assertTrue(msg["data"]["name"] in padatious_intents)
+
+    def test_registered_events(self):
+        registered_events = [e[0] for e in self.skill.events]
+
+        # common query event handlers
+        self.assertTrue(isinstance(self.skill, CommonQuerySkill))
+        common_query = ['question:action',
+                        'question:query']
+        for event in common_query:
+            self.assertTrue(event in registered_events)
+
+        # intent events
+        intent_triggers = [f"{self.skill.skill_id}:FakeWikiMore",
+                           f"{self.skill.skill_id}:search_fakewiki.intent"]
+        for event in intent_triggers:
+            self.assertTrue(event in registered_events)
+
+        # base skill class events shared with mycroft-core
+        default_skill = ["mycroft.skill.enable_intent",
+                         "mycroft.skill.disable_intent",
+                         "mycroft.skill.set_cross_context",
+                         "mycroft.skill.remove_cross_context",
+                         "intent.service.skills.deactivated",
+                         "intent.service.skills.activated",
+                         "mycroft.skills.settings.changed"]
+        for event in default_skill:
+            self.assertTrue(event in registered_events)
+
+        # base skill class events exclusive to ovos-core
+        default_ovos = ["skill.converse.ping",
+                        "skill.converse.request",
+                        f"{self.skill.skill_id}.activate",
+                        f"{self.skill.skill_id}.deactivate"]
+        for event in default_ovos:
+            self.assertTrue(event in registered_events)


### PR DESCRIPTION
add initial unittests for common query and continuous dialog

also adds a new event to trigger common_query directly without going trough the intent service