### PR TITLE
Fix invalid license spec in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ setup(
     classifiers=[
         "Development Status :: 4 - Beta",
         "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: Apache-2.0",
+        "License :: OSI Approved :: Apache Software License",
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Update to valid spec per https://pypi.org/classifiers/
Failing action: https://github.com/OpenVoiceOS/ovos-core/actions/runs/4146490400/jobs/7172210267