### PR TITLE
fix: blacklisted skills

### DIFF
--- a/ovos_core/skill_manager.py
+++ b/ovos_core/skill_manager.py
@@ -128,7 +128,7 @@ class SkillManager(Thread):
 
     @property
     def blacklist(self):
-        return Configuration().get("skills", {}).get("blacklisted_skills", ["skill-ovos-fallback-unknown.openvoiceos"])
+        return Configuration().get("skills", {}).get("blacklisted_skills", ["skill-ovos-stop.openvoiceos"])
 
     def _init_filewatcher(self):
         # monitor skill settings files for changes

--- a/ovos_core/skill_manager.py
+++ b/ovos_core/skill_manager.py
@@ -600,7 +600,7 @@ class SkillManager(Thread):
         skill_id = basename(skill_directory)
         if skill_id in self.blacklist:
             LOG.warning(f"{skill_id} is blacklisted, it will NOT be loaded")
-            LOG.info(f"Consider uninstalling {skill_id} instead of blacklisting it")
+            LOG.info(f"Consider deleting {skill_directory} instead of blacklisting it")
             return None
 
         skill_loader = self._get_skill_loader(skill_directory)

--- a/ovos_core/skill_manager.py
+++ b/ovos_core/skill_manager.py
@@ -20,18 +20,18 @@ from threading import Thread, Event, Lock
 from time import sleep, monotonic
 
 from ovos_backend_client.pairing import is_paired
+from ovos_bus_client.apis.enclosure import EnclosureAPI
 from ovos_bus_client.client import MessageBusClient
 from ovos_bus_client.message import Message
 from ovos_config.config import Configuration
 from ovos_config.locations import get_xdg_config_save_path
 from ovos_plugin_manager.skills import find_skill_plugins
-from ovos_bus_client.apis.enclosure import EnclosureAPI
+from ovos_plugin_manager.skills import get_skill_directories
 from ovos_utils.file_utils import FileWatcher
 from ovos_utils.gui import is_gui_connected
 from ovos_utils.log import LOG
 from ovos_utils.network_utils import is_connected
 from ovos_utils.process_utils import ProcessStatus, StatusCallbackMap, ProcessState
-from ovos_plugin_manager.skills import get_skill_directories
 from ovos_workshop.skill_launcher import SKILL_MAIN_MODULE
 from ovos_workshop.skill_launcher import SkillLoader, PluginSkillLoader
 
@@ -125,6 +125,10 @@ class SkillManager(Thread):
 
         self.status.bind(self.bus)
         self._init_filewatcher()
+
+    @property
+    def blacklist(self):
+        return Configuration().get("skills", {}).get("blacklisted_skills", ["skill-ovos-fallback-unknown.openvoiceos"])
 
     def _init_filewatcher(self):
         # monitor skill settings files for changes
@@ -326,6 +330,10 @@ class SkillManager(Thread):
         plugins = find_skill_plugins()
         loaded_skill_ids = [basename(p) for p in self.skill_loaders]
         for skill_id, plug in plugins.items():
+            if skill_id in self.blacklist:
+                LOG.warning(f"{skill_id} is blacklisted, it will NOT be loaded")
+                LOG.info(f"Consider uninstalling {skill_id} instead of blacklisting it")
+                continue
             if skill_id not in self.plugin_skills and skill_id not in loaded_skill_ids:
                 skill_loader = self._get_plugin_skill_loader(skill_id, init_bus=False)
                 requirements = skill_loader.runtime_requirements
@@ -586,6 +594,14 @@ class SkillManager(Thread):
         return SkillLoader(bus, skill_directory)
 
     def _load_skill(self, skill_directory):
+        LOG.warning(f"Found deprecated skill directory: {skill_directory}\n"
+                    f"please create a setup.py for this skill")
+        skill_id = basename(skill_directory)
+        if skill_id in self.blacklist:
+            LOG.warning(f"{skill_id} is blacklisted, it will NOT be loaded")
+            LOG.info(f"Consider uninstalling {skill_id} instead of blacklisting it")
+            return None
+
         skill_loader = self._get_skill_loader(skill_directory)
         try:
             load_status = skill_loader.load()
@@ -594,7 +610,7 @@ class SkillManager(Thread):
             load_status = False
         finally:
             self.skill_loaders[skill_directory] = skill_loader
-
+        LOG.info(f"Loaded old style skill: {skill_directory}")
         return skill_loader if load_status else None
 
     def _unload_skill(self, skill_dir):

--- a/ovos_core/skill_manager.py
+++ b/ovos_core/skill_manager.py
@@ -128,7 +128,8 @@ class SkillManager(Thread):
 
     @property
     def blacklist(self):
-        return Configuration().get("skills", {}).get("blacklisted_skills", ["skill-ovos-stop.openvoiceos"])
+        return Configuration().get("skills", {}).get("blacklisted_skills",
+                                                     ["skill-ovos-stop.openvoiceos"])
 
     def _init_filewatcher(self):
         # monitor skill settings files for changes


### PR DESCRIPTION
closes https://github.com/OpenVoiceOS/ovos-core/issues/383

missed in https://github.com/OpenVoiceOS/ovos-core/pull/313 apparently

logs should have
```
2024-02-28 22:01:00.559 - skills - ovos_core.skill_manager:_load_on_startup:540 - INFO - Loading offline skills...
2024-02-28 22:01:03.834 - skills - ovos_core.skill_manager:load_plugin_skills:334 - WARNING - skill-ovos-stop.openvoiceos is blacklisted, it will NOT be loaded
2024-02-28 22:01:03.834 - skills - ovos_core.skill_manager:load_plugin_skills:335 - INFO - Consider uninstalling skill-ovos-stop.openvoiceos instead of blacklisting it
```