### PR TITLE
Loosen ovos-bus-client dependency to allow ovos-utils 0.0.X

### DIFF
--- a/requirements/mycroft.txt
+++ b/requirements/mycroft.txt
@@ -1,7 +1,7 @@
 # ovos modules for compat with mycroft namespace
 ovos_PHAL<0.1.0, >=0.0.5a14
 ovos-audio~=0.0, >=0.0.2a32
-ovos-listener~=0.0, >=0.0.2a13
+ovos-listener~=0.0, >=0.0.3a2
 ovos-gui~=0.0, >=0.0.4a5
 ovos-messagebus~=0.0
 

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -7,7 +7,7 @@ padacioso~=0.2, >=0.2.1
 adapt-parser>=1.0.0, <2.0.0
 
 ovos-utils>=0.0.38
-ovos_bus_client<0.1.0, >=0.0.9a15
+ovos_bus_client<0.1.0, >=0.0.8
 ovos-plugin-manager<0.1.0, >=0.0.25
 ovos-config~=0.0,>=0.0.13a8
 ovos-lingua-franca>=0.4.7

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -18,3 +18,6 @@ ovos-audio~=0.0, >=0.0.2a10
 ovos-listener~=0.0, >=0.0.2a9
 ovos-gui~=0.0, >=0.0.2
 ovos-messagebus~=0.0
+
+# Support OCP tests
+ovos_bus_client>=0.0.9a15

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -15,7 +15,7 @@ python-vlc==1.1.2
 # ovos modules for compat with mycroft namespace
 ovos_PHAL<0.1.0, >=0.0.2
 ovos-audio~=0.0, >=0.0.2a10
-ovos-listener~=0.0, >=0.0.2a9
+ovos-listener~=0.0, >=0.0.3a2
 ovos-gui~=0.0, >=0.0.2
 ovos-messagebus~=0.0
 

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -8,7 +8,7 @@ sphinx-rtd-theme==0.4.3
 mock_msm~=0.9.2
 
 mycroft-messagebus-client
-ovos-stt-plugin-selene>=0.0.3a3
+#ovos-stt-plugin-selene>=0.0.3a3
 ovos-stt-plugin-vosk>=0.1.3
 python-vlc==1.1.2
 


### PR DESCRIPTION
Add test dependency to allow for OCP intent service tests
Closes #447 