### PR TITLE
add adapt match levels

### DIFF
--- a/ovos_core/intent_services/__init__.py
+++ b/ovos_core/intent_services/__init__.py
@@ -504,7 +504,7 @@ class IntentService:
         """
         utterance = message.data["utterance"]
         lang = get_message_lang(message)
-        intent = self.adapt_service.match_intent([utterance], lang, message)
+        intent = self.adapt_service.match_intent([utterance], lang=lang, message=message)
         intent_data = intent.intent_data if intent else None
         self.bus.emit(message.reply("intent.service.adapt.reply",
                                     {"intent": intent_data}))

--- a/ovos_core/intent_services/__init__.py
+++ b/ovos_core/intent_services/__init__.py
@@ -504,7 +504,7 @@ class IntentService:
         """
         utterance = message.data["utterance"]
         lang = get_message_lang(message)
-        intent = self.adapt_service.match_intent([utterance], lang=lang, message=message)
+        intent = self.adapt_service.match_intent([utterance], lang, message)
         intent_data = intent.intent_data if intent else None
         self.bus.emit(message.reply("intent.service.adapt.reply",
                                     {"intent": intent_data}))

--- a/ovos_core/intent_services/__init__.py
+++ b/ovos_core/intent_services/__init__.py
@@ -504,7 +504,7 @@ class IntentService:
         """
         utterance = message.data["utterance"]
         lang = get_message_lang(message)
-        intent = self.adapt_service.match_intent([utterance], lang, message.serialize())
+        intent = self.adapt_service.match_intent((utterance,), lang, message.serialize())
         intent_data = intent.intent_data if intent else None
         self.bus.emit(message.reply("intent.service.adapt.reply",
                                     {"intent": intent_data}))

--- a/ovos_core/intent_services/__init__.py
+++ b/ovos_core/intent_services/__init__.py
@@ -223,14 +223,16 @@ class IntentService:
             "stop_low": self.stop.match_stop_low,
             "padatious_high": padatious_matcher.match_high,
             "padacioso_high": self.padacioso_service.match_high,
-            "adapt": self.adapt_service.match_intent,
+            "adapt_high": self.adapt_service.match_high,
             "common_qa": self.common_qa.match,
             "fallback_high": self.fallback.high_prio,
             "padatious_medium": padatious_matcher.match_medium,
             "padacioso_medium": self.padacioso_service.match_medium,
+            "adapt_medium": self.adapt_service.match_medium,
             "fallback_medium": self.fallback.medium_prio,
             "padatious_low": padatious_matcher.match_low,
             "padacioso_low": self.padacioso_service.match_low,
+            "adapt_low": self.adapt_service.match_low,
             "fallback_low": self.fallback.low_prio
         }
         skips = skips or []

--- a/ovos_core/intent_services/__init__.py
+++ b/ovos_core/intent_services/__init__.py
@@ -496,7 +496,7 @@ class IntentService:
         """
         self.converse.handle_get_active_skills(message)
 
-    def handle_get_adapt(self, message):
+    def handle_get_adapt(self, message: Message):
         """handler getting the adapt response for an utterance.
 
         Args:
@@ -504,7 +504,7 @@ class IntentService:
         """
         utterance = message.data["utterance"]
         lang = get_message_lang(message)
-        intent = self.adapt_service.match_intent([utterance], lang, message)
+        intent = self.adapt_service.match_intent([utterance], lang, message.serialize())
         intent_data = intent.intent_data if intent else None
         self.bus.emit(message.reply("intent.service.adapt.reply",
                                     {"intent": intent_data}))

--- a/ovos_core/intent_services/adapt_service.py
+++ b/ovos_core/intent_services/adapt_service.py
@@ -164,12 +164,15 @@ class AdaptService:
         """Run the Adapt engine to search for an matching intent.
 
         Args:
-            utterances (iterable): utterances for consideration in intent
-            matching. As a practical matter, a single utterance will be
-            passed in most cases.  But there are instances, such as
-            streaming STT that could pass multiple.  Each utterance
-            is represented as a tuple containing the raw, normalized, and
-            possibly other variations of the utterance.
+            utterances (iterable): utterances for consideration in intent 
+                    matching. As a practical matter, a single utterance will 
+                    be passed in most cases. But there are instances, such as
+                    streaming STT that could pass multiple. Each utterance is 
+                    represented as a tuple containing the raw, normalized, and
+                    possibly other variations of the utterance.
+            limit (float): confidence threshold for intent matching
+            lang (str): language to use for intent matching
+            message (Message): message to use for context
 
         Returns:
             Intent structure, or None if no match was found.

--- a/ovos_core/intent_services/adapt_service.py
+++ b/ovos_core/intent_services/adapt_service.py
@@ -135,7 +135,7 @@ class AdaptService:
         ents = [tag['entities'][0] for tag in intent['__tags__'] if 'entities' in tag]
         sess.context.update_context(ents)
     
-    def match_high(self, utterances: List[str, tuple],
+    def match_high(self, utterances: List[str],
                          lang: Optional[str] = None,
                          message: Optional[Message] = None):
         """Intent matcher for high confidence.
