### PR TITLE
fix lang detect

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -60,7 +60,7 @@ jobs:
           pip install ./test/end2end/skill-ovos-fallback-unknownv1
           pip install ./test/end2end/skill-converse_test
           pip install ./test/end2end/skill-ovos-schedule
-          pip install git+https://github.com/OpenVoiceOS/ovos-utils@troubleshoot
+          pip install git+https://github.com/OpenVoiceOS/ovos-utils
       - name: Run unittests
         run: |
           pytest --cov=ovos_core --cov-report xml test/unittests

--- a/ovos_core/intent_services/__init__.py
+++ b/ovos_core/intent_services/__init__.py
@@ -180,15 +180,15 @@ class IntentService:
         3 - detected_lang -> tagged by transformers  (text classification, free form chat)
         4 - config lang (or from message.data)
         """
-        sess = SessionManager.get(message)
         default_lang = get_message_lang(message)
+        valid_langs = [default_lang] + Configuration().get("secondary_langs", [])
         lang_keys = ["stt_lang",
                      "request_lang",
                      "detected_lang"]
         for k in lang_keys:
             if k in message.context:
                 v = message.context[k]
-                if v in sess.valid_languages:
+                if v in valid_langs:
                     if v != default_lang:
                         LOG.info(f"replaced {default_lang} with {k}: {v}")
                     return v

--- a/test/end2end/session/test_session.py
+++ b/test/end2end/session/test_session.py
@@ -206,7 +206,6 @@ class TestSessions(TestCase):
         # test deserialization of payload
         sess = Session.deserialize(messages[10].data["session_data"])
         self.assertEqual(sess.session_id, "default")
-        self.assertEqual(sess.valid_languages, ["en-us"])
 
         # test that active skills list has been updated
         self.assertEqual(messages[10].data["session_data"]["active_skills"][0][0], self.skill_id)


### PR DESCRIPTION
fix https://github.com/OpenVoiceOS/ovos-core/issues/378
```
ovos-core-86bc9bc566-vjn5j ovos-core 2023-12-07 16:54:08.030 - skills - ovos_core.intent_services:handle_utterance:343 - ERROR - 'Session' object has no attribute 'valid_languages'
ovos-core-86bc9bc566-vjn5j ovos-core Traceback (most recent call last):
ovos-core-86bc9bc566-vjn5j ovos-core   File "/home/ovos/.venv/lib/python3.11/site-packages/ovos_core/intent_services/__init__.py", line 289, in handle_utterance
ovos-core-86bc9bc566-vjn5j ovos-core     lang = self.disambiguate_lang(message)
ovos-core-86bc9bc566-vjn5j ovos-core            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ovos-core-86bc9bc566-vjn5j ovos-core   File "/home/ovos/.venv/lib/python3.11/site-packages/ovos_core/intent_services/__init__.py", line 191, in disambiguate_lang
ovos-core-86bc9bc566-vjn5j ovos-core     if v in sess.valid_languages:
ovos-core-86bc9bc566-vjn5j ovos-core             ^^^^^^^^^^^^^^^^^^^^
ovos-core-86bc9bc566-vjn5j ovos-core AttributeError: 'Session' object has no attribute 'valid_languages'
``