### PR TITLE
Troubleshooting unit test failures

### DIFF
--- a/mycroft/skills/skill_loader.py
+++ b/mycroft/skills/skill_loader.py
@@ -387,7 +387,7 @@ class SkillLoader:
         return self.instance is None
 
     def reload(self):
-        LOG.info('ATTEMPTING TO RELOAD SKILL: ' + self.skill_id)
+        LOG.info(f'ATTEMPTING TO RELOAD SKILL: {self.skill_id}')
         if self.instance:
             if not self.instance.reload_skill:
                 LOG.info("skill does not allow reloading!")
@@ -396,7 +396,7 @@ class SkillLoader:
         return self._load()
 
     def load(self):
-        LOG.info('ATTEMPTING TO LOAD SKILL: ' + self.skill_id)
+        LOG.info(f'ATTEMPTING TO LOAD SKILL: {self.skill_id}')
         return self._load()
 
     def _unload(self):
@@ -455,7 +455,7 @@ class SkillLoader:
             self._skip_load()
         else:
             self.skill_module = self._load_skill_source()
-            self._create_skill_instance()
+            self.loaded = self._create_skill_instance()
 
         self.last_loaded = time()
         self._communicate_load_status()

--- a/mycroft/skills/skill_loader.py
+++ b/mycroft/skills/skill_loader.py
@@ -24,7 +24,7 @@ from time import time
 from ovos_config.locations import get_xdg_data_dirs, get_xdg_data_save_path
 from ovos_config.meta import get_xdg_base
 from ovos_plugin_manager.skills import find_skill_plugins
-from ovos_workshop.skills.base import SkillNetworkRequirements
+from ovos_workshop.skills.base import SkillNetworkRequirements, BaseSkill
 from ovos_config.config import Configuration
 from mycroft.messagebus import Message
 from mycroft.skills.mycroft_skill.mycroft_skill import MycroftSkill
@@ -307,7 +307,7 @@ class SkillLoader:
         self.load_attempted = False
         self.last_modified = 0
         self.last_loaded = 0
-        self.instance = None
+        self.instance: BaseSkill = None
         self.active = True
         self._watchdog = None
         self.config = Configuration()
@@ -317,7 +317,7 @@ class SkillLoader:
 
     @property
     def loaded(self):
-        return self._loaded or self.instance is None
+        return self._loaded  # or self.instance is None
 
     @loaded.setter
     def loaded(self, val):
@@ -338,8 +338,10 @@ class SkillLoader:
     def skill_id(self):
         skill_id = self._skill_id
         if self.instance and not skill_id:
+            LOG.debug(f"skill_id from instance")
             skill_id = self.instance.skill_id
         if self.skill_directory and not skill_id:
+            LOG.debug(f"skill_id from directory")
             skill_id = os.path.basename(self.skill_directory)
         return skill_id
 

--- a/test/unittests/skills/test_skill_manager.py
+++ b/test/unittests/skills/test_skill_manager.py
@@ -96,26 +96,22 @@ class TestSkillManager(MycroftUnitTestBase):
         }
 
     def test_instantiate(self):
-        expected_result = {
-            'mycroft.internet.connected',
+        expected_result = [
             'skillmanager.list',
             'skillmanager.deactivate',
             'skillmanager.keep',
             'skillmanager.activate',
-           # 'mycroft.paired',
-           # 'mycroft.skills.settings.update',
             'mycroft.skills.initialized',
             'mycroft.skills.trained',
+            'mycroft.network.connected',
+            'mycroft.internet.connected',
             'mycroft.skills.is_alive',
             'mycroft.skills.is_ready',
-            'mycroft.skills.all_loaded',
-            'mycroft.network.connected',
-            'mycroft.internet.connected'
-        }
-        self.assertSetEqual(
-            expected_result,
-            set(self.message_bus_mock.event_handlers)
-        )
+            'mycroft.skills.all_loaded'
+        ]
+
+        self.assertListEqual(expected_result,
+                             self.message_bus_mock.event_handlers)
 
     def test_unload_removed_skills(self):
         self.skill_manager._unload_removed_skills()

--- a/test/unittests/skills/test_skill_manager.py
+++ b/test/unittests/skills/test_skill_manager.py
@@ -96,7 +96,7 @@ class TestSkillManager(MycroftUnitTestBase):
         }
 
     def test_instantiate(self):
-        expected_result = [
+        expected_result = {
             'mycroft.internet.connected',
             'skillmanager.list',
             'skillmanager.deactivate',
@@ -111,10 +111,10 @@ class TestSkillManager(MycroftUnitTestBase):
             'mycroft.skills.all_loaded',
             'mycroft.network.connected',
             'mycroft.internet.connected'
-        ]
-        self.assertListEqual(
+        }
+        self.assertSetEqual(
             expected_result,
-            self.message_bus_mock.event_handlers
+            set(self.message_bus_mock.event_handlers)
         )
 
     def test_unload_removed_skills(self):

--- a/test/unittests/skills/test_skill_manager.py
+++ b/test/unittests/skills/test_skill_manager.py
@@ -108,7 +108,9 @@ class TestSkillManager(MycroftUnitTestBase):
             'mycroft.skills.trained',
             'mycroft.skills.is_alive',
             'mycroft.skills.is_ready',
-            'mycroft.skills.all_loaded'
+            'mycroft.skills.all_loaded',
+            'mycroft.network.connected',
+            'mycroft.internet.connected'
         ]
         self.assertListEqual(
             expected_result,


### PR DESCRIPTION
Update logging to prevent Type Errors in testing
Add back `self.loaded` set in skill_loader.py
Add new bus handlers to test_skill_manager.py