### PR TITLE
Fix show_pages index api

### DIFF
--- a/mycroft/gui/namespace.py
+++ b/mycroft/gui/namespace.py
@@ -195,7 +195,7 @@ class Namespace:
                 self.persistent = False
                 self.duration = 30
 
-    def load_pages(self, pages: List[str]):
+    def load_pages(self, pages: List[str], show_index: None):
         """Maintains a list of active pages within the active namespace.
 
         Skills with multiple pages of data can either show all the screens
@@ -218,7 +218,10 @@ class Namespace:
         else:
             page = pages[0]
 
-        self._activate_page(pages[0])
+        if show_index:
+            self._activate_page(pages[show_index])
+        else:
+            self._activate_page(pages[0])
 
     def _add_pages(self, new_pages: List[str]):
         """Adds once or more pages to the active page list.
@@ -510,6 +513,7 @@ class NamespaceManager:
             namespace_name = message.data["__from"]
             pages_to_show = message.data["page"]
             persistence = message.data["__idle"]
+            show_index = message.data.get("index", None)
 
             pages_to_load = list()
             for page in pages_to_show:
@@ -532,7 +536,7 @@ class NamespaceManager:
 
             with namespace_lock:
                 self._activate_namespace(namespace_name)
-                self._load_pages(pages_to_load)
+                self._load_pages(pages_to_load, show_index)
                 self._update_namespace_persistence(persistence)
 
     def _activate_namespace(self, namespace_name: str):
@@ -575,14 +579,14 @@ class NamespaceManager:
 
         return namespace
 
-    def _load_pages(self, pages_to_show: str):
+    def _load_pages(self, pages_to_show: str, show_index: None):
         """Loads the requested pages in the namespace.
 
         Args:
             pages_to_show: the pages requested to be loaded
         """
         active_namespace = self.active_namespaces[0]
-        active_namespace.load_pages(pages_to_show)
+        active_namespace.load_pages(pages_to_show, show_index)
 
     def _update_namespace_persistence(self, persistence: Union[bool, int]):
         """Sets the persistence of the namespace being activated.

--- a/test/unittests/gui/test_namespace.py
+++ b/test/unittests/gui/test_namespace.py
@@ -100,7 +100,8 @@ class TestNamespace(TestCase):
         )
         patch_function = PATCH_MODULE + ".send_message_to_gui"
         with mock.patch(patch_function) as send_message_mock:
-            self.namespace.load_pages(new_pages)
+            show_index = None
+            self.namespace.load_pages(new_pages, show_index)
             send_message_mock.assert_called_with(load_page_message)
         self.assertListEqual(self.namespace.pages, self.namespace.pages)
 
@@ -115,7 +116,8 @@ class TestNamespace(TestCase):
         )
         patch_function = PATCH_MODULE + ".send_message_to_gui"
         with mock.patch(patch_function) as send_message_mock:
-            self.namespace.load_pages(new_pages)
+            show_index = None
+            self.namespace.load_pages(new_pages, show_index)
             send_message_mock.assert_called_with(load_page_message)
         self.assertListEqual(self.namespace.pages, self.namespace.pages)
 


### PR DESCRIPTION
- Show Pages index request was simply ignored in the API and always defaulted to activating the first page, instead of the requested index
- Fixes page handling when index is specified along with list of pages in show_pages method call