### PR TITLE
Update SkillManager logging and optimize infinite loop

### DIFF
--- a/ovos_core/skill_manager.py
+++ b/ovos_core/skill_manager.py
@@ -401,8 +401,10 @@ class SkillManager(Thread):
         loaded_skill_ids = [basename(p) for p in self.skill_loaders]
         for skill_id, plug in plugins.items():
             if skill_id in self.blacklist:
-                LOG.warning(f"{skill_id} is blacklisted, it will NOT be loaded")
-                LOG.info(f"Consider uninstalling {skill_id} instead of blacklisting it")
+                if skill_id not in self._logged_skill_warnings:
+                    self._logged_skill_warnings.append(skill_id)
+                    LOG.warning(f"{skill_id} is blacklisted, it will NOT be loaded")
+                    LOG.info(f"Consider uninstalling {skill_id} instead of blacklisting it")
                 continue
             if skill_id not in self.plugin_skills and skill_id not in loaded_skill_ids:
                 skill_loader = self._get_plugin_skill_loader(skill_id, init_bus=False)

--- a/ovos_core/skill_manager.py
+++ b/ovos_core/skill_manager.py
@@ -665,9 +665,7 @@ class SkillManager(Thread):
 
                 # A local source install is replacing this plugin, unload it!
                 if skill_id in self.plugin_skills:
-                    if skill_id not in self._logged_skill_warnings:
-                        self._logged_skill_warnings.append(skill_id)
-                        LOG.info(f"{skill_id} plugin will be replaced by a local version: {skill_dir}")
+                    LOG.info(f"{skill_id} plugin will be replaced by a local version: {skill_dir}")
                     self._unload_plugin_skill(skill_id)
 
                 for old_skill_dir, skill_loader in self.skill_loaders.items():

--- a/test/unittests/skills/test_manager.py
+++ b/test/unittests/skills/test_manager.py
@@ -186,10 +186,11 @@ class TestSkillManager(unittest.TestCase):
 
         # Mock loading a local directory that is blacklisted
         self.skill_manager.config['skills']['blacklisted_skills'].append("local_skill.test")
-        self.skill_manager._load_skill(join(dirname(__file__), 'local_skill.test'))
+        test_skill_path = join(dirname(__file__), 'local_skill.test')
+        self.skill_manager._load_skill(test_skill_path)
         mock_log.warning.assert_called_with("local_skill.test is blacklisted, it will NOT be loaded")
         mock_log.info.assert_called_with(
-            "Consider uninstalling local_skill.test instead of blacklisting it")
+            f"Consider deleting {test_skill_path} instead of blacklisting it")
         self.assertIn("local_skill.test", self.skill_manager._logged_skill_warnings)
 
 

--- a/test/unittests/skills/test_manager.py
+++ b/test/unittests/skills/test_manager.py
@@ -175,8 +175,9 @@ class TestSkillManager(unittest.TestCase):
 
                 # Calling _load_new_skills
                 self.skill_manager._load_new_skills(network=True, internet=True, gui=True)
+                self.skill_manager._load_new_skills(network=True, internet=True, gui=True)
 
-                # Assert that a warning log message is generated for the blacklisted skill
+                # Assert that a warning log message is generated once for the blacklisted skill
                 mock_log.warning.assert_called_once_with("blacklisted_skill is blacklisted, it will NOT be loaded")
                 mock_log.info.assert_called_once_with(
                     "Consider uninstalling blacklisted_skill instead of blacklisting it")

--- a/test/unittests/skills/test_manager.py
+++ b/test/unittests/skills/test_manager.py
@@ -1,4 +1,5 @@
 import unittest
+from os.path import join, dirname
 from unittest.mock import MagicMock, patch
 
 from ovos_bus_client.message import Message
@@ -175,12 +176,21 @@ class TestSkillManager(unittest.TestCase):
 
                 # Calling _load_new_skills
                 self.skill_manager._load_new_skills(network=True, internet=True, gui=True)
+                self.assertEqual(self.skill_manager._logged_skill_warnings, ["blacklisted_skill"])
                 self.skill_manager._load_new_skills(network=True, internet=True, gui=True)
 
                 # Assert that a warning log message is generated once for the blacklisted skill
                 mock_log.warning.assert_called_once_with("blacklisted_skill is blacklisted, it will NOT be loaded")
                 mock_log.info.assert_called_once_with(
                     "Consider uninstalling blacklisted_skill instead of blacklisting it")
+
+        # Mock loading a local directory that is blacklisted
+        self.skill_manager.config['skills']['blacklisted_skills'].append("local_skill.test")
+        self.skill_manager._load_skill(join(dirname(__file__), 'local_skill.test'))
+        mock_log.warning.assert_called_once_with("local_skill.test is blacklisted, it will NOT be loaded")
+        mock_log.info.assert_called_once_with(
+            "Consider uninstalling local_skill.test instead of blacklisting it")
+        self.assertIn("local_skill.test", self.skill_manager._logged_skill_warnings)
 
 
 if __name__ == '__main__':

--- a/test/unittests/skills/test_manager.py
+++ b/test/unittests/skills/test_manager.py
@@ -187,8 +187,8 @@ class TestSkillManager(unittest.TestCase):
         # Mock loading a local directory that is blacklisted
         self.skill_manager.config['skills']['blacklisted_skills'].append("local_skill.test")
         self.skill_manager._load_skill(join(dirname(__file__), 'local_skill.test'))
-        mock_log.warning.assert_called_once_with("local_skill.test is blacklisted, it will NOT be loaded")
-        mock_log.info.assert_called_once_with(
+        mock_log.warning.assert_called_with("local_skill.test is blacklisted, it will NOT be loaded")
+        mock_log.info.assert_called_with(
             "Consider uninstalling local_skill.test instead of blacklisting it")
         self.assertIn("local_skill.test", self.skill_manager._logged_skill_warnings)
 


### PR DESCRIPTION
Update logging to prevent extra logs in the skill loading loop
Optimize skill loading loop to exit more quickly and use fewer CPU cycles
Closes #431 