### PR TITLE
Handle multiple intents with the same name (#2921)

### DIFF
--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -21,7 +21,7 @@ from copy import copy
 from inspect import signature
 from itertools import chain
 from os.path import join, abspath, dirname, basename, exists, isfile
-from threading import Event
+from threading import Event, Lock
 from hashlib import md5
 
 from ovos_utils.intents import Intent, IntentBuilder
@@ -151,6 +151,7 @@ class MycroftSkill:
         # Delegator classes
         self.event_scheduler = EventSchedulerInterface()
         self.intent_service = IntentServiceInterface()
+        self.intent_service_lock = Lock()
 
         # Skill Public API
         self.public_api = {}
@@ -587,9 +588,10 @@ class MycroftSkill:
             self._start_filewatcher()
 
     def detach(self):
-        for (name, _) in self.intent_service:
-            name = f'{self.skill_id}:{name}'
-            self.intent_service.detach_intent(name)
+        with self.intent_service_lock:
+            for (name, _) in self.intent_service:
+                name = f'{self.skill_id}:{name}'
+                self.intent_service.detach_intent(name)
 
     def initialize(self):
         """Perform any final setup needed for the skill.
@@ -1184,19 +1186,44 @@ class MycroftSkill:
     def _register_adapt_intent(self, intent_parser, handler):
         """Register an adapt intent.
 
+        Will handle registration of anonymous
         Args:
             intent_parser: Intent object to parse utterance for the handler.
             handler (func): function to register with intent
         """
         # Default to the handler's function name if none given
+        is_anonymous = not intent_parser.name
         name = intent_parser.name or handler.__name__
+        if is_anonymous:
+            # Find a good name
+            original_name = name
+            nbr = 0
+            while name in self.intent_service:
+                nbr += 1
+                name = f'{original_name}{nbr}'
+        else:
+            if name in self.intent_service:
+                raise ValueError(f'The intent name {name} is already taken')
+
         munge_intent_parser(intent_parser, name, self.skill_id)
         self.intent_service.register_adapt_intent(name, intent_parser)
+
         if handler:
             self.add_event(intent_parser.name, handler,
                            'mycroft.skill.handler')
 
     def register_intent(self, intent_parser, handler):
+        """Register an Intent with the intent service.
+
+        Args:
+            intent_parser: Intent, IntentBuilder object or padatious intent
+                           file to parse utterance for the handler.
+            handler (func): function to register with intent
+        """
+        with self.intent_service_lock:
+            self._register_intent(intent_parser, handler)
+
+    def _register_intent(self, intent_parser, handler):
         """Register an Intent with the intent service.
 
         Args:
@@ -1274,23 +1301,20 @@ class MycroftSkill:
                 continue
             filename = str(entity.file_path)
             name = f"{self.skill_id}:{basename(entity_file)}_{md5(entity_file.encode('utf-8')).hexdigest()}"
-            self.intent_service.register_padatious_entity(name, filename, lang)
+            with self.intent_service_lock:
+                self.intent_service.register_padatious_entity(name, filename, lang)
 
     def handle_enable_intent(self, message):
         """Listener to enable a registered intent if it belongs to this skill.
         """
         intent_name = message.data['intent_name']
-        for (name, _) in self.intent_service:
-            if name == intent_name:
-                return self.enable_intent(intent_name)
+        return self.enable_intent(intent_name)
 
     def handle_disable_intent(self, message):
         """Listener to disable a registered intent if it belongs to this skill.
         """
         intent_name = message.data['intent_name']
-        for (name, _) in self.intent_service:
-            if name == intent_name:
-                return self.disable_intent(intent_name)
+        return self.disable_intent(intent_name)
 
     def disable_intent(self, intent_name):
         """Disable a registered intent if it belongs to this skill.
@@ -1301,19 +1325,20 @@ class MycroftSkill:
         Returns:
                 bool: True if disabled, False if it wasn't registered
         """
-        if intent_name in self.intent_service:
-            LOG.info('Disabling intent ' + intent_name)
-            name = f'{self.skill_id}:{intent_name}'
-            self.intent_service.detach_intent(name)
+        with self.intent_service_lock:
+            if intent_name in self.intent_service:
+                LOG.info('Disabling intent ' + intent_name)
+                name = f'{self.skill_id}:{intent_name}'
+                self.intent_service.detach_intent(name)
 
-            langs = [self._core_lang] + self._secondary_langs
-            for lang in langs:
-                lang_intent_name = f'{name}_{lang}'
-                self.intent_service.detach_intent(lang_intent_name)
-            return True
-        else:
-            LOG.error(f'Could not disable {intent_name}, it hasn\'t been registered.')
-            return False
+                langs = [self._core_lang] + self._secondary_langs
+                for lang in langs:
+                    lang_intent_name = f'{name}_{lang}'
+                    self.intent_service.detach_intent(lang_intent_name)
+                return True
+            else:
+                LOG.error(f'Could not disable {intent_name}, it hasn\'t been registered.')
+                return False
 
     def enable_intent(self, intent_name):
         """(Re)Enable a registered intent if it belongs to this skill.
@@ -1325,17 +1350,22 @@ class MycroftSkill:
             bool: True if enabled, False if it wasn't registered
         """
         intent = self.intent_service.get_intent(intent_name)
-        if intent:
-            if ".intent" in intent_name:
-                self.register_intent_file(intent_name, None)
+        with self.intent_service_lock:
+            if intent and self.intent_service.intent_is_detached(intent_name):
+                if ".intent" in intent_name:
+                    self.register_intent_file(intent_name, None)
+                else:
+                    intent.name = intent_name
+                    self._register_intent(intent, None)
+                LOG.debug('Enabling intent {}'.format(intent_name))
+                return True
+            elif intent:
+                LOG.error(f'Could not enable {intent_name}, '
+                          'it\'s not detached')
             else:
-                intent.name = intent_name
-                self.register_intent(intent, None)
-            LOG.debug(f'Enabling intent {intent_name}')
-            return True
-        else:
-            LOG.error(f'Could not enable {intent_name}, it hasn\'t been registered.')
-            return False
+                LOG.error('Could not enable '
+                          f'{intent_name}, it hasn\'t been registered.')
+                return False
 
     def set_context(self, context, word='', origin=''):
         """Add context to intent service
@@ -1406,7 +1436,8 @@ class MycroftSkill:
         """
         keyword_type = self._alphanumeric_skill_id + entity_type
         lang = lang or self.lang
-        self.intent_service.register_adapt_keyword(keyword_type, entity, lang=lang)
+        with self.intent_service_lock:
+            self.intent_service.register_adapt_keyword(keyword_type, entity, lang=lang)
 
     def register_regex(self, regex_str, lang=None):
         """Register a new regex.
@@ -1416,7 +1447,8 @@ class MycroftSkill:
         self.log.debug('registering regex string: ' + regex_str)
         regex = munge_regex(regex_str, self.skill_id)
         re.compile(regex)  # validate regex
-        self.intent_service.register_adapt_regex(regex, lang=lang or self.lang)
+        with self.intent_service_lock:
+            self.intent_service.register_adapt_regex(regex, lang=lang or self.lang)
 
     def speak(self, utterance, expect_response=False, wait=False, meta=None):
         """Speak a sentence.
@@ -1517,8 +1549,9 @@ class MycroftSkill:
                     for line in skill_vocabulary[vocab_type]:
                         entity = line[0]
                         aliases = line[1:]
-                        self.intent_service.register_adapt_keyword(
-                            vocab_type, entity, aliases, lang)
+                        with self.intent_service_lock:
+                            self.intent_service.register_adapt_keyword(
+                                vocab_type, entity, aliases, lang)
 
     def load_regex_files(self, root_directory=None):
         """ Load regex files found under the skill directory."""
@@ -1528,7 +1561,8 @@ class MycroftSkill:
             if resources.types.regex.base_directory is not None:
                 regexes = resources.load_skill_regex(self._alphanumeric_skill_id)
                 for regex in regexes:
-                    self.intent_service.register_adapt_regex(regex, lang)
+                    with self.intent_service_lock:
+                        self.intent_service.register_adapt_regex(regex, lang)
 
     def __handle_stop(self, message):
         """Handler for the "mycroft.stop" signal. Runs the user defined

--- a/test/unittests/skills/test_mycroft_skill.py
+++ b/test/unittests/skills/test_mycroft_skill.py
@@ -26,7 +26,7 @@ from adapt.intent import IntentBuilder
 from copy import deepcopy
 from mycroft.configuration import Configuration
 from mycroft.messagebus.message import Message
-from mycroft.skills.core import MycroftSkill, resting_screen_handler
+from mycroft.skills.core import MycroftSkill, resting_screen_handler, intent_handler
 from mycroft.skills.intent_service import open_intent_envelope
 from mycroft.skills.skill_data import (load_regex_from_file, load_regex,
                                        load_vocabulary, read_vocab_file)
@@ -619,6 +619,23 @@ class TestMycroftSkill(unittest.TestCase):
         s.config_core['secondary_langs'] = secondary
 
 
+class TestIntentCollisions(unittest.TestCase):
+    def test_two_intents_with_same_name(self):
+        emitter = MockEmitter()
+        skill = SameIntentNameSkill()
+        skill.bind(emitter)
+        with self.assertRaises(ValueError):
+            skill.initialize()
+
+    def test_two_anonymous_intent_decorators(self):
+        """Two anonymous intent handlers should be ok."""
+        emitter = MockEmitter()
+        skill = SameAnonymousIntentDecoratorsSkill()
+        skill.bind(emitter)
+        skill._register_decorated()
+        self.assertEqual(len(skill.intent_service.registered_intents), 2)
+
+
 class _TestSkill(MycroftSkill):
     def __init__(self):
         super().__init__()
@@ -695,5 +712,29 @@ class SimpleSkill6(_TestSkill):
         self.register_intent('test.intent', self.handler)
         self.register_entity_file('test_ent.entity')
 
+    def handler(self, message):
+        pass
+
+
+class SameIntentNameSkill(_TestSkill):
+    """Test skill for duplicate intent namesr."""
+    skill_id = 'A'
+
+    def initialize(self):
+        intent = IntentBuilder('TheName').require('Keyword')
+        intent2 = IntentBuilder('TheName').require('Keyword')
+        self.register_intent(intent, self.handler)
+        self.register_intent(intent2, self.handler)
+
+    def handler(self, message):
+        pass
+
+
+class SameAnonymousIntentDecoratorsSkill(_TestSkill):
+    """Test skill for duplicate anonymous intent handlers."""
+    skill_id = 'A'
+
+    @intent_handler(IntentBuilder('').require('Keyword'))
+    @intent_handler(IntentBuilder('').require('OtherKeyword'))
     def handler(self, message):
         pass


### PR DESCRIPTION
closes #233 

* Add check for duplicate adapt intents

There are two cases, duplicated named intent and duplicated anonymous intent.

A named intent will cause a ValueError exception notifying the skill author that there is a collision.

An anonymous intent will silently derive a new name and use that instead of the default generated one.

* Add tests for intent collisions

* Make enable/disable intent handle the new exception

The enable/disable intent did not mark an intent as detached, instead it remained in the list of intents after disabling in the IntentServiceInterface to be retrieved when the intent should be re-enabled.

This moves detached intents into a list of detached intents to so they won't cause the double enable exception.

* Add move logic to find if intent is detached

MycroftSkill.enable_intent() will now check if the intent is detached before trying to re-enable it.

* Lock updates of intents

This should avoid some race conditions that may occur if multiple threads tries to enable / disable intents