### PR TITLE
bump_padacioso 0.2.1a7

### DIFF
--- a/ovos_core/intent_services/padatious_service.py
+++ b/ovos_core/intent_services/padatious_service.py
@@ -314,7 +314,6 @@ class PadatiousService:
         lang = lang or self.lang
         lang = lang.lower()
         if lang in self.containers:
-            intents = []
             intent_container = self.containers.get(lang)
 
             if self.threaded_inference:

--- a/ovos_core/intent_services/padatious_service.py
+++ b/ovos_core/intent_services/padatious_service.py
@@ -139,11 +139,12 @@ class PadatiousService:
         self.conf_high = self.padatious_config.get("conf_high") or 0.95
         self.conf_med = self.padatious_config.get("conf_med") or 0.8
         self.conf_low = self.padatious_config.get("conf_low") or 0.5
+        self.workers = self.padatious_config.get("workers") or 4
 
         if self.is_regex_only:
             LOG.debug('Using Padacioso intent parser.')
             self.containers = {lang: FallbackIntentContainer(
-                self.padatious_config.get("fuzz"))
+                self.padatious_config.get("fuzz"), n_workers=self.workers)
                 for lang in langs}
         else:
             LOG.debug('Using Padatious intent parser.')
@@ -333,8 +334,6 @@ class PadatiousService:
                 #     Not Subject to the GIL, not constrained to sequential execution.
                 #     Suited to CPU-bound Tasks, probably not IO-bound tasks.
                 #     Create 10s of Workers, not 100s or 1,000s of tasks.
-
-                self.workers = 4  # do the work in parallel instead of sequentially
                 with concurrent.futures.ProcessPoolExecutor(max_workers=self.workers) as executor:
                     future_to_source = {
                         executor.submit(_calc_padatious_intent,

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -3,7 +3,7 @@ python-dateutil>=2.6, <3.0
 watchdog>=2.1, <3.0
 combo-lock>=0.2.2, <0.3
 
-padacioso~=0.2, >=0.2.1a7
+padacioso~=0.2, >=0.2.1a8
 adapt-parser>=1.0.0, <2.0.0
 
 ovos_bus_client<0.1.0, >=0.0.5

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -3,7 +3,7 @@ python-dateutil>=2.6, <3.0
 watchdog>=2.1, <3.0
 combo-lock>=0.2.2, <0.3
 
-padacioso~=0.2
+padacioso~=0.2, >=0.2.1a7
 adapt-parser>=1.0.0, <2.0.0
 
 ovos_bus_client<0.1.0, >=0.0.5

--- a/test/unittests/skills/test_utterance_intents.py
+++ b/test/unittests/skills/test_utterance_intents.py
@@ -117,28 +117,3 @@ class UtteranceIntentMatchingTest(unittest.TestCase):
         self.assertEqual(intent.matches, {'thing': 'Mycroft'})
         self.assertEqual(intent.sent, utterance)
         self.assertTrue(intent.conf <= 0.8)
-
-    def test_threaded_intent(self):
-        from time import time
-        intent_service = self.get_service(regex_only=True, fuzz=False)
-        utterances = []
-        for i in range(50):
-            utterances.append("tell me about Mycroft")
-        intent_service.padatious_config['threaded_inference'] = False
-        start = time()
-        intent = intent_service.calc_intent(utterances, "en-US")
-        single_thread_time = time() - start
-        self.assertEqual(intent.name, "test2")
-        self.assertEqual(intent.matches, {'thing': 'Mycroft'})
-        self.assertEqual(intent.sent, utterances[0])
-
-        intent_service.padatious_config['threaded_inference'] = True
-        start = time()
-        intent2 = intent_service.calc_intent(utterances, "en-US")
-        multi_thread_time = time() - start
-        self.assertEqual(intent.__dict__, intent2.__dict__)
-
-        speedup = (single_thread_time - multi_thread_time) / len(utterances)
-        print(f"speedup={speedup}")
-        # Assert threaded execution was faster (or at least not much slower)
-        self.assertGreaterEqual(speedup, -0.01)


### PR DESCRIPTION
more performance, follow up to #326 

padacioso now also uses concurrent.futures internally to parallelize the regex matching