### PR TITLE
fix/fallbackV1

### DIFF
--- a/mycroft/skills/intent_services/fallback_service.py
+++ b/mycroft/skills/intent_services/fallback_service.py
@@ -154,7 +154,7 @@ class FallbackService:
             IntentMatch or None
         """
         # NOTE - utterances here is a list of tuple of [(ut, norm)]
-        # they have been munged along the way... TODO undo the munging
+        # they have been munged along the way... TODO undo the munging at the source
         utterances = [u[0] for u in utterances]
         message.data["utterances"] = utterances  # all transcripts
         message.data["lang"] = lang
@@ -172,7 +172,7 @@ class FallbackService:
         LOG.debug("checking for FallbackSkillsV1")
         msg = message.reply(
             'mycroft.skills.fallback',
-            data={'utterance': utterances[0][0],
+            data={'utterance': utterances[0],
                   'lang': lang,
                   'fallback_range': (fb_range.start, fb_range.stop)}
         )


### PR DESCRIPTION
fix https://github.com/OpenVoiceOS/ovos-core/issues/315

```
2023-04-29 18:12:46.597 - skills - ovos_core.intent_services:_normalize_all_utterances:77 - DEBUG - Utterances: [('',)]
2023-04-29 18:12:46.601 - skills - ovos_core.intent_services.padatious_service:_match_level:79 - INFO - Jurebes Matching confidence > 0.95
2023-04-29 18:12:46.871 - skills - ovos_core.intent_services.padatious_service:calc_intent:302 - INFO -  IntentMatch(intent_name='ovos.common_play:resume.intent', confidence=0.6349888471087107, entities={})
2023-04-29 18:12:46.873 - skills - ovos_core.intent_services.padatious_service:_match_level:91 - INFO - low confidence jurebes match, discarding result!
2023-04-29 18:12:46.878 - skills - ovos_core.intent_services.fallback_service:_fallback_range:172 - DEBUG - checking for FallbackSkillsV1
2023-04-29 18:12:46.880 - skills - ovos_core.intent_services:handle_utterance:276 - ERROR - string index out of range
Traceback (most recent call last):
  File "/home/ovos/.venv/lib/python3.11/site-packages/ovos_core/intent_services/__init__.py", line 250, in handle_utterance
    match = match_func(combined, lang, message)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ovos/.venv/lib/python3.11/site-packages/ovos_core/intent_services/fallback_service.py", line 187, in high_prio
    return self._fallback_range(utterances, lang, message,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ovos/.venv/lib/python3.11/site-packages/ovos_core/intent_services/fallback_service.py", line 175, in _fallback_range
    data={'utterance': utterances[0][0],
                       ~~~~~~~~~~~~~^^^
IndexError: string index out of range
```