### PR TITLE
add platform-requirements to not include any base skill installs

### DIFF
--- a/requirements/platform-requirements.txt
+++ b/requirements/platform-requirements.txt
@@ -1,0 +1,32 @@
+requests~=2.26
+PyAudio~=0.2
+SpeechRecognition~=3.8
+tornado~=6.0, >=6.0.3
+psutil~=5.6.6
+python-dateutil~=2.6
+combo-lock~=0.2
+PyYAML~=5.4
+watchdog
+
+mycroft-messagebus-client~=0.9,!=0.9.2,!=0.9.3
+adapt-parser~=0.5
+padatious~=0.4.8
+padacioso~=0.1.2
+fann2==1.0.7
+padaos~=0.1
+
+ovos_backend_client~=0.0, >=0.0.5
+ovos-config~=0.0,>=0.0.5
+ovos-utils~=0.0, >=0.0.27
+ovos-plugin-manager~=0.0, >=0.0.19
+ovos_workshop~=0.0, >=0.0.10
+ovos_PHAL~=0.0, >=0.0.2
+ovos-lingua-franca>=0.4.6
+
+ovos-stt-plugin-server~=0.0, >=0.0.2
+ovos-tts-plugin-mimic~=0.2, >=0.2.6
+ovos-tts-plugin-mimic2~=0.1, >=0.1.5
+ovos-tts-plugin-google-tx~=0.0, >=0.0.3
+ovos-ww-plugin-pocketsphinx~=0.1
+ovos-ww-plugin-precise~=0.1
+ovos-vad-plugin-webrtcvad

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,8 @@ setup(
         'bus': required('requirements/extra-bus.txt'),
         'deprecated': required('requirements/extra-deprecated.txt'),
         'all': required('requirements/requirements.txt'),
-        'skills-essential': required('requirements/skills-essential.txt')
+        'skills-essential': required('requirements/skills-essential.txt'),
+        "platform": required('requirements/platform-requirements.txt')
     },
     packages=find_packages(include=['mycroft*']),
     include_package_data=True,


### PR DESCRIPTION
- Add platform-requirements.txt and ["platform"] egg for platforms where no default skills should be included, as platform / distributions can choose and pick what defaults to install and package.

- Fixes https://github.com/OpenVoiceOS/ovos-core/issues/276