### PR TITLE
fix/backwards_compat

### DIFF
--- a/mycroft/configuration/config.py
+++ b/mycroft/configuration/config.py
@@ -1,3 +1,4 @@
 # backwards compat - moved to own python package
 from ovos_config.config import *
-from ovos_config.locations import DEFAULT_CONFIG
+from ovos_config.locations import *
+


### PR DESCRIPTION
some places expect the config locations variables to be available under mycroft.configuration.config module

seen in ovos-alarm-skill