### PR TITLE
Add missing requirement for ovos-messagebus

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -13,6 +13,7 @@ ovos-config~=0.0,>=0.0.11a3
 ovos-lingua-franca>=0.4.7
 ovos_backend_client>=0.1.0a6
 ovos_workshop<0.1.0, >=0.0.12a39
+ovos_messagebus~=0.0.3
 
 # provides plugins and classic machine learning framework
 ovos-classifiers<0.1.0, >=0.0.0a33


### PR DESCRIPTION
When updating ovos-core, the messagebus wouldn't start because this dependency isn't listed.