@@ -149,7 +149,7 @@ class AdaptService:
             return match
         return None
 
-    def match_medium(self, utterances: List[str, tuple],
+    def match_medium(self, utterances: List[str],
                            lang: Optional[str] = None,
                            message: Optional[Message] = None):
         """Intent matcher for medium confidence.
@@ -163,7 +163,7 @@ class AdaptService:
             return match
         return None
 
-    def match_low(self, utterances: List[str, tuple],
+    def match_low(self, utterances: List[str],
                         lang: Optional[str] = None,
                         message: Optional[Message] = None):
         """Intent matcher for low confidence.
@@ -178,7 +178,7 @@ class AdaptService:
         return None
 
     @lru_cache(maxsize=3)
-    def match_intent(self, utterances: Tuple[str, tuple],
+    def match_intent(self, utterances: Tuple[str],
                            lang: Optional[str] = None,
                            message: Optional[str] = None):
         """Run the Adapt engine to search for an matching intent.

--- a/ovos_core/intent_services/adapt_service.py
+++ b/ovos_core/intent_services/adapt_service.py
@@ -160,7 +160,7 @@ class AdaptService:
         """
         return self.match_intent(utterances, self.conf_low, lang, message)
 
-    def match_intent(self, utterances, limit, lang=None, message=None):
+    def match_intent(self, utterances, limit=0, lang=None, message=None):
         """Run the Adapt engine to search for an matching intent.
 
         Args:

--- a/ovos_core/intent_services/adapt_service.py
+++ b/ovos_core/intent_services/adapt_service.py
@@ -145,7 +145,7 @@ class AdaptService:
                                          with optional normalized version.
         """
         match = self.match_intent(tuple(utterances), lang, message.serialize())
-        if match and match.confidence > self.conf_high:
+        if match and match.intent_data.get("confidence", 0.0) > self.conf_high:
             return match
         return None
 
@@ -159,7 +159,7 @@ class AdaptService:
                                          with optional normalized version.
         """
         match = self.match_intent(tuple(utterances), lang, message.serialize())
-        if match and match.confidence > self.conf_med:
+        if match and match.intent_data.get("confidence", 0.0) > self.conf_med:
             return match
         return None
 
@@ -173,7 +173,7 @@ class AdaptService:
                                          with optional normalized version.
         """
         match = self.match_intent(tuple(utterances), lang, message.serialize())
-        if match and match.confidence > self.conf_low:
+        if match and match.intent_data.get("confidence", 0.0) > self.conf_low:
             return match
         return None
 

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -9,7 +9,7 @@ adapt-parser>=1.0.0, <2.0.0
 ovos-utils>=0.0.38
 ovos_bus_client<0.1.0, >=0.0.8
 ovos-plugin-manager<0.1.0, >=0.0.25
-ovos-config~=0.0,>=0.0.13a5
+ovos-config~=0.0,>=0.0.13a6
 ovos-lingua-franca>=0.4.7
 ovos-backend-client~=0.1.0
 ovos-workshop<0.1.0, >=0.0.15

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -9,7 +9,7 @@ adapt-parser>=1.0.0, <2.0.0
 ovos-utils>=0.0.38
 ovos_bus_client<0.1.0, >=0.0.8
 ovos-plugin-manager<0.1.0, >=0.0.25
-ovos-config~=0.0,>=0.0.12
+ovos-config~=0.0,>=0.0.13a5
 ovos-lingua-franca>=0.4.7
 ovos-backend-client~=0.1.0
 ovos-workshop<0.1.0, >=0.0.15

--- a/test/end2end/session/test_stop.py
+++ b/test/end2end/session/test_stop.py
@@ -47,13 +47,14 @@ class TestSessions(TestCase):
                            "stop_high",
                            "converse",
                            "padatious_high",
-                           "adapt",
-                           "common_qa",
+                           "adapt_high",
                            "fallback_high",
                            "stop_medium",
                            "padatious_medium",
+                           "adapt_medium",
+                           "adapt_low",
+                           "common_qa",
                            "fallback_medium",
-                           "padatious_low",
                            "fallback_low"
                        ])
 
