### PR TITLE
error_handling/very_large_utterances

### DIFF
--- a/ovos_core/intent_services/adapt_service.py
+++ b/ovos_core/intent_services/adapt_service.py
@@ -55,6 +55,7 @@ class AdaptService:
                         for lang in langs}
 
         self.lock = Lock()
+        self.max_words = 50  # if an utterance contains more words than this, don't attempt to match
 
     @property
     def context_keywords(self):
@@ -143,6 +144,12 @@ class AdaptService:
         """
         # we call flatten in case someone is sending the old style list of tuples
         utterances = flatten_list(utterances)
+
+        utterances = [u for u in utterances if len(u.split()) < self.max_words]
+        if not utterances:
+            LOG.error(f"utterance exceeds max size of {self.max_words} words, skipping adapt match")
+            return None
+
         lang = lang or self.lang
         if lang not in self.engines:
             return None

--- a/ovos_core/intent_services/padacioso_service.py
+++ b/ovos_core/intent_services/padacioso_service.py
@@ -73,6 +73,7 @@ class PadaciosoService:
 
         self.registered_intents = []
         self.registered_entities = []
+        self.max_words = 50  # if an utterance contains more words than this, don't attempt to match
 
     def _match_level(self, utterances, limit, lang=None):
         """Match intent and make sure a certain level of confidence is reached.
@@ -217,6 +218,10 @@ class PadaciosoService:
         """
         if isinstance(utterances, str):
             utterances = [utterances]  # backwards compat when arg was a single string
+        utterances = [u for u in utterances if len(u.split()) < self.max_words]
+        if not utterances:
+            LOG.error(f"utterance exceeds max size of {self.max_words} words, skipping padacioso match")
+            return None
         lang = lang or self.lang
         lang = lang.lower()
         if lang in self.containers:

--- a/ovos_core/intent_services/padatious_service.py
+++ b/ovos_core/intent_services/padatious_service.py
@@ -124,6 +124,7 @@ class PadatiousService:
 
         self.registered_intents = []
         self.registered_entities = []
+        self.max_words = 50  # if an utterance contains more words than this, don't attempt to match
 
     def train(self, message=None):
         """Perform padatious training.
@@ -259,6 +260,11 @@ class PadatiousService:
         """
         if isinstance(utterances, str):
             utterances = [utterances]  # backwards compat when arg was a single string
+        utterances = [u for u in utterances if len(u.split()) < self.max_words]
+        if not utterances:
+            LOG.error(f"utterance exceeds max size of {self.max_words} words, skipping padatious match")
+            return None
+
         lang = lang or self.lang
         lang = lang.lower()
         if lang in self.containers:


### PR DESCRIPTION
if we get a very large utterance (over 50 words) we are almost certain any intent match is wrong

these utterances are better handled by a fallback skill, skip adapt/padatious matching entirely

besides a minor performance improvement due to not wasting time matching intents,  false matches can be avoided as seen in this chat exchange

![imagem](https://github.com/OpenVoiceOS/ovos-core/assets/33701864/19a3c2a8-67dd-450b-b7f5-9b474821e76e)
