### PR TITLE
feat/better_ocp_pipeline_handling

### DIFF
--- a/mycroft/skills/intent_services/__init__.py
+++ b/mycroft/skills/intent_services/__init__.py
@@ -1,14 +1,12 @@
 from ovos_core.intent_services import AdaptService,\
-    ConverseService,\
+    ConverseService, \
     CommonQAService, \
     FallbackService, \
-    PadaciosoService, \
-    PadatiousService
+    PadaciosoService
 from ovos_core.intent_services import IntentMatch
 from mycroft.skills.intent_services.adapt_service import AdaptIntent, IntentBuilder, Intent
 
-try:  # TODO -remove backwards compat import, before 0.0.8, ovos_core module didnt make it into a stable release yet!
-    from ovos_core.intent_services import PadatiousMatcher
+try:
+    from ovos_core.intent_services.padatious_service import PadatiousService, PadatiousMatcher
 except ImportError:
-    from ovos_utils.log import LOG
-    LOG.warning("padatious not installed")
+    from ovos_core.intent_services.padacioso_service import PadaciosoService as PadatiousService

--- a/mycroft/skills/intent_services/__init__.py
+++ b/mycroft/skills/intent_services/__init__.py
@@ -9,4 +9,6 @@ from mycroft.skills.intent_services.adapt_service import AdaptIntent, IntentBuil
 try:
     from ovos_core.intent_services.padatious_service import PadatiousService, PadatiousMatcher
 except ImportError:
+    from ovos_utils.log import LOG
+    LOG.warning("padatious not installed")
     from ovos_core.intent_services.padacioso_service import PadaciosoService as PadatiousService

--- a/ovos_core/intent_services/__init__.py
+++ b/ovos_core/intent_services/__init__.py
@@ -30,11 +30,6 @@ from ovos_utils.log import LOG, deprecated, log_deprecation
 from ovos_utils.metrics import Stopwatch
 from ovos_workshop.intents import open_intent_envelope
 
-try:
-    from ovos_core.intent_services.padatious_service import PadatiousService, PadatiousMatcher
-except ImportError:
-    from ovos_core.intent_services.padacioso_service import PadaciosoService as PadatiousService
-
 
 # Intent match response tuple containing
 # intent_service: Name of the service that matched the intent
@@ -63,10 +58,11 @@ class IntentService:
 
         # TODO - replace with plugins
         self.adapt_service = AdaptService()
-        if PadaciosoService is not PadatiousService:
+        try:
+            from ovos_core.intent_services.padatious_service import PadatiousService, PadatiousMatcher
             self.padatious_service = PadatiousService(bus, config['padatious'])
-        else:
-            LOG.error(f'Failed to create padatious handlers, padatious not installed')
+        except ImportError:
+            LOG.error(f'Failed to create padatious intent handlers, padatious not installed')
             self.padatious_service = None
         self.padacioso_service = PadaciosoService(bus, config['padatious'])
         self.fallback = FallbackService(bus)
@@ -249,8 +245,7 @@ class IntentService:
             "padatious_low": padatious_matcher.match_low,
             "padacioso_low": self.padacioso_service.match_low,
             "adapt_low": self.adapt_service.match_low,