@@ -238,13 +239,14 @@ class TestSessions(TestCase):
                            "stop_high",
                            "converse",
                            "padatious_high",
-                           "adapt",
-                           "common_qa",
+                           "adapt_high",
                            "fallback_high",
                            "stop_medium",
                            "padatious_medium",
+                           "adapt_medium",
+                           "adapt_low",
+                           "common_qa",
                            "fallback_medium",
-                           "padatious_low",
                            "fallback_low"
                        ])
 

--- a/test/unittests/skills/test_intent_service.py
+++ b/test/unittests/skills/test_intent_service.py
@@ -21,7 +21,6 @@ from ovos_config import Configuration
 from ovos_bus_client.message import Message
 from ovos_core.intent_services import IntentService
 from ovos_bus_client.util import get_message_lang
-from ovos_bus_client.session import Session
 from ovos_utils.log import LOG
 from ovos_core.intent_services.adapt_service import ContextManager
 
@@ -133,22 +132,6 @@ def get_last_message(bus):
 class TestIntentServiceApi(TestCase):
     def setUp(self):
         self.intent_service = IntentService(mock.Mock())
-        self.sess = Session("adapt",
-                       pipeline=[
-                           "stop_high",
-                           "converse",
-                           "padatious_high",
-                           "adapt_high",
-                           "common_qa",
-                           "fallback_high",
-                           "stop_medium",
-                           "padatious_medium",
-                           "adapt_medium",
-                           "fallback_medium",
-                           "padatious_low",
-                           "adapt_low",
-                           "fallback_low"
-                       ])
 
     def setup_simple_adapt_intent(self,
                                   msg=create_vocab_msg('testKeyword', 'test')):
@@ -165,8 +148,7 @@ class TestIntentServiceApi(TestCase):
 
         # Check that the intent is returned
         msg = Message('intent.service.adapt.get',
-                      data={'utterance': 'test'},
-                      context={"session": self.sess.serialize()})
+                      data={'utterance': 'test'})
         self.intent_service.handle_get_adapt(msg)
 
         reply = get_last_message(self.intent_service.bus)
@@ -177,8 +159,7 @@ class TestIntentServiceApi(TestCase):
         self.setup_simple_adapt_intent()
         # Check that the intent is returned
         msg = Message('intent.service.adapt.get',
-                      data={'utterance': 'test'},
-                      context={"session": self.sess.serialize()})
+                      data={'utterance': 'test'})
         self.intent_service.handle_get_adapt(msg)
 
         reply = get_last_message(self.intent_service.bus)
@@ -190,8 +171,7 @@ class TestIntentServiceApi(TestCase):
         self.setup_simple_adapt_intent()
         # Check that no intent is matched
         msg = Message('intent.service.adapt.get',
-                      data={'utterance': 'five'},
-                      context={"session": self.sess.serialize()})
+                      data={'utterance': 'five'})
         self.intent_service.handle_get_adapt(msg)
         reply = get_last_message(self.intent_service.bus)
         self.assertEqual(reply.data['intent'], None)
@@ -201,8 +181,7 @@ class TestIntentServiceApi(TestCase):
         self.setup_simple_adapt_intent()
         # Check that the intent is returned
         msg = Message('intent.service.adapt.get',
-                      data={'utterance': 'test'},
-                      context={"session": self.sess.serialize()})
+                      data={'utterance': 'test'})
         self.intent_service.handle_get_intent(msg)
 
         reply = get_last_message(self.intent_service.bus)
@@ -214,8 +193,7 @@ class TestIntentServiceApi(TestCase):
         self.setup_simple_adapt_intent()
         # Check that no intent is matched
         msg = Message('intent.service.intent.get',
-                      data={'utterance': 'five'},
-                      context={"session": self.sess.serialize()})
+                      data={'utterance': 'five'})
         self.intent_service.handle_get_intent(msg)
         reply = get_last_message(self.intent_service.bus)
         self.assertEqual(reply.data['intent'], None)
@@ -225,8 +203,7 @@ class TestIntentServiceApi(TestCase):
         self.setup_simple_adapt_intent()
         # Check that no intent is matched
         msg = Message('intent.service.intent.get',
-                      data={'utterance': 'five'},
-                      context={"session": self.sess.serialize()})
+                      data={'utterance': 'five'})
         self.intent_service.handle_get_intent(msg)
         reply = get_last_message(self.intent_service.bus)
         self.assertEqual(reply.data['intent'], None)
