### PR TITLE
Update minimal.txt

### DIFF
--- a/requirements/minimal.txt
+++ b/requirements/minimal.txt
@@ -9,3 +9,4 @@ ovos-lingua-franca~=0.4, >=0.4.6
 ovos_backend_client~=0.0, >=0.0.5
 ovos_workshop~=0.0, >=0.0.11a4
 watchdog
+tornado


### PR DESCRIPTION
On minimal install, `mycroft-messagebus` would not start with `no module found 'tornado'`