### PR TITLE
Update backwards-compat import for ovos-utils 0.1 compat

### DIFF
--- a/mycroft/skills/api.py
+++ b/mycroft/skills/api.py
@@ -1,1 +1,1 @@
-from ovos_utils.skills.api import SkillApi
+from ovos_workshop.skills.api import SkillApi


### PR DESCRIPTION
Replace import deprecated in ovos-utils 0.1
Bug noted in https://github.com/NeonGeckoCom/NeonCore/actions/runs/8840311299/job/24275381025

Related, #442 introduced a dependency on ovos-utils 0.1.0aX