-            "fallback_low": self.fallback.low_prio,
-            "adapt": self.adapt_service.match_medium # DEPRECATED - compat only TODO remove before stable, was only in alphas
+            "fallback_low": self.fallback.low_prio
         }
         if self.ocp is not None:
             matchers.update({

--- a/ovos_core/intent_services/__init__.py
+++ b/ovos_core/intent_services/__init__.py
@@ -59,7 +59,7 @@ class IntentService:
         # TODO - replace with plugins
         self.adapt_service = AdaptService()
         try:
-            from ovos_core.intent_services.padatious_service import PadatiousService, PadatiousMatcher
+            from ovos_core.intent_services.padatious_service import PadatiousService
             self.padatious_service = PadatiousService(bus, config['padatious'])
         except ImportError:
             LOG.error(f'Failed to create padatious intent handlers, padatious not installed')

--- a/ovos_core/intent_services/padacioso_service.py
+++ b/ovos_core/intent_services/padacioso_service.py
@@ -61,7 +61,6 @@ class PadaciosoService:
         self.conf_low = self.padacioso_config.get("conf_low") or 0.5
         self.workers = self.padacioso_config.get("workers") or 4
 
-        LOG.debug('Using Padacioso intent parser.')
         self.containers = {lang: FallbackIntentContainer(
             self.padacioso_config.get("fuzz"), n_workers=self.workers)
             for lang in langs}
@@ -74,6 +73,7 @@ class PadaciosoService:
         self.registered_intents = []
         self.registered_entities = []
         self.max_words = 50  # if an utterance contains more words than this, don't attempt to match
+        LOG.debug('Loaded Padacioso intent parser.')
 
     def _match_level(self, utterances, limit, lang=None):
         """Match intent and make sure a certain level of confidence is reached.

--- a/ovos_core/intent_services/padatious_service.py
+++ b/ovos_core/intent_services/padatious_service.py
@@ -103,7 +103,6 @@ class PadatiousService:
         self.conf_med = self.padatious_config.get("conf_med") or 0.8
         self.conf_low = self.padatious_config.get("conf_low") or 0.5
 
-        LOG.debug('Using Padatious intent parser.')
         intent_cache = self.padatious_config.get(
             'intent_cache') or f"{xdg_data_home()}/{get_xdg_base()}/intent_cache"
         self.containers = {
@@ -125,6 +124,7 @@ class PadatiousService:
         self.registered_intents = []
         self.registered_entities = []
         self.max_words = 50  # if an utterance contains more words than this, don't attempt to match
+        LOG.debug('Loaded Padatious intent parser.')
 
     def train(self, message=None):
         """Perform padatious training.

--- a/test/end2end/session/test_stop.py
+++ b/test/end2end/session/test_stop.py
@@ -68,9 +68,6 @@ class TestSessions(TestCase):
                 "recognizer_loop:utterance",
                 # global stop trigger
                 "mycroft.stop",
-                # ocp reporting nothing to stop
-                "ovos.common_play.stop",
-                "ovos.common_play.stop.response",
 
                 # skill reporting
                 f"{self.skill_id}.stop",  # internal, @killable_events
@@ -162,8 +159,6 @@ class TestSessions(TestCase):
 
                 # stop fallback
                 "mycroft.stop",  # global stop for backwards compat
-                "ovos.common_play.stop",  # ocp stop ping
-                "ovos.common_play.stop.response",  # ocp nothing to stop
                 f"{self.skill_id}.stop",
                 f"{self.skill_id}.stop.response",  # apparently fails to stop  (old style)
 
@@ -256,8 +251,6 @@ class TestSessions(TestCase):
                 "recognizer_loop:utterance",
                 # global stop trigger
                 "mycroft.stop",
-                "ovos.common_play.stop",
-                "ovos.common_play.stop.response",
                 f"{self.skill_id}.stop",  # internal, @killable_events
                 f"{self.skill_id}.stop.response",  # skill reporting nothing to stop
                 f"{self.new_skill_id}.stop",  # internal, @killable_events
@@ -395,8 +388,6 @@ class TestSessions(TestCase):
 
                 # global stop fallback
                 "mycroft.stop",
-                "ovos.common_play.stop",
-                "ovos.common_play.stop.response",
                 f"{self.skill_id}.stop",  # skill specific stop trigger
                 f"{self.skill_id}.stop.response",  # old style, never stops
                 f"{self.new_skill_id}.stop",  # skill specific stop trigger


### PR DESCRIPTION
avoids loading OCPPipeline into memory unless old audio service is disabled

do not load OCP pipeline if old audio service is enabled  (regular intents registered by OCP plugin)

dont fake import padacioso as if it was padatious, check properly at init time instead

remove "adapt" as valid pipeline option (TODO in code before stable release)

better logs