### PR TITLE
Fix AudioProducer shutdown

### DIFF
--- a/.github/workflows/license_tests.yml
+++ b/.github/workflows/license_tests.yml
@@ -37,7 +37,7 @@ jobs:
           requirements: 'requirements-all.txt'
           fail: 'Copyleft,Other,Error'
           fails-only: true
-          exclude: '^(precise-runner|fann2|tqdm|bs4).*'
+          exclude: '^(precise-runner|fann2|tqdm|bs4|ovos-stt-plugin).*'
           exclude-license: '^(Mozilla).*$'
       - name: Print report
         if: ${{ always() }}

--- a/mycroft/listener/__init__.py
+++ b/mycroft/listener/__init__.py
@@ -106,6 +106,7 @@ class AudioProducer(Thread):
                 finally:
                     if self.stream_handler is not None:
                         self.stream_handler.stream_stop()
+            LOG.info("Loop stopped running")
 
     def stop(self):
         """Stop producer thread."""

--- a/mycroft/listener/__init__.py
+++ b/mycroft/listener/__init__.py
@@ -110,6 +110,7 @@ class AudioProducer(Thread):
 
     def stop(self):
         """Stop producer thread."""
+        LOG.debug("stopping producer")
         self.loop.state.running = False
         self.loop.responsive_recognizer.stop()
 

--- a/mycroft/listener/mic.py
+++ b/mycroft/listener/mic.py
@@ -802,6 +802,10 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
                                         self._stop_signaled, ww_frames), \
                            self.config.get("lang", "en-us")
 
+                if self._stop_signaled:
+                    LOG.info("Stopping")
+                    break
+
                 audio_buffer.append(chunk)
                 ww_frames.append(chunk)
 
@@ -855,7 +859,7 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
                             self.write_mic_level(energy, source)
                         mic_write_counter += 1
         LOG.info("Stopping...")
-        return WakeWordData(None, False, True, None), stt_lang
+        return WakeWordData(None, False, True, None), ""
 
     @staticmethod
     def _create_audio_data(raw_data, source):
@@ -907,7 +911,7 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
         if self.listen_state == ListenerState.WAKEWORD:
             LOG.debug("Waiting for wake word...")
             ww_data, lang = self._wait_until_wake_word(source, sec_per_buffer)
-
+            LOG.debug("Done waiting for WW")
             if ww_data.stopped or self.loop.state.sleeping:
                 LOG.debug(f"No data: stopped={ww_data.stopped}")
                 # If the waiting returned from a stop signal or sleep mode is active

--- a/mycroft/listener/mic.py
+++ b/mycroft/listener/mic.py
@@ -794,9 +794,8 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
         # that we want to keep to send to STT
         ww_frames = deque(maxlen=7)
 
-        said_wake_word = False
         audio_data = silence
-        while not said_wake_word and not self._stop_signaled:
+        while not self._stop_signaled:
             for chunk in source.stream.iter_chunks():
                 if self._skip_wake_word():
                     return WakeWordData(audio_data, False,
@@ -820,14 +819,16 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
 
                     # else check for hotwords
                     if not was_wakeup:
-                        for hotword in self.check_for_hotwords(audio_data, source):
+                        for hotword in self.check_for_hotwords(audio_data,
+                                                               source):
                             said_hot_word = True
                             listen = self.loop.engines[hotword]["listen"]
                             stt_lang = self.loop.engines[hotword]["stt_lang"]
                             self._handle_hotword_found(hotword, audio_data, source)
                             if listen and not self.loop.state.sleeping:
-                                return WakeWordData(audio_data, said_wake_word,
-                                                    self._stop_signaled, ww_frames), stt_lang
+                                return WakeWordData(audio_data, True,
+                                                    self._stop_signaled,
+                                                    ww_frames), stt_lang
 
                     if said_hot_word:
                         # reset bytearray to store wake word audio in, else many
@@ -853,6 +854,8 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
                             self._watchdog()
                             self.write_mic_level(energy, source)
                         mic_write_counter += 1
+        LOG.info("Stopping...")
+        return WakeWordData(None, False, True, None), stt_lang
 
     @staticmethod
     def _create_audio_data(raw_data, source):
@@ -906,6 +909,7 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
             ww_data, lang = self._wait_until_wake_word(source, sec_per_buffer)
 
             if ww_data.stopped or self.loop.state.sleeping:
+                LOG.debug(f"No data: stopped={ww_data.stopped}")
                 # If the waiting returned from a stop signal or sleep mode is active
                 return None, lang
 

--- a/requirements/extra-stt.txt
+++ b/requirements/extra-stt.txt
@@ -3,6 +3,5 @@ PyAudio~=0.2
 ovos-vad-plugin-webrtcvad
 ovos-ww-plugin-pocketsphinx~=0.1, >=0.1.3
 ovos-ww-plugin-precise~=0.1
-ovos-stt-plugin-selene>=0.0.2a1
-ovos-stt-plugin-server~=0.0, >=0.0.2
+ovos-stt-plugin-selene>=0.0.3a3
 ovos-stt-plugin-vosk~=0.1

--- a/requirements/extra-stt.txt
+++ b/requirements/extra-stt.txt
@@ -3,6 +3,6 @@ PyAudio~=0.2
 ovos-vad-plugin-webrtcvad
 ovos-ww-plugin-pocketsphinx~=0.1, >=0.1.3
 ovos-ww-plugin-precise~=0.1
-ovos-stt-plugin-selene
+ovos-stt-plugin-selene>=0.0.2a1
 ovos-stt-plugin-server~=0.0, >=0.0.2
 ovos-stt-plugin-vosk~=0.1


### PR DESCRIPTION
Cleanup and refactor `_wait_until_wake_word` to deprecate static variables and better handle requests to shutdown so `join` call successfully joins the thread and return values are properly handled

