### PR TITLE
fix backend tests

### DIFF
--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -268,7 +268,7 @@
   // - https://github.com/OpenVoiceOS/OVOS-local-backend
   // - https://mycroft-ai.gitbook.io/docs/using-mycroft-ai/pairing-your-device
   "server": {
-    // Valid types: offline, selene, personal
+    // Valid types: offline, selene, personal, neon, ovos
     "backend_type": "offline",
     // url for selene -> https://api.mycroft.ai
     "url": "",
@@ -276,6 +276,31 @@
     "update": false,
     "metrics": true,
     "sync_skill_settings": true
+  },
+
+  // This section controls what providers should be used by each 3rd party API
+  "microservices": {
+      // auto == backend from "server" section above
+      // auto / wolfram / selene / personal / ovos / neon
+      "wolfram_provider": "auto",
+      // auto / owm / selene / personal / ovos / neon
+      "weather_provider": "auto",
+      // auto / osm / selene / personal / ovos / neon
+      "geolocation_provider": "auto",
+
+      // secret keys for offline usage
+      "wolfram_key": "",
+      "owm_key": "",
+      "email": {
+          // by default send emails here
+          "recipient": "",
+          "smtp": {
+            "username": "",
+            "password": "",
+            "host": "smtp.mailprovider.com",
+            "port": 465
+          }
+      }
   },
 
   // The mycroft-core messagebus websocket

--- a/mycroft/deprecated/skills/settings.py
+++ b/mycroft/deprecated/skills/settings.py
@@ -8,14 +8,13 @@ to be a drop in replacement for mycroft-core
 
 import json
 import os
-import re
 from os.path import dirname, basename
 from pathlib import Path
 from threading import Timer, Lock
 
 import yaml
 
-from ovos_backend_client.pairing import is_paired, is_backend_disabled
+from ovos_backend_client.pairing import is_paired
 from ovos_backend_client.api import DeviceApi
 from mycroft.messagebus.message import Message
 from mycroft.util.file_utils import ensure_directory_exists
@@ -105,10 +104,7 @@ class SettingsMetaUploader:
         self.settings_meta = {}
         self.api = None
         self.upload_timer = None
-        if is_backend_disabled():
-            self.sync_enabled = False
-        else:
-            self.sync_enabled = self.config["server"] \
+        self.sync_enabled = self.config["server"] \
                 .get("sync_skill_settings", False)
         if not self.sync_enabled:
             LOG.info("Skill settings sync is disabled, settingsmeta will "
@@ -325,10 +321,7 @@ class SkillSettingsDownloader:
         self.api = DeviceApi()
         self.download_timer = None
 
-        if is_backend_disabled():
-            self.sync_enabled = False
-        else:
-            self.sync_enabled = Configuration().get("server", {}).get("sync_skill_settings", False)
+        self.sync_enabled = Configuration().get("server", {}).get("sync_skill_settings", False)
 
         if not self.sync_enabled:
             LOG.debug("Skill settings sync is disabled, backend settings will "


### PR DESCRIPTION
assumes neon/ovos support added to ovos-backend-client already

companion PR to https://github.com/OpenVoiceOS/ovos-backend-client/pull/11 , that should be merged and version pinned here