@@ -234,8 +211,7 @@ class TestIntentServiceApi(TestCase):
     def test_get_adapt_intent_manifest(self):
         """Make sure the manifest returns a list of Intent Parser objects."""
         self.setup_simple_adapt_intent()
-        msg = Message('intent.service.adapt.manifest.get',
-                      context={"session": self.sess.serialize()})
+        msg = Message('intent.service.adapt.manifest.get')
         self.intent_service.handle_adapt_manifest(msg)
         reply = get_last_message(self.intent_service.bus)
         self.assertEqual(reply.data['intents'][0]['name'],
@@ -243,8 +219,7 @@ class TestIntentServiceApi(TestCase):
 
     def test_get_adapt_vocab_manifest(self):
         self.setup_simple_adapt_intent()
-        msg = Message('intent.service.adapt.vocab.manifest.get',
-                      context={"session": self.sess.serialize()})
+        msg = Message('intent.service.adapt.vocab.manifest.get')
         self.intent_service.handle_vocab_manifest(msg)
         reply = get_last_message(self.intent_service.bus)
         value = reply.data['vocab'][0]['entity_value']
@@ -257,8 +232,7 @@ class TestIntentServiceApi(TestCase):
         self.setup_simple_adapt_intent()
         # Check that no intent is matched
         msg = Message('detach_intent',
-                      data={'intent_name': 'skill:testIntent'},
-                      context={"session": self.sess.serialize()})
+                      data={'intent_name': 'skill:testIntent'})
         self.intent_service.handle_detach_intent(msg)
         msg = Message('intent.service.adapt.get', data={'utterance': 'test'})
         self.intent_service.handle_get_adapt(msg)
@@ -270,8 +244,7 @@ class TestIntentServiceApi(TestCase):
         self.setup_simple_adapt_intent()
         # Check that no intent is matched
         msg = Message('detach_intent',
-                      data={'skill_id': 'skill'},
-                      context={"session": self.sess.serialize()})
+                      data={'skill_id': 'skill'})
         self.intent_service.handle_detach_skill(msg)
         msg = Message('intent.service.adapt.get', data={'utterance': 'test'})
         self.intent_service.handle_get_adapt(msg)

--- a/test/unittests/skills/test_intent_service.py
+++ b/test/unittests/skills/test_intent_service.py
@@ -21,6 +21,7 @@ from ovos_config import Configuration
 from ovos_bus_client.message import Message
 from ovos_core.intent_services import IntentService
 from ovos_bus_client.util import get_message_lang
+from ovos_bus_client.session import Session
 from ovos_utils.log import LOG
 from ovos_core.intent_services.adapt_service import ContextManager
 
@@ -132,6 +133,22 @@ def get_last_message(bus):
 class TestIntentServiceApi(TestCase):
     def setUp(self):
         self.intent_service = IntentService(mock.Mock())
+        self.sess = Session("adapt",
+                       pipeline=[
+                           "stop_high",
+                           "converse",
+                           "padatious_high",
+                           "adapt_high",
+                           "common_qa",
+                           "fallback_high",
+                           "stop_medium",
+                           "padatious_medium",
+                           "adapt_medium",
+                           "fallback_medium",
+                           "padatious_low",
+                           "adapt_low",
+                           "fallback_low"
+                       ])
 
     def setup_simple_adapt_intent(self,
                                   msg=create_vocab_msg('testKeyword', 'test')):
@@ -147,7 +164,9 @@ class TestIntentServiceApi(TestCase):
         )
 
         # Check that the intent is returned
-        msg = Message('intent.service.adapt.get', data={'utterance': 'test'})
+        msg = Message('intent.service.adapt.get',
+                      data={'utterance': 'test'},
+                      context={"session": self.sess.serialize()})
         self.intent_service.handle_get_adapt(msg)
 
         reply = get_last_message(self.intent_service.bus)
@@ -157,7 +176,9 @@ class TestIntentServiceApi(TestCase):
     def test_get_adapt_intent(self):
         self.setup_simple_adapt_intent()
         # Check that the intent is returned
-        msg = Message('intent.service.adapt.get', data={'utterance': 'test'})
+        msg = Message('intent.service.adapt.get',
+                      data={'utterance': 'test'},
+                      context={"session": self.sess.serialize()})
         self.intent_service.handle_get_adapt(msg)
 
         reply = get_last_message(self.intent_service.bus)
@@ -168,7 +189,9 @@ class TestIntentServiceApi(TestCase):
         """Check that if the intent doesn't match at all None is returned."""
         self.setup_simple_adapt_intent()
         # Check that no intent is matched
