### PR TITLE
default settings cleanup

### DIFF
--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -467,13 +467,6 @@
   // Hotword configurations
   "hotwords": {
     "hey_mycroft": {
-        // hey mycroft is a bundled pre trained model
-        // auto selected because of keyword name
-        "module": "ovos-ww-plugin-openwakeword",
-        "listen": true,
-        "fallback_ww": "hey_mycroft_precise_lite"
-    },
-    "hey_mycroft_precise_lite": {
         "module": "ovos-ww-plugin-precise-lite",
         "model": "https://github.com/OpenVoiceOS/precise-lite-models/raw/master/wakewords/en/hey_mycroft.tflite",
         "expected_duration": 3,

--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -565,7 +565,7 @@
     // Engine.  Options: "mycroft", "google", "wit", "ibm", "kaldi", "bing",
     //                   "houndify", "deepspeech_server", "govivace", "yandex"
     "module": "ovos-stt-plugin-server",
-    "fallback_module": "dummy",
+    "fallback_module": "",
     // the default instance is hosted by a OpenVoiceOS member
     // it is a google proxy equivalent to mycroft selene
     "ovos-stt-plugin-server": {"url": "https://stt.openvoiceos.com/stt"}

--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -467,6 +467,13 @@
   // Hotword configurations
   "hotwords": {
     "hey_mycroft": {
+        // hey mycroft is a bundled pre trained model
+        // auto selected because of keyword name
+        "module": "ovos-ww-plugin-openwakeword",
+        "listen": true,
+        "fallback_ww": "hey_mycroft_precise_lite"
+    },
+    "hey_mycroft_precise_lite": {
         "module": "ovos-ww-plugin-precise-lite",
         "model": "https://github.com/OpenVoiceOS/precise-lite-models/raw/master/wakewords/en/hey_mycroft.tflite",
         "expected_duration": 3,

--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -562,8 +562,7 @@
   // Speech to Text parameters
   // Override: REMOTE
   "stt": {
-    // Engine.  Options: "mycroft", "google", "wit", "ibm", "kaldi", "bing",
-    //                   "houndify", "deepspeech_server", "govivace", "yandex"
+    // select a STT plugin as described in the respective readme
     "module": "ovos-stt-plugin-server",
     "fallback_module": "",
     // the default instance is hosted by a OpenVoiceOS member
@@ -578,7 +577,7 @@
     "module": "ovos-tts-plugin-mimic3-server",
     "fallback_module": "ovos-tts-plugin-mimic",
     "ovos-tts-plugin-mimic": {
-      "voice": "ap",
+        "voice": "ap"
     },
     "ovos-tts-plugin-mimic3-server": {
         "voice": "en_UK/apope_low"

--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -362,7 +362,7 @@
     // under: /'save_path'/mycroft_utterances/<TIMESTAMP>.wav
     "save_utterances": false,
     "wake_word_upload": {
-      "disable": false,
+      "disable": true,
       // official mycroft endpoint disabled, enable if you want to collect your own
       // eg, eltocino localcroft or personal backend
       "url": ""
@@ -467,16 +467,38 @@
   // Hotword configurations
   "hotwords": {
     "hey_mycroft": {
+        "module": "ovos-ww-plugin-precise-lite",
+        "model": "https://github.com/OpenVoiceOS/precise-lite-models/raw/master/wakewords/en/hey_mycroft.tflite",
+        "expected_duration": 3,
+        "trigger_level": 3,
+        "sensitivity": 0.5,
+        "listen": true,
+        "fallback_ww": "hey_mycroft_precise"
+    },
+    "hey_mycroft_precise": {
         "module": "ovos-ww-plugin-precise",
         "version": "0.3",
         "model": "https://github.com/MycroftAI/precise-data/raw/models-dev/hey-mycroft.tar.gz",
+        "expected_duration": 3,
+        "trigger_level": 3,
+        "sensitivity": 0.5,
+        "listen": true,
+        "fallback_ww": "hey_mycroft_vosk"
+    },
+    "hey_mycroft_vosk": {
+        "module": "ovos-ww-plugin-vosk",
+        "samples": ["hey mycroft", "hey microsoft", "hey mike roft", "hey minecraft"],
+        "rule": "fuzzy",
+        "listen": true,
+        "fallback_ww": "hey_mycroft_pocketsphinx"
+    },
+    "hey_mycroft_pocketsphinx": {
+        "module": "ovos-ww-plugin-pocketsphinx",
         "phonemes": "HH EY . M AY K R AO F T",
         "threshold": 1e-90,
         "lang": "en-us",
-        "listen": true,
-        "sound": "snd/start_listening.wav"
+        "listen": true
     },
-
     "wake_up": {
         "module": "ovos-ww-plugin-pocketsphinx",
         "phonemes": "W EY K . AH P",
@@ -543,7 +565,7 @@
     // Engine.  Options: "mycroft", "google", "wit", "ibm", "kaldi", "bing",
     //                   "houndify", "deepspeech_server", "govivace", "yandex"
     "module": "ovos-stt-plugin-server",
-    "fallback_module": "ovos-stt-plugin-vosk",
+    "fallback_module": "dummy",
     // the default instance is hosted by a OpenVoiceOS member
     // it is a google proxy equivalent to mycroft selene
     "ovos-stt-plugin-server": {"url": "https://stt.openvoiceos.com/stt"}
@@ -553,8 +575,14 @@
   // Override: REMOTE
   "tts": {
     "pulse_duck": false,
-    "module": "ovos-tts-plugin-mimic2",
-    "fallback_module": "ovos-tts-plugin-mimic"
+    "module": "ovos-tts-plugin-mimic3-server",
+    "fallback_module": "ovos-tts-plugin-mimic",
+    "ovos-tts-plugin-mimic": {
+      "voice": "ap",
+    },
+    "ovos-tts-plugin-mimic3-server": {
+        "voice": "en_UK/apope_low"
+    }
   },
 
   "padatious": {

--- a/requirements/extra-stt.txt
+++ b/requirements/extra-stt.txt
@@ -1,7 +1,10 @@
 SpeechRecognition~=3.8
 PyAudio~=0.2
+
 ovos-vad-plugin-webrtcvad~=0.0.1
+
 ovos-ww-plugin-pocketsphinx~=0.1, >=0.1.3
-ovos-ww-plugin-precise~=0.1
-ovos-stt-plugin-selene>=0.0.3a3
+ovos-ww-plugin-precise-lite
+
+ovos-stt-plugin-server~=0.0, >=0.0.2
 ovos-stt-plugin-vosk~=0.1

--- a/requirements/extra-stt.txt
+++ b/requirements/extra-stt.txt
@@ -5,6 +5,7 @@ ovos-vad-plugin-webrtcvad~=0.0.1
 
 ovos-ww-plugin-pocketsphinx~=0.1, >=0.1.3
 ovos-ww-plugin-openwakeword
+ovos-ww-plugin-vosk
 # ovos-ww-plugin-precise-lite
 
 ovos-stt-plugin-server~=0.0, >=0.0.2

--- a/requirements/extra-stt.txt
+++ b/requirements/extra-stt.txt
@@ -4,7 +4,8 @@ PyAudio~=0.2
 ovos-vad-plugin-webrtcvad~=0.0.1
 
 ovos-ww-plugin-pocketsphinx~=0.1, >=0.1.3
-ovos-ww-plugin-precise-lite
+ovos-ww-plugin-openwakeword
+# ovos-ww-plugin-precise-lite
 
 ovos-stt-plugin-server~=0.0, >=0.0.2
 ovos-stt-plugin-vosk~=0.1

--- a/requirements/extra-stt.txt
+++ b/requirements/extra-stt.txt
@@ -4,9 +4,9 @@ PyAudio~=0.2
 ovos-vad-plugin-webrtcvad~=0.0.1
 
 ovos-ww-plugin-pocketsphinx~=0.1, >=0.1.3
-ovos-ww-plugin-openwakeword
+ovos-ww-plugin-precise~=0.1
+ovos-ww-plugin-precise-lite
 ovos-ww-plugin-vosk
-# ovos-ww-plugin-precise-lite
 
 ovos-stt-plugin-server~=0.0, >=0.0.2
 ovos-stt-plugin-vosk~=0.1

--- a/requirements/extra-tts.txt
+++ b/requirements/extra-tts.txt
@@ -1,3 +1,3 @@
 ovos-tts-plugin-mimic~=0.2, >=0.2.6
 ovos-tts-plugin-mimic2~=0.1, >=0.1.5
-ovos-tts-plugin-google-tx~=0.0, >=0.0.3
+ovos-tts-plugin-mimic3-server

--- a/requirements/minimal.txt
+++ b/requirements/minimal.txt
@@ -2,7 +2,7 @@ requests~=2.26
 mycroft-messagebus-client~=0.9,!=0.9.2,!=0.9.3
 combo-lock~=0.2
 ovos-utils~=0.0, >=0.0.30
-ovos-plugin-manager~=0.0, >=0.0.23a1
+ovos-plugin-manager~=0.0, >=0.0.22
 ovos-config~=0.0,>=0.0.5
 python-dateutil~=2.6
 ovos-lingua-franca~=0.4, >=0.4.6

--- a/requirements/minimal.txt
+++ b/requirements/minimal.txt
@@ -2,7 +2,7 @@ requests~=2.26
 mycroft-messagebus-client~=0.9,!=0.9.2,!=0.9.3
 combo-lock~=0.2
 ovos-utils~=0.0, >=0.0.30
-ovos-plugin-manager~=0.0, >=0.0.20
+ovos-plugin-manager~=0.0, >=0.0.23a1
 ovos-config~=0.0,>=0.0.5
 python-dateutil~=2.6
 ovos-lingua-franca~=0.4, >=0.4.6

--- a/requirements/minimal.txt
+++ b/requirements/minimal.txt
@@ -1,11 +1,14 @@
 requests~=2.26
+python-dateutil~=2.6
+watchdog~=2.1
+
 mycroft-messagebus-client~=0.9,!=0.9.2,!=0.9.3
 combo-lock~=0.2
+padacioso~=0.1.2
+
 ovos-utils~=0.0, >=0.0.30
 ovos-plugin-manager~=0.0, >=0.0.22
 ovos-config~=0.0,>=0.0.5
-python-dateutil~=2.6
 ovos-lingua-franca~=0.4, >=0.4.6
 ovos_backend_client~=0.0, >=0.0.5
 ovos_workshop~=0.0, >=0.0.11
-watchdog~=2.1

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -18,7 +18,7 @@ padaos~=0.1
 ovos_backend_client~=0.0, >=0.0.5
 ovos-config~=0.0,>=0.0.5
 ovos-utils~=0.0, >=0.0.30
-ovos-plugin-manager~=0.0, >=0.0.19
+ovos-plugin-manager~=0.0, >=0.0.23a1
 ovos_workshop~=0.0, >=0.0.11
 ovos_PHAL~=0.0, >=0.0.2
 ovos-lingua-franca>=0.4.6
@@ -26,9 +26,10 @@ ovos-lingua-franca>=0.4.6
 ovos-stt-plugin-server~=0.0, >=0.0.2
 ovos-tts-plugin-mimic~=0.2, >=0.2.6
 ovos-tts-plugin-mimic2~=0.1, >=0.1.5
-ovos-tts-plugin-google-tx~=0.0, >=0.0.3
+ovos-tts-plugin-mimic3-server
+
 ovos-ww-plugin-pocketsphinx~=0.1
-ovos-ww-plugin-precise~=0.1
+ovos-ww-plugin-precise-lite~=0.1
 ovos-vad-plugin-webrtcvad~=0.0.1
 
 ovos_plugin_common_play~=0.0.3

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -29,7 +29,8 @@ ovos-tts-plugin-mimic2~=0.1, >=0.1.5
 ovos-tts-plugin-mimic3-server
 
 ovos-ww-plugin-pocketsphinx~=0.1
-ovos-ww-plugin-precise-lite~=0.1
+ovos-ww-plugin-openwakeword
+# ovos-ww-plugin-precise-lite~=0.1
 ovos-vad-plugin-webrtcvad~=0.0.1
 
 ovos_plugin_common_play~=0.0.3

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -30,7 +30,6 @@ ovos-tts-plugin-mimic3-server
 
 ovos-ww-plugin-pocketsphinx~=0.1
 ovos-ww-plugin-openwakeword
-# ovos-ww-plugin-precise-lite~=0.1
 ovos-vad-plugin-webrtcvad~=0.0.1
 
 ovos_plugin_common_play~=0.0.3
@@ -43,3 +42,9 @@ ovos-ocp-news-plugin~=0.0.3
 ovos-skill-volume~=0.0.1
 ovos-skill-fallback-unknown~=0.0.2
 ovos-skill-stop~=0.2
+neon-skill-alerts~=1.2
+ovos-skill-personal
+ovos-skill-naptime
+ovos-skill-date-time>=0.2.2a1
+ovos-skill-hello-world
+ovos-skill-filebrowser

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -25,7 +25,6 @@ ovos-lingua-franca>=0.4.6
 
 ovos-stt-plugin-server~=0.0, >=0.0.2
 ovos-tts-plugin-mimic~=0.2, >=0.2.6
-ovos-tts-plugin-mimic2~=0.1, >=0.1.5
 ovos-tts-plugin-mimic3-server
 
 ovos-ww-plugin-pocketsphinx~=0.1

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -18,7 +18,7 @@ padaos~=0.1
 ovos_backend_client~=0.0, >=0.0.5
 ovos-config~=0.0,>=0.0.5
 ovos-utils~=0.0, >=0.0.30
-ovos-plugin-manager~=0.0, >=0.0.23a1
+ovos-plugin-manager~=0.0, >=0.0.22
 ovos_workshop~=0.0, >=0.0.11
 ovos_PHAL~=0.0, >=0.0.2
 ovos-lingua-franca>=0.4.6

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -28,7 +28,7 @@ ovos-tts-plugin-mimic~=0.2, >=0.2.6
 ovos-tts-plugin-mimic3-server
 
 ovos-ww-plugin-pocketsphinx~=0.1
-ovos-ww-plugin-openwakeword
+ovos-ww-plugin-precise~=0.1
 ovos-vad-plugin-webrtcvad~=0.0.1
 
 ovos_plugin_common_play~=0.0.3

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -6,5 +6,7 @@ cov-core==1.15.0
 sphinx==2.2.1
 sphinx-rtd-theme==0.4.3
 mock_msm~=0.9.2
+
+ovos-stt-plugin-selene>=0.0.3a3
 ovos-stt-plugin-vosk>=0.1.3
 python-vlc==1.1.2

--- a/setup.py
+++ b/setup.py
@@ -84,6 +84,8 @@ setup(
     ],
     entry_points={
         'console_scripts': [
+            'ovos-core=mycroft.skills.__main__:main',
+            # TODO - remove below console_scripts in 0.1.0 (backwards compat)
             'mycroft-speech-client=mycroft.listener.__main__:main',
             'mycroft-messagebus=mycroft.messagebus.service.__main__:main',
             'mycroft-skills=mycroft.skills.__main__:main',


### PR DESCRIPTION
optimize config file and requirements.txt

- takes advantage of https://github.com/OpenVoiceOS/ovos-plugin-manager/pull/99 , the best ww plugin will be used depending on what is installed
- no fallback stt by default, this was causing issues in rpi3 because of memory usage
- change default TTS to mimic3 server, mimic2 will go down any day now + voice matches mimic1
- remove ovos-tts-plugin-mimic2 dependency
- remove ovos-tts-plugin-google-tx dependency
- remove ovos-stt-plugin-selene dependency
- remove ovos-stt-plugin-vosk dependency

NOTES:
- precise-lite can still not be made a default because buildtests fail on python 3.10
- stt/tts extra requirements include more plugins not in requirements.txt

TODO:
- adopt https://github.com/OpenVoiceOS/ovos-ww-plugin-openWakeWord as default ww enfine
- remove ovos-ww-plugin-precise dependency
- stt unittests depend on selene plugin, those should be moved to the respective plugin repository, they can also remain here as integration tests