### PR TITLE
defaults/do_not_force_transformer_plugins

### DIFF
--- a/ovos_core/transformers.py
+++ b/ovos_core/transformers.py
@@ -15,10 +15,7 @@ class UtteranceTransformersService:
         self.loaded_plugins = {}
         self.has_loaded = False
         self.bus = bus
-        self.config = self.config_core.get("utterance_transformers") or {
-            "ovos-utterance-normalizer": {},
-            "ovos-utterance-coref-normalizer": {}
-        }
+        self.config = self.config_core.get("utterance_transformers") or {}
         self.load_plugins()
 
     def load_plugins(self):


### PR DESCRIPTION
do not force utterance normalizer / coref plugins

that is up to [ovos-config to provide default values](https://github.com/OpenVoiceOS/ovos-config/pull/93)

utterance normalize should be added to ovos-config, coref plugin should be removed