### PR TITLE
Prevent logging errors when a blacklisted skill is handled as expected

### DIFF
--- a/mycroft/skills/skill_loader.py
+++ b/mycroft/skills/skill_loader.py
@@ -498,7 +498,10 @@ class SkillLoader:
             message = Message('mycroft.skills.loading_failure',
                               {"path": self.skill_directory, "id": self.skill_id})
             self.bus.emit(message)
-            LOG.error(f'Skill {self.skill_id} failed to load')
+            if not self.is_blacklisted:
+                LOG.error(f'Skill {self.skill_id} failed to load')
+            else:
+                LOG.info(f'Skill {self.skill_id} not loaded')
 
 
 class PluginSkillLoader(SkillLoader):

--- a/test/unittests/skills/test_skill_loader.py
+++ b/test/unittests/skills/test_skill_loader.py
@@ -158,7 +158,7 @@ class TestSkillLoader(MycroftUnitTestBase):
             call.info(
                 'Skill test_skill is blacklisted - it will not be loaded'
             ),
-            call.error('Skill test_skill failed to load')
+            call.warning('Skill test_skill not loaded')
         ]
         self.assertListEqual(log_messages, self.log_mock.method_calls)
         self.loader.config['skills']['blacklisted_skills'].remove('test_skill')

--- a/test/unittests/skills/test_skill_loader.py
+++ b/test/unittests/skills/test_skill_loader.py
@@ -158,7 +158,7 @@ class TestSkillLoader(MycroftUnitTestBase):
             call.info(
                 'Skill test_skill is blacklisted - it will not be loaded'
             ),
-            call.warning('Skill test_skill not loaded')
+            call.info('Skill test_skill not loaded')
         ]
         self.assertListEqual(log_messages, self.log_mock.method_calls)
         self.loader.config['skills']['blacklisted_skills'].remove('test_skill')


### PR DESCRIPTION
Changes blacklisted skill load failures from ERROR to INFO since its expected that a blacklisted skill didn't load