### PR TITLE
default session managed by core

### DIFF
--- a/ovos_core/intent_services/__init__.py
+++ b/ovos_core/intent_services/__init__.py
@@ -308,8 +308,8 @@ class IntentService:
 
             if sess.session_id == "default":
                 # sync any changes made to the default session, eg by ConverseService
-                self.bus.emit(Message("ovos.session.update_default",
-                                      {"session_data": SessionManager.default_session.serialize()}))
+                self.bus.emit(message.reply("ovos.session.update_default",
+                                            {"session_data": SessionManager.default_session.serialize()}))
             return match, message.context, stopwatch
 
         except Exception as err:

--- a/ovos_core/intent_services/__init__.py
+++ b/ovos_core/intent_services/__init__.py
@@ -282,7 +282,7 @@ class IntentService:
                 # Default session, check if it needs to be (re)-created
                 if sess.expired():
                     sess = SessionManager.reset_default_session()
-                sess.lang = lang
+            sess.lang = lang
 
             # match
             match = None

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -6,7 +6,7 @@ combo-lock>=0.2.2, <0.3
 padacioso~=0.2, >=0.2.1a8
 adapt-parser>=1.0.0, <2.0.0
 
-ovos_bus_client~=0.0,>=0.0.6a7
+
 ovos-utils<0.1.0, >=0.0.35a7
 ovos-plugin-manager<0.1.0, >=0.0.24a5
 ovos-config~=0.0,>=0.0.11a9

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -6,7 +6,7 @@ combo-lock>=0.2.2, <0.3
 padacioso~=0.2, >=0.2.1a8
 adapt-parser>=1.0.0, <2.0.0
 
-
+ovos_bus_client~=0.0,>=0.0.6a8
 ovos-utils<0.1.0, >=0.0.35a7
 ovos-plugin-manager<0.1.0, >=0.0.24a5
 ovos-config~=0.0,>=0.0.11a9


### PR DESCRIPTION
companion to https://github.com/OpenVoiceOS/ovos-bus-client/pull/50

bug: session data from a bus client may overwrite session in all other clients, either on purpose or due to race conditions
bug2: under docker each skill container gets it's own session, all skills should be getting the same default session

```
2023-09-27 22:00:28.404 - skills - ovos_bus_client.session:update:569 - DEBUG - session updated: default, active skills: []
2023-09-27 22:00:28.404 - skills - ovos_bus_client.session:update:569 - DEBUG - session updated: default, active skills: []
2023-09-27 22:00:28.429 - skills - ovos_bus_client.session:update:569 - DEBUG - session updated: default, active skills: [['skill-alerts.openvoiceos', 1695844827.9951017]]
2023-09-27 22:00:28.471 - skills - ovos_bus_client.session:update:569 - DEBUG - session updated: default, active skills: []
2023-09-27 22:00:28.483 - skills - ovos_bus_client.session:update:569 - DEBUG - session updated: default, active skills: []
2023-09-27 22:00:28.491 - skills - ovos_bus_client.session:update:569 - DEBUG - session updated: default, active skills: [['skill-alerts.openvoiceos', 1695844827.9951017]]
2023-09-27 22:00:28.510 - skills - ovos_bus_client.session:update:569 - DEBUG - session updated: default, active skills: [['skill-alerts.openvoiceos', 1695844827.9951017]]
2023-09-27 22:00:28.523 - skills - ovos_bus_client.session:update:569 - DEBUG - session updated: default, active skills: []
2023-09-27 22:00:28.537 - skills - ovos_bus_client.session:update:569 - DEBUG - session updated: default, active skills: []
2023-09-27 22:00:28.564 - skills - ovos_bus_client.session:update:569 - DEBUG - session updated: default, active skills: []
2023-09-27 22:00:28.569 - skills - ovos_bus_client.session:update:569 - DEBUG - session updated: default, active skills: [['skill-alerts.openvoiceos', 1695844827.9951017]]
2023-09-27 22:00:28.590 - skills - ovos_bus_client.session:update:569 - DEBUG - session updated: default, active skills: []
2023-09-27 22:00:28.591 - skills - ovos_bus_client.session:update:569 - DEBUG - session updated: default, active skills: []

```
we dont clients accidentally updating each others or core session. this bug happens because skills share session among each other


with this + companion PR in ovos-bus-client

default session scenario:
- core + local skills
- skills from containers
- ovos-cli-client or whatever replaces it
- messages can come from anywhere, accidentally overwriting default session (due to misordering or other race conditions) -> do not allow updates from clients to default session to avoid this
- ovos-core is the source of truth for "default" session, always

unique sessions:
- external clients (eg, hivemind) specify it by [passing session=Session()](https://github.com/JarbasHiveMind/hivemind_websocket_client/pull/20) to bus client constructor
- any message received in the bus is from core -> client exclusively
- update session data in the client at all times


this also keeps old (pre-session) behaviour, since usage of "session isolation" becomes a explicitly enabled feature only (via passing a session in the message)