### PR TITLE
fix/ww_cfg

### DIFF
--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -392,11 +392,12 @@
     "multiplier": 1.0,
     "energy_ratio": 1.5,
 
-    // DEPRECATED, multiple hotwords are supported now, see "hotwords" section below
-    // wake_word can be used to get a speakable string of main wake word, ie, mycrofts name
+    // NOTE, multiple hotwords are supported now, these fields define the main wake_word,
+    // this is equivalent to setting "active": true in the "hotwords" section below IF "active" is missing
+    // this field is also used to get a speakable string of main wake word, ie, mycrofts name
     // this is set by selene and used in naptime skill
     "wake_word": "hey_mycroft",
-    //"stand_up_word": "wake_up",
+    "stand_up_word": "wake_up",
 
     // Settings used by microphone to set recording timeout
     "recording_timeout": 10.0,

--- a/mycroft/listener/__init__.py
+++ b/mycroft/listener/__init__.py
@@ -332,12 +332,17 @@ class RecognizerLoop(EventEmitter):
         hot_words = self.config_core.get("hotwords", {})
         global_listen = self.config_core.get("confirm_listening")
         global_sounds = self.config_core.get("sounds", {})
-        main_ww = self.config_core.get("listener", {}).get("wake_word", "hey_mycroft")
-        wakeupw = self.config_core.get("listener", {}).get("stand_up_word", "wake_up")
+
+        main_ww = self.config_core.get("listener", {}).get("wake_word", "hey_mycroft").replace(" ", "_")
+        wakeupw = self.config_core.get("listener", {}).get("stand_up_word", "wake_up").replace(" ", "_")
 
         for word, data in dict(hot_words).items():
             try:
-                word = word.replace(" ", "_")  # normalization step to avoid naming collisions across configs
+                # normalization step to avoid naming collisions
+                # TODO - move this to ovos_config package, on changes to the hotwords section this should be enforced directly
+                # this approach does not fully solve the issue, config merging may be messed up
+                word = word.replace(" ", "_")
+
                 sound = data.get("sound")
                 utterance = data.get("utterance")
                 listen = data.get("listen", False)


### PR DESCRIPTION
handle naming collisions due to white space and underscore differences

handle "active" flag based on the concept of "main wake word", compatible with the mycroft way and expectations, multiple wake words will require explicitly setting "active": True in config from now on

fix possible iteration bug on stop