### PR TITLE
improve skill loading

### DIFF
--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -109,7 +109,9 @@
   # audio -> audio playback reported ready
   # gui -> gui websocket reported ready - NOT IMPLEMENTED
   # enclosure -> enclosure/HAL reported ready - NOT IMPLEMENTED
-  "ready_settings": ["skills"],
+  # network_skills -> skills with network requirements
+  # internet_skills -> skills with internet requirements
+  "ready_settings": ["skills", "network_skills", "internet_skills"],
 
   // General skill values
   "skills": {

--- a/mycroft/skills/skill_loader.py
+++ b/mycroft/skills/skill_loader.py
@@ -579,7 +579,7 @@ class PluginSkillLoader(SkillLoader):
         if self.is_blacklisted:
             self._skip_load()
         else:
-            self._create_skill_instance()
+            self.loaded = self._create_skill_instance()
 
         self.last_loaded = time()
         self._communicate_load_status()

--- a/mycroft/skills/skill_loader.py
+++ b/mycroft/skills/skill_loader.py
@@ -24,7 +24,7 @@ from time import time
 from ovos_config.locations import get_xdg_data_dirs, get_xdg_data_save_path
 from ovos_config.meta import get_xdg_base
 from ovos_plugin_manager.skills import find_skill_plugins
-from ovos_workshop.skills.ovos import SkillNetworkRequirements
+from ovos_workshop.skills.base import SkillNetworkRequirements
 from ovos_config.config import Configuration
 from mycroft.messagebus import Message
 from mycroft.skills.mycroft_skill.mycroft_skill import MycroftSkill

--- a/mycroft/skills/skill_loader.py
+++ b/mycroft/skills/skill_loader.py
@@ -303,6 +303,7 @@ class SkillLoader:
         self._skill_directory = skill_directory
         self._skill_id = None
         self._skill_class = None
+        self._loaded = None
         self.load_attempted = False
         self.last_modified = 0
         self.last_loaded = 0
@@ -316,7 +317,11 @@ class SkillLoader:
 
     @property
     def loaded(self):
-        return self.instance is None
+        return self._loaded or self.instance is None
+
+    @loaded.setter
+    def loaded(self, val):
+        self._loaded = val
 
     @property
     def skill_directory(self):
@@ -324,6 +329,10 @@ class SkillLoader:
         if self.instance and not skill_dir:
             skill_dir = self.instance.root_dir
         return skill_dir
+
+    @skill_directory.setter
+    def skill_directory(self, val):
+        self._skill_directory = val
 
     @property
     def skill_id(self):
@@ -334,6 +343,10 @@ class SkillLoader:
             skill_id = os.path.basename(self.skill_directory)
         return skill_id
 
+    @skill_id.setter
+    def skill_id(self, val):
+        self._skill_id = val
+
     @property
     def skill_class(self):
         skill_class = self._skill_class
@@ -342,6 +355,10 @@ class SkillLoader:
         if self.skill_module and not skill_class:
             skill_class = get_skill_class(self.skill_module)
         return skill_class
+
+    @skill_class.setter
+    def skill_class(self, val):
+        self._skill_class = val
 
     @property
     def network_requirements(self):

--- a/mycroft/skills/skill_loader.py
+++ b/mycroft/skills/skill_loader.py
@@ -24,7 +24,7 @@ from time import time
 from ovos_config.locations import get_xdg_data_dirs, get_xdg_data_save_path
 from ovos_config.meta import get_xdg_base
 from ovos_plugin_manager.skills import find_skill_plugins
-from ovos_workshop.skills.base import SkillNetworkRequirements
+from ovos_workshop.skills.base import SkillNetworkRequirements, BaseSkill
 from ovos_config.config import Configuration
 from mycroft.messagebus import Message
 from mycroft.skills.mycroft_skill.mycroft_skill import MycroftSkill
@@ -307,7 +307,7 @@ class SkillLoader:
         self.load_attempted = False
         self.last_modified = 0
         self.last_loaded = 0
-        self.instance = None
+        self.instance: BaseSkill = None
         self.active = True
         self._watchdog = None
         self.config = Configuration()
@@ -317,7 +317,7 @@ class SkillLoader:
 
     @property
     def loaded(self):
-        return self._loaded or self.instance is None
+        return self._loaded  # or self.instance is None
 
     @loaded.setter
     def loaded(self, val):
@@ -338,8 +338,10 @@ class SkillLoader:
     def skill_id(self):
         skill_id = self._skill_id
         if self.instance and not skill_id:
+            LOG.debug(f"skill_id from instance")
             skill_id = self.instance.skill_id
         if self.skill_directory and not skill_id:
+            LOG.debug(f"skill_id from directory")
             skill_id = os.path.basename(self.skill_directory)
         return skill_id
 
@@ -387,7 +389,7 @@ class SkillLoader:
         return self.instance is None
 
     def reload(self):
-        LOG.info('ATTEMPTING TO RELOAD SKILL: ' + self.skill_id)
+        LOG.info(f'ATTEMPTING TO RELOAD SKILL: {self.skill_id}')
         if self.instance:
             if not self.instance.reload_skill:
                 LOG.info("skill does not allow reloading!")
@@ -396,7 +398,7 @@ class SkillLoader:
         return self._load()
 
     def load(self):
-        LOG.info('ATTEMPTING TO LOAD SKILL: ' + self.skill_id)
+        LOG.info(f'ATTEMPTING TO LOAD SKILL: {self.skill_id}')
         return self._load()
 
     def _unload(self):
@@ -455,7 +457,7 @@ class SkillLoader:
             self._skip_load()
         else:
             self.skill_module = self._load_skill_source()
-            self._create_skill_instance()
+            self.loaded = self._create_skill_instance()
 
         self.last_loaded = time()
         self._communicate_load_status()

--- a/mycroft/skills/skill_manager.py
+++ b/mycroft/skills/skill_manager.py
@@ -382,6 +382,12 @@ class SkillManager(Thread):
                 LOG.debug("Internet skills loaded")
             else:
                 LOG.error("Gave up waiting for internet skills to load")
+        if not all((self._network_loaded.is_set(),
+                    self._internet_loaded.is_set())):
+            self.bus.emit(Message(
+                'mycroft.skills.error',
+                {'internet_loaded': self._internet_loaded.is_set(),
+                 'network_loaded': self._network_loaded.is_set()}))
         self.bus.emit(Message('mycroft.skills.initialized'))
 
         # wait for initial intents training

--- a/mycroft/skills/skill_manager.py
+++ b/mycroft/skills/skill_manager.py
@@ -384,21 +384,15 @@ class SkillManager(Thread):
                 os.remove(i)
 
     def _load_on_network(self):
-        LOG.info('Loading network plugin skills...')
-        self.load_plugin_skills(network=True, internet=False)
         LOG.info('Loading network skills...')
         self._load_new_skills(network=True, internet=False)
 
     def _load_on_internet(self):
-        LOG.info('Loading internet plugin skills...')
-        self.load_plugin_skills(network=True, internet=True)
         LOG.info('Loading internet skills...')
         self._load_new_skills(network=True, internet=True)
 
     def _load_on_startup(self):
         """Handle initial skill load."""
-        LOG.info('Loading offline plugin skills...')
-        self.load_plugin_skills(network=False, internet=False)
         LOG.info('Loading offline skills...')
         self._load_new_skills(network=False, internet=False)
 
@@ -408,6 +402,8 @@ class SkillManager(Thread):
             network = self._network_event.is_set()
         if internet is None:
             internet = self._connected_event.is_set()
+
+        self.load_plugin_skills(network=network, internet=internet)
 
         for skill_dir in self._get_skill_directories():
             replaced_skills = []

--- a/mycroft/skills/skill_manager.py
+++ b/mycroft/skills/skill_manager.py
@@ -104,6 +104,8 @@ class SkillManager(Thread):
         self._stop_event = Event()
         self._connected_event = Event()
         self._network_event = Event()
+        self._network_loaded = Event()
+        self._internet_loaded = Event()
         self.config = Configuration()
         self.manifest_uploader = SeleneSkillManifestUploader()
         self.upload_queue = UploadQueue()  # DEPRECATED
@@ -364,6 +366,10 @@ class SkillManager(Thread):
             while not self._connected_event.is_set():
                 sleep(1)
             LOG.debug("Internet Connected")
+            if self._network_loaded.wait(60):
+                LOG.debug("Network skills loaded")
+            if self._internet_loaded.wait(60):
+                LOG.debug("Internet skills loaded")
 
         self.bus.emit(Message('mycroft.skills.initialized'))
 
@@ -400,10 +406,12 @@ class SkillManager(Thread):
     def _load_on_network(self):
         LOG.info('Loading network skills...')
         self._load_new_skills(network=True, internet=False)
+        self._network_loaded.set()
 
     def _load_on_internet(self):
         LOG.info('Loading internet skills...')
         self._load_new_skills(network=True, internet=True)
+        self._internet_loaded.set()
 
     def _load_on_startup(self):
         """Handle initial skill load."""

--- a/mycroft/skills/skill_manager.py
+++ b/mycroft/skills/skill_manager.py
@@ -279,7 +279,7 @@ class SkillManager(Thread):
         if network is None:
             network = self._network_event.is_set()
         if internet is None:
-            internet = self._internet_event.is_set()
+            internet = self._connected_event.is_set()
         plugins = find_skill_plugins()
         loaded_skill_ids = [basename(p) for p in self.skill_loaders]
         for skill_id, plug in plugins.items():
@@ -401,7 +401,7 @@ class SkillManager(Thread):
         if network is None:
             network = self._network_event.is_set()
         if internet is None:
-            internet = self._internet_event.is_set()
+            internet = self._connected_event.is_set()
 
         for skill_dir in self._get_skill_directories():
             replaced_skills = []

--- a/mycroft/skills/skill_manager.py
+++ b/mycroft/skills/skill_manager.py
@@ -358,18 +358,22 @@ class SkillManager(Thread):
         self._load_on_startup()
 
         if self.skills_config.get("wait_for_internet", False):
+            LOG.debug("Waiting for internet")
             # NOTE - self._connected_event will never be set
             # if PHAL plugin is not running to emit the connected events
             while not self._connected_event.is_set():
                 sleep(1)
+            LOG.debug("Internet Connected")
+
+        self.bus.emit(Message('mycroft.skills.initialized'))
 
         # wait for initial intents training
+        LOG.debug("Waiting for initial training")
         while not self.initial_load_complete:
             sleep(0.5)
         self.status.set_ready()
 
         LOG.info("Skills all loaded!")
-        self.bus.emit(Message('mycroft.skills.initialized'))
 
         # Scan the file folder that contains Skills.  If a Skill is updated,
         # unload the existing version from memory and reload from the disk.

--- a/mycroft/skills/skill_manager.py
+++ b/mycroft/skills/skill_manager.py
@@ -120,8 +120,13 @@ class SkillManager(Thread):
 
         self.status.bind(self.bus)
 
-        # If PHAL loaded first, make sure we get network events
-        self.bus.emit(Message("ovos.PHAL.internet_check"))
+        # If PHAL loaded first, make sure we get network state
+        resp = self.bus.wait_for_response(Message("ovos.PHAL.internet_check"))
+        if resp:
+            if resp.data.get('internet_connected'):
+                self.handle_internet_connected(resp)
+            elif resp.data.get('network_connected'):
+                self.handle_network_connected(resp)
 
     def _define_message_bus_events(self):
         """Define message bus events with handlers defined in this class."""

--- a/mycroft/skills/skill_manager.py
+++ b/mycroft/skills/skill_manager.py
@@ -120,6 +120,9 @@ class SkillManager(Thread):
 
         self.status.bind(self.bus)
 
+        # If PHAL loaded first, make sure we get network events
+        self.bus.emit(Message("ovos.PHAL.internet_check"))
+
     def _define_message_bus_events(self):
         """Define message bus events with handlers defined in this class."""
         # Update upon request
@@ -262,6 +265,7 @@ class SkillManager(Thread):
         pass
 
     def handle_internet_connected(self, message):
+        LOG.debug("Internet Connected")
         self._network_event.set()
         self._connected_event.set()
         self._load_on_internet()
@@ -272,6 +276,7 @@ class SkillManager(Thread):
             self.manifest_uploader.post_manifest()
 
     def handle_network_connected(self, message):
+        LOG.debug("Network Connected")
         self._network_event.set()
         self._load_on_network()
 

--- a/mycroft/skills/skill_manager.py
+++ b/mycroft/skills/skill_manager.py
@@ -284,7 +284,7 @@ class SkillManager(Thread):
         loaded_skill_ids = [basename(p) for p in self.skill_loaders]
         for skill_id, plug in plugins.items():
             if skill_id not in self.plugin_skills and skill_id not in loaded_skill_ids:
-                skill_loader = self._get_plugin_skill_loader(skill_id)
+                skill_loader = self._get_plugin_skill_loader(skill_id, init_bus=False)
                 requirements = skill_loader.network_requirements
                 if not network and requirements.network_before_load:
                     continue
@@ -292,8 +292,10 @@ class SkillManager(Thread):
                     continue
                 self._load_plugin_skill(skill_id, plug)
 
-    def _get_plugin_skill_loader(self, skill_id):
-        if not self.config["websocket"].get("shared_connection", True):
+    def _get_plugin_skill_loader(self, skill_id, init_bus=True):
+        if not init_bus:
+            bus = None
+        elif not self.config["websocket"].get("shared_connection", True):
             # see BusBricker skill to understand why this matters
             # any skill can manipulate the bus from other skills
             # this patch ensures each skill gets it's own
@@ -407,7 +409,7 @@ class SkillManager(Thread):
             replaced_skills = []
             # by definition skill_id == folder name
             skill_id = os.path.basename(skill_dir)
-            skill_loader = self._get_skill_loader(skill_dir)
+            skill_loader = self._get_skill_loader(skill_dir, init_bus=False)
             requirements = skill_loader.network_requirements
             if not network and requirements.network_before_load:
                 continue
@@ -432,8 +434,10 @@ class SkillManager(Thread):
             if skill_dir not in self.skill_loaders:
                 self._load_skill(skill_dir)
 
-    def _get_skill_loader(self, skill_directory):
-        if not self.config["websocket"].get("shared_connection", True):
+    def _get_skill_loader(self, skill_directory, init_bus=True):
+        if not init_bus:
+            bus = None
+        elif not self.config["websocket"].get("shared_connection", True):
             # see BusBricker skill to understand why this matters
             # any skill can manipulate the bus from other skills
             # this patch ensures each skill gets it's own

--- a/requirements/extra-skills.txt
+++ b/requirements/extra-skills.txt
@@ -3,3 +3,4 @@ padacioso~=0.1.2
 ovos-lingua-franca~=0.4, >=0.4.2
 PyYAML~=5.4
 ovos_workshop~=0.0, >=0.0.10a4
+ovos-phal-plugin-connectivity-events@git+https://github.com/openvoiceos/ovos-phal-plugin-connectivity-events@FIX_FixThreadInit

--- a/requirements/extra-skills.txt
+++ b/requirements/extra-skills.txt
@@ -2,5 +2,5 @@ adapt-parser~=0.5
 padacioso~=0.1.2
 ovos-lingua-franca~=0.4, >=0.4.2
 PyYAML~=5.4
-ovos_workshop~=0.0, >=0.0.10a4
-ovos-phal-plugin-connectivity-events@git+https://github.com/openvoiceos/ovos-phal-plugin-connectivity-events@FIX_FixThreadInit
+ovos_workshop~=0.0.10
+ovos-phal-plugin-connectivity-events~=0.0.1a2

--- a/requirements/extra-skills.txt
+++ b/requirements/extra-skills.txt
@@ -3,4 +3,4 @@ padacioso~=0.1.2
 ovos-lingua-franca~=0.4, >=0.4.2
 PyYAML~=5.4
 ovos_workshop~=0.0.10
-ovos-phal-plugin-connectivity-events~=0.0.1a2
+ovos-phal-plugin-connectivity-events~=0.0.1

--- a/test/unittests/mocks.py
+++ b/test/unittests/mocks.py
@@ -74,3 +74,6 @@ class MessageBusMock:
 
     def once(self, event, _):
         self.event_handlers.append(event)
+
+    def wait_for_response(self, message):
+        self.emit(message)

--- a/test/unittests/skills/test_skill_loader.py
+++ b/test/unittests/skills/test_skill_loader.py
@@ -20,7 +20,7 @@ from unittest.mock import call, Mock, patch
 from mycroft.skills.mycroft_skill.mycroft_skill import MycroftSkill
 from mycroft.skills.skill_loader import _get_last_modified_time, SkillLoader
 from ovos_workshop.decorators import classproperty
-from ovos_workshop.skills.ovos import SkillNetworkRequirements
+from ovos_workshop.skills.base import SkillNetworkRequirements
 from ..base import MycroftUnitTestBase
 
 ONE_MINUTE = 60

--- a/test/unittests/skills/test_skill_loader.py
+++ b/test/unittests/skills/test_skill_loader.py
@@ -119,6 +119,7 @@ class TestSkillLoader(MycroftUnitTestBase):
         """The loader should take to action for an already loaded skill."""
         self.loader.instance = Mock
         self.loader.instance.reload_skill = True
+        self.loader.loaded = True
         self.loader.last_loaded = time() + ONE_MINUTE
 
         self.assertFalse(self.loader.reload_needed())
@@ -128,6 +129,7 @@ class TestSkillLoader(MycroftUnitTestBase):
         self.loader.instance = Mock()
         self.loader.instance.reload_skill = False
         self.loader.active = True
+        self.loader.loaded = True
         self.assertFalse(self.loader.reload_needed())
 
     def test_skill_reloading_deactivated(self):
@@ -135,11 +137,13 @@ class TestSkillLoader(MycroftUnitTestBase):
         self.loader.instance = Mock()
         self.loader.instance.reload_skill = True
         self.loader.active = False
+        self.loader.loaded = False
         self.assertFalse(self.loader.reload_needed())
 
     def test_skill_reload(self):
         """Test reloading a skill that was modified."""
         self.loader.instance = Mock()
+        self.loader.loaded = True
         self.loader.last_loaded = 0
 
         with patch(self.mock_package + 'time') as time_mock:

--- a/test/unittests/skills/test_skill_manager.py
+++ b/test/unittests/skills/test_skill_manager.py
@@ -125,10 +125,11 @@ class TestSkillManager(MycroftUnitTestBase):
         self.skill_manager.send_skill_list(None)
 
         self.assertListEqual(
-            ['mycroft.skills.list'],
+            ['ovos.PHAL.internet_check',
+             'mycroft.skills.list'],
             self.message_bus_mock.message_types
         )
-        message_data = self.message_bus_mock.message_data[0]
+        message_data = self.message_bus_mock.message_data[-1]
         self.assertIn('test_skill', message_data.keys())
         skill_data = message_data['test_skill']
         self.assertDictEqual(dict(active=True, id='test_skill'), skill_data)

--- a/test/unittests/skills/test_skill_manager.py
+++ b/test/unittests/skills/test_skill_manager.py
@@ -97,23 +97,21 @@ class TestSkillManager(MycroftUnitTestBase):
 
     def test_instantiate(self):
         expected_result = [
-            'mycroft.internet.connected',
             'skillmanager.list',
             'skillmanager.deactivate',
             'skillmanager.keep',
             'skillmanager.activate',
-           # 'mycroft.paired',
-           # 'mycroft.skills.settings.update',
             'mycroft.skills.initialized',
             'mycroft.skills.trained',
+            'mycroft.network.connected',
+            'mycroft.internet.connected',
             'mycroft.skills.is_alive',
             'mycroft.skills.is_ready',
             'mycroft.skills.all_loaded'
         ]
-        self.assertListEqual(
-            expected_result,
-            self.message_bus_mock.event_handlers
-        )
+
+        self.assertListEqual(expected_result,
+                             self.message_bus_mock.event_handlers)
 
     def test_unload_removed_skills(self):
         self.skill_manager._unload_removed_skills()


### PR DESCRIPTION
companion PR to https://github.com/OpenVoiceOS/OVOS-workshop/pull/36

integrates with https://github.com/OpenVoiceOS/ovos-PHAL-plugin-connectivity-events

usage
```python
from ovos_workshop.skills.ovos import OVOSSkill, SkillNetworkRequirements, classproperty

class MySkill(OVOSSkill):

    @classproperty
    def network_requirements(self):
        """ skill developers should override this if they do not require connectivity
         some examples:
         IOT skill that controls skills via LAN could return:
            scans_on_init = True
            SkillNetworkRequirements(internet_before_load=False,
                                     network_before_load=scans_on_init,
                                     requires_internet=False,
                                     requires_network=True,
                                     no_internet_fallback=True,
                                     no_network_fallback=False)
         online search skill with a local cache:
            has_cache = False
            SkillNetworkRequirements(internet_before_load=not has_cache,
                                     network_before_load=not has_cache,
                                     requires_internet=True,
                                     requires_network=True,
                                     no_internet_fallback=True,
                                     no_network_fallback=True)
         a fully offline skill:
            SkillNetworkRequirements(internet_before_load=False,
                                     network_before_load=False,
                                     requires_internet=False,
                                     requires_network=False,
                                     no_internet_fallback=True,
                                     no_network_fallback=True)
        """
        return SkillNetworkRequirements()
 ```