-        msg = Message('intent.service.adapt.get', data={'utterance': 'five'})
+        msg = Message('intent.service.adapt.get',
+                      data={'utterance': 'five'},
+                      context={"session": self.sess.serialize()})
         self.intent_service.handle_get_adapt(msg)
         reply = get_last_message(self.intent_service.bus)
         self.assertEqual(reply.data['intent'], None)
@@ -177,7 +200,9 @@ class TestIntentServiceApi(TestCase):
         """Check that the registered adapt intent is triggered."""
         self.setup_simple_adapt_intent()
         # Check that the intent is returned
-        msg = Message('intent.service.adapt.get', data={'utterance': 'test'})
+        msg = Message('intent.service.adapt.get',
+                      data={'utterance': 'test'},
+                      context={"session": self.sess.serialize()})
         self.intent_service.handle_get_intent(msg)
 
         reply = get_last_message(self.intent_service.bus)
@@ -188,7 +213,9 @@ class TestIntentServiceApi(TestCase):
         """Check that if the intent doesn't match at all None is returned."""
         self.setup_simple_adapt_intent()
         # Check that no intent is matched
-        msg = Message('intent.service.intent.get', data={'utterance': 'five'})
+        msg = Message('intent.service.intent.get',
+                      data={'utterance': 'five'},
+                      context={"session": self.sess.serialize()})
         self.intent_service.handle_get_intent(msg)
         reply = get_last_message(self.intent_service.bus)
         self.assertEqual(reply.data['intent'], None)
@@ -197,7 +224,9 @@ class TestIntentServiceApi(TestCase):
         """Check that if the intent doesn't match at all None is returned."""
         self.setup_simple_adapt_intent()
         # Check that no intent is matched
-        msg = Message('intent.service.intent.get', data={'utterance': 'five'})
+        msg = Message('intent.service.intent.get',
+                      data={'utterance': 'five'},
+                      context={"session": self.sess.serialize()})
         self.intent_service.handle_get_intent(msg)
         reply = get_last_message(self.intent_service.bus)
         self.assertEqual(reply.data['intent'], None)
@@ -205,7 +234,8 @@ class TestIntentServiceApi(TestCase):
     def test_get_adapt_intent_manifest(self):
         """Make sure the manifest returns a list of Intent Parser objects."""
         self.setup_simple_adapt_intent()
-        msg = Message('intent.service.adapt.manifest.get')
+        msg = Message('intent.service.adapt.manifest.get',
+                      context={"session": self.sess.serialize()})
         self.intent_service.handle_adapt_manifest(msg)
         reply = get_last_message(self.intent_service.bus)
         self.assertEqual(reply.data['intents'][0]['name'],
@@ -213,7 +243,8 @@ class TestIntentServiceApi(TestCase):
 
     def test_get_adapt_vocab_manifest(self):
         self.setup_simple_adapt_intent()
-        msg = Message('intent.service.adapt.vocab.manifest.get')
+        msg = Message('intent.service.adapt.vocab.manifest.get',
+                      context={"session": self.sess.serialize()})
         self.intent_service.handle_vocab_manifest(msg)
         reply = get_last_message(self.intent_service.bus)
         value = reply.data['vocab'][0]['entity_value']
@@ -226,7 +257,8 @@ class TestIntentServiceApi(TestCase):
         self.setup_simple_adapt_intent()
         # Check that no intent is matched
         msg = Message('detach_intent',
-                      data={'intent_name': 'skill:testIntent'})
+                      data={'intent_name': 'skill:testIntent'},
+                      context={"session": self.sess.serialize()})
         self.intent_service.handle_detach_intent(msg)
         msg = Message('intent.service.adapt.get', data={'utterance': 'test'})
         self.intent_service.handle_get_adapt(msg)
@@ -238,7 +270,8 @@ class TestIntentServiceApi(TestCase):
         self.setup_simple_adapt_intent()
         # Check that no intent is matched
         msg = Message('detach_intent',
-                      data={'skill_id': 'skill'})
+                      data={'skill_id': 'skill'},
+                      context={"session": self.sess.serialize()})
         self.intent_service.handle_detach_skill(msg)
         msg = Message('intent.service.adapt.get', data={'utterance': 'test'})
         self.intent_service.handle_get_adapt(msg)


### PR DESCRIPTION
Problem: The Adapt matcher matching unrestricted.

As with the other services, 3 (configurable) threshold matcher are added to the pipeline for finegrained adjustability. 
One thing in question, is the config option (key `context`) what we want?

Companion PR (config): https://github.com/OpenVoiceOS/ovos-config/pull/100