### PR TITLE
Add ovos-utils 0.0.X dependency compat.

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -12,7 +12,8 @@ ovos-plugin-manager<0.1.0, >=0.0.25
 ovos-config~=0.0,>=0.0.13a8
 ovos-lingua-franca>=0.4.7
 ovos-backend-client~=0.1.0
-ovos-workshop<0.1.0, >=0.0.16a24
+ovos-workshop<0.1.0, >=0.0.15
+# ovos-workshop 0.0.16a5 added a dependency on ovos-utils 0.1.0aX
 
 # provides plugins and classic machine learning framework
 ovos-classifiers<0.1.0, >=0.0.0a53


### PR DESCRIPTION
Update ovos-workshop dependency to allow ovos-utils 0.0.X compat.
https://github.com/NeonGeckoCom/NeonCore/actions/runs/8886985863/job/24401444645?pr=641

According to PyCharm, no import or other errors are caused by this change and tests are passing, but I am not sure if there is any other context to this version update other than OCP and CommonQA intent service (optional) improvements.

This alpha dependency was added in #442 with the (optional) OCP intent service