### PR TITLE
fix/deactivate inside intent/converse

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -59,6 +59,7 @@ jobs:
           pip install ./test/end2end/skill-ovos-schedule
           pip install ./test/end2end/skill-new-stop
           pip install ./test/end2end/skill-old-stop
+          pip install git+https://github.com/OpenVoiceOS/ovos-workshop@refactor/skill_activation_before_events
       - name: Install core repo
         run: |
           pip install -e .[mycroft,deprecated]

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -59,7 +59,6 @@ jobs:
           pip install ./test/end2end/skill-ovos-schedule
           pip install ./test/end2end/skill-new-stop
           pip install ./test/end2end/skill-old-stop
-          pip install git+https://github.com/OpenVoiceOS/ovos-workshop@refactor/skill_activation_before_events
       - name: Install core repo
         run: |
           pip install -e .[mycroft,deprecated]

--- a/ovos_core/intent_services/__init__.py
+++ b/ovos_core/intent_services/__init__.py
@@ -293,10 +293,8 @@ class IntentService:
         message.data["utterance"] = match.utterance
 
         if match.skill_id:
-            self.converse.activate_skill(match.skill_id, message=message)
+            # ensure skill_id is present in message.context
             message.context["skill_id"] = match.skill_id
-            # If the service didn't report back the skill_id it
-            # takes on the responsibility of making the skill "active"
 
         # Launch skill if not handled by the match function
         if match.intent_type:

--- a/ovos_core/intent_services/ocp_service.py
+++ b/ovos_core/intent_services/ocp_service.py
@@ -340,6 +340,7 @@ class OCPPipelineMatcher(OVOSAbstractApplication):
             else:
                 return None
 
+        self.activate()  # mark skill_id as active, this is a catch all for all OCP skills
         return ovos_core.intent_services.IntentMatch(intent_service="OCP_intents",
                                                      intent_type=f'ocp:{match["name"]}',
                                                      intent_data=match,
@@ -365,6 +366,7 @@ class OCPPipelineMatcher(OVOSAbstractApplication):
         # extract the query string
         query = self.remove_voc(utterance, "Play", lang).strip()
 
+        self.activate()  # mark skill_id as active, this is a catch all for all OCP skills
         return ovos_core.intent_services.IntentMatch(intent_service="OCP_media",
                                                      intent_type=f"ocp:play",
                                                      intent_data={"media_type": media_type,
@@ -391,6 +393,7 @@ class OCPPipelineMatcher(OVOSAbstractApplication):
 
         # extract the query string
         query = self.remove_voc(utterance, "Play", lang).strip()
+        self.activate()  # mark skill_id as active, this is a catch all for all OCP skills
         return ovos_core.intent_services.IntentMatch(intent_service="OCP_fallback",
                                                      intent_type=f"ocp:play",
                                                      intent_data={"media_type": media_type,
@@ -401,6 +404,9 @@ class OCPPipelineMatcher(OVOSAbstractApplication):
                                                      utterance=utterance)
 
     def _process_play_query(self, utterance: str, lang: str, match: dict = None):
+
+        self.activate()  # mark skill_id as active, this is a catch all for all OCP skills
+
         match = match or {}
         # if media is currently paused, empty string means "resume playback"
         if self.player_state == PlayerState.PAUSED and \

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -12,8 +12,8 @@ ovos-plugin-manager<0.1.0, >=0.0.25
 ovos-config~=0.0,>=0.0.13a8
 ovos-lingua-franca>=0.4.7
 ovos-backend-client~=0.1.0
-ovos-workshop<0.1.0, >=0.0.16a24
-
+#ovos-workshop<0.1.0, >=0.0.16a24
+git+https://github.com/OpenVoiceOS/ovos-workshop@refactor/skill_activation_before_events
 # provides plugins and classic machine learning framework
 ovos-classifiers<0.1.0, >=0.0.0a53
 

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -12,8 +12,7 @@ ovos-plugin-manager<0.1.0, >=0.0.25
 ovos-config~=0.0,>=0.0.13a8
 ovos-lingua-franca>=0.4.7
 ovos-backend-client~=0.1.0
-#ovos-workshop<0.1.0, >=0.0.16a24
-git+https://github.com/OpenVoiceOS/ovos-workshop@refactor/skill_activation_before_events
+ovos-workshop<0.1.0, >=0.0.16a24
 # provides plugins and classic machine learning framework
 ovos-classifiers<0.1.0, >=0.0.0a53
 

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -12,7 +12,7 @@ ovos-plugin-manager<0.1.0, >=0.0.25
 ovos-config~=0.0,>=0.0.13a8
 ovos-lingua-franca>=0.4.7
 ovos-backend-client~=0.1.0
-ovos-workshop<0.1.0, >=0.0.16a24
+ovos-workshop<0.1.0, >=0.0.16a26
 # provides plugins and classic machine learning framework
 ovos-classifiers<0.1.0, >=0.0.0a53
 

--- a/test/end2end/routing/test_session.py
+++ b/test/end2end/routing/test_session.py
@@ -50,10 +50,12 @@ class TestRouting(TestCase):
         # confirm all expected messages are sent
         expected_messages = [
             "recognizer_loop:utterance",  # no session
-            "intent.service.skills.activated",  # default session injected
-            f"{self.skill_id}.activate",
             f"{self.skill_id}:HelloWorldIntent",
             "mycroft.skill.handler.start",
+            "intent.service.skills.activate",
+            "intent.service.skills.activated",
+            f"{self.skill_id}.activate",
+            "ovos.session.update_default",
             "enclosure.active_skill",
             "speak",
             "mycroft.skill.handler.complete",
@@ -72,13 +74,12 @@ class TestRouting(TestCase):
         for m in messages[1:]:
             self.assertEqual(m.context["session"]["session_id"], "default")
 
-        # verify that source an destination are kept until intent trigger
-        for m in messages[:3]:
-            self.assertEqual(m.context["source"], "A")
-            self.assertEqual(m.context["destination"], "B")
-
         # verify that source and destination are swapped after intent trigger
-        self.assertEqual(messages[3].msg_type, f"{self.skill_id}:HelloWorldIntent")
-        for m in messages[3:]:
-            self.assertEqual(m.context["source"], "B")
-            self.assertEqual(m.context["destination"], "A")
+        self.assertEqual(messages[1].msg_type, f"{self.skill_id}:HelloWorldIntent")
+        for m in messages:
+            if m.msg_type in ["recognizer_loop:utterance", "ovos.session.update_default"]:
+                self.assertEqual(messages[0].context["source"], "A")
+                self.assertEqual(messages[0].context["destination"], "B")
+            else:
+                self.assertEqual(m.context["source"], "B")
+                self.assertEqual(m.context["destination"], "A")

--- a/test/end2end/session/test_converse.py
+++ b/test/end2end/session/test_converse.py
@@ -47,444 +47,449 @@ class TestSessions(TestCase):
 
         self.core.bus.on("message", new_msg)
 
+        ######################################
+        # STEP 1
         # triggers intent from converse test skill to make it active
         # no converse ping pong as no skill is active
-        # verify active skills list (test)
-        def skill_converse_no():
+        # verify active skills list after triggering skill (test)
+        utt = Message("recognizer_loop:utterance",
+                      {"utterances": ["no"]})  # converse returns False
+        self.core.bus.emit(utt)
 
-            nonlocal messages
+        # confirm all expected messages are sent
+        expected_messages = [
+            "recognizer_loop:utterance",  # no session
+            # skill selected
+            f"{self.skill_id}:converse_off.intent",
+            # skill triggering
+            "mycroft.skill.handler.start",
+            "intent.service.skills.activate",
+            "intent.service.skills.activated",
+            f"{self.skill_id}.activate",
+            "ovos.session.update_default",
+            # intent code executing
+            "enclosure.active_skill",
+            "speak",
+            "mycroft.skill.handler.complete",
+            # session updated
+            "ovos.session.update_default"
+        ]
+        wait_for_n_messages(len(expected_messages))
 
-            utt = Message("recognizer_loop:utterance",
-                          {"utterances": ["no"]})  # converse returns False
-            self.core.bus.emit(utt)
+        self.assertEqual(len(expected_messages), len(messages))
 
-            # confirm all expected messages are sent
-            expected_messages = [
-                "recognizer_loop:utterance",  # no session
-                # skill selected
-                "intent.service.skills.activated",
-                f"{self.skill_id}.activate",
-                f"{self.skill_id}:converse_off.intent",
-                # skill executing
-                "mycroft.skill.handler.start",
-                "enclosure.active_skill",
-                "speak",
-                "mycroft.skill.handler.complete",
-                # session updated
-                "ovos.session.update_default"
-            ]
-            wait_for_n_messages(len(expected_messages))
+        mtypes = [m.msg_type for m in messages]
+        for m in expected_messages:
+            self.assertTrue(m in mtypes)
 
-            self.assertEqual(len(expected_messages), len(messages))
+        # verify that "session" is injected
+        # (missing in utterance message) and kept in all messages
+        for m in messages[1:]:
+            self.assertEqual(m.context["session"]["session_id"], "default")
+            self.assertEqual(m.context["lang"], "en-us")
 
-            mtypes = [m.msg_type for m in messages]
-            for m in expected_messages:
-                self.assertTrue(m in mtypes)
+        # verify intent triggers
+        self.assertEqual(messages[1].msg_type, f"{self.skill_id}:converse_off.intent")
+        # verify skill_id is now present in every message.context
+        for m in messages[1:]:
+            self.assertEqual(m.context["skill_id"], self.skill_id)
 
-            # verify that "session" is injected
-            # (missing in utterance message) and kept in all messages
-            for m in messages[1:]:
-                self.assertEqual(m.context["session"]["session_id"], "default")
-                self.assertEqual(m.context["lang"], "en-us")
+        self.assertEqual(messages[2].msg_type, "mycroft.skill.handler.start")
+        self.assertEqual(messages[2].data["name"], "TestAbortSkill.handle_converse_off")
+        # verify skill is activated
+        self.assertEqual(messages[3].msg_type, "intent.service.skills.activate")
+        self.assertEqual(messages[3].data["skill_id"], self.skill_id)
+        self.assertEqual(messages[4].msg_type, "intent.service.skills.activated")
+        self.assertEqual(messages[4].data["skill_id"], self.skill_id)
+        self.assertEqual(messages[5].msg_type, f"{self.skill_id}.activate")
+        self.assertEqual(messages[6].msg_type, "ovos.session.update_default")
+        # verify intent execution
+        self.assertEqual(messages[7].msg_type, "enclosure.active_skill")
+        self.assertEqual(messages[7].data["skill_id"], self.skill_id)
+        self.assertEqual(messages[8].msg_type, "speak")
+        self.assertEqual(messages[8].data["lang"], "en-us")
+        self.assertFalse(messages[8].data["expect_response"])
+        self.assertEqual(messages[8].data["meta"]["skill"], self.skill_id)
+        self.assertEqual(messages[9].msg_type, "mycroft.skill.handler.complete")
+        self.assertEqual(messages[9].data["name"], "TestAbortSkill.handle_converse_off")
 
-            # verify skill is activated by intent service (intent pipeline matched)
-            self.assertEqual(messages[1].msg_type, "intent.service.skills.activated")
-            self.assertEqual(messages[1].data["skill_id"], self.skill_id)
-            self.assertEqual(messages[2].msg_type, f"{self.skill_id}.activate")
+        # verify default session is now updated
+        self.assertEqual(messages[10].msg_type, "ovos.session.update_default")
+        self.assertEqual(messages[10].data["session_data"]["session_id"], "default")
+        # test deserialization of payload
+        sess = Session.deserialize(messages[10].data["session_data"])
+        self.assertEqual(sess.session_id, "default")
 
-            # verify intent triggers
-            self.assertEqual(messages[3].msg_type, f"{self.skill_id}:converse_off.intent")
-            # verify skill_id is now present in every message.context
-            for m in messages[3:]:
-                self.assertEqual(m.context["skill_id"], self.skill_id)
+        # test that active skills list has been updated
+        self.assertEqual(sess.active_skills[0][0], self.skill_id)
+        self.assertEqual(messages[10].data["session_data"]["active_skills"][0][0], self.skill_id)
 
-            # verify intent execution
-            self.assertEqual(messages[4].msg_type, "mycroft.skill.handler.start")
-            self.assertEqual(messages[4].data["name"], "TestAbortSkill.handle_converse_off")
-            self.assertEqual(messages[5].msg_type, "enclosure.active_skill")
-            self.assertEqual(messages[5].data["skill_id"], self.skill_id)
-            self.assertEqual(messages[6].msg_type, "speak")
-            self.assertEqual(messages[6].data["lang"], "en-us")
-            self.assertFalse(messages[6].data["expect_response"])
-            self.assertEqual(messages[6].data["meta"]["skill"], self.skill_id)
-            self.assertEqual(messages[7].msg_type, "mycroft.skill.handler.complete")
-            self.assertEqual(messages[7].data["name"], "TestAbortSkill.handle_converse_off")
+        messages = []
 
-            # verify default session is now updated
-            self.assertEqual(messages[8].msg_type, "ovos.session.update_default")
-            self.assertEqual(messages[8].data["session_data"]["session_id"], "default")
-            # test deserialization of payload
-            sess = Session.deserialize(messages[8].data["session_data"])
-            self.assertEqual(sess.session_id, "default")
-
-            # test that active skills list has been updated
-            self.assertEqual(sess.active_skills[0][0], self.skill_id)
-            self.assertEqual(messages[8].data["session_data"]["active_skills"][0][0], self.skill_id)
-
-            messages = []
-
-        skill_converse_no()
-
+        ######################################
+        # STEP 2
         # converse test skill is now active
         # test hello world skill triggers, converse test skill says it does not want to converse
         # verify active skills list (hello, test)
-        def hello_world():
-            nonlocal messages
-            utt = Message("recognizer_loop:utterance",
-                          {"utterances": ["hello world"]})
-            self.core.bus.emit(utt)
+        utt = Message("recognizer_loop:utterance",
+                      {"utterances": ["hello world"]})
+        self.core.bus.emit(utt)
 
-            # confirm all expected messages are sent
-            expected_messages = [
-                "recognizer_loop:utterance",  # no session
-                f"{self.skill_id}.converse.ping",  # default session injected
-                "skill.converse.pong",
-                f"{self.skill_id}.converse.request",
-                "skill.converse.response",  # does not want to converse
-                # skill selected
-                "intent.service.skills.activated",
-                f"{self.other_skill_id}.activate",
-                f"{self.other_skill_id}:HelloWorldIntent",
-                # skill executing
-                "mycroft.skill.handler.start",
-                "enclosure.active_skill",
-                "speak",
-                "mycroft.skill.handler.complete",
-                # session updated
-                "ovos.session.update_default"
-            ]
+        # confirm all expected messages are sent
+        expected_messages = [
+            "recognizer_loop:utterance",  # no session
+            f"{self.skill_id}.converse.ping",  # default session injected
+            "skill.converse.pong",
+            f"{self.skill_id}.converse.request",
+            "skill.converse.response",  # does not want to converse
+            # skill selected
+            f"{self.other_skill_id}:HelloWorldIntent",
+            "mycroft.skill.handler.start",
+            # skill activated
+            "intent.service.skills.activate",
+            "intent.service.skills.activated",
+            f"{self.other_skill_id}.activate",
+            "ovos.session.update_default",
+            # skill executing
+            "enclosure.active_skill",
+            "speak",
+            "mycroft.skill.handler.complete",
+            # session updated
+            "ovos.session.update_default"
+        ]
 
-            wait_for_n_messages(len(expected_messages))
+        wait_for_n_messages(len(expected_messages))
 
-            self.assertEqual(len(expected_messages), len(messages))
+        self.assertEqual(len(expected_messages), len(messages))
 
-            mtypes = [m.msg_type for m in messages]
-            for m in expected_messages:
-                self.assertTrue(m in mtypes)
+        mtypes = [m.msg_type for m in messages]
+        for m in expected_messages:
+            self.assertTrue(m in mtypes)
 
-            # verify that "session" is injected
-            # (missing in utterance message) and kept in all messages
-            for m in messages[1:]:
-                self.assertEqual(m.context["session"]["session_id"], "default")
-                self.assertEqual(m.context["lang"], "en-us")
+        # verify that "session" is injected
+        # (missing in utterance message) and kept in all messages
+        for m in messages[1:]:
+            self.assertEqual(m.context["session"]["session_id"], "default")
+            self.assertEqual(m.context["lang"], "en-us")
 
-            # verify that "lang" is injected by converse.ping
-            # (missing in utterance message) and kept in all messages
-            self.assertEqual(messages[1].msg_type, f"{self.skill_id}.converse.ping")
+        # verify that "lang" is injected by converse.ping
+        # (missing in utterance message) and kept in all messages
+        self.assertEqual(messages[1].msg_type, f"{self.skill_id}.converse.ping")
 
-            # verify "pong" answer from converse test skill
-            self.assertEqual(messages[2].msg_type, "skill.converse.pong")
-            # assert it reports converse method has been implemented by skill
-            self.assertTrue(messages[2].data["can_handle"])
+        # verify "pong" answer from converse test skill
+        self.assertEqual(messages[2].msg_type, "skill.converse.pong")
+        # assert it reports converse method has been implemented by skill
+        self.assertTrue(messages[2].data["can_handle"])
 
-            # verify answer from skill that it does not want to converse
-            self.assertEqual(messages[3].msg_type, f"{self.skill_id}.converse.request")
-            self.assertEqual(messages[4].msg_type, "skill.converse.response")
-            self.assertEqual(messages[4].data["skill_id"], self.skill_id)
-            self.assertFalse(messages[4].data["result"])  # does not want to converse
+        # verify answer from skill that it does not want to converse
+        self.assertEqual(messages[3].msg_type, f"{self.skill_id}.converse.request")
+        self.assertEqual(messages[4].msg_type, "skill.converse.response")
+        self.assertEqual(messages[4].data["skill_id"], self.skill_id)
+        self.assertFalse(messages[4].data["result"])  # does not want to converse
 
-            # verify skill is activated by intent service (intent pipeline matched)
-            self.assertEqual(messages[5].msg_type, "intent.service.skills.activated")
-            self.assertEqual(messages[5].data["skill_id"], self.other_skill_id)
-            self.assertEqual(messages[6].msg_type, f"{self.other_skill_id}.activate")
+        # verify intent triggers
+        self.assertEqual(messages[5].msg_type, f"{self.other_skill_id}:HelloWorldIntent")
+        # verify skill_id is now present in every message.context
+        for m in messages[5:]:
+            self.assertEqual(m.context["skill_id"], self.other_skill_id)
 
-            # verify intent triggers
-            self.assertEqual(messages[7].msg_type, f"{self.other_skill_id}:HelloWorldIntent")
-            # verify skill_id is now present in every message.context
-            for m in messages[7:]:
-                self.assertEqual(m.context["skill_id"], self.other_skill_id)
+        self.assertEqual(messages[6].msg_type, "mycroft.skill.handler.start")
+        self.assertEqual(messages[6].data["name"], "HelloWorldSkill.handle_hello_world_intent")
 
-            # verify intent execution
-            self.assertEqual(messages[8].msg_type, "mycroft.skill.handler.start")
-            self.assertEqual(messages[8].data["name"], "HelloWorldSkill.handle_hello_world_intent")
-            self.assertEqual(messages[9].msg_type, "enclosure.active_skill")
-            self.assertEqual(messages[9].data["skill_id"], self.other_skill_id)
-            self.assertEqual(messages[10].msg_type, "speak")
-            self.assertEqual(messages[10].data["lang"], "en-us")
-            self.assertFalse(messages[10].data["expect_response"])
-            self.assertEqual(messages[10].data["meta"]["skill"], self.other_skill_id)
-            self.assertEqual(messages[11].msg_type, "mycroft.skill.handler.complete")
-            self.assertEqual(messages[11].data["name"], "HelloWorldSkill.handle_hello_world_intent")
+        # verify skill is activated
+        self.assertEqual(messages[7].msg_type, "intent.service.skills.activate")
+        self.assertEqual(messages[7].data["skill_id"], self.other_skill_id)
+        self.assertEqual(messages[8].msg_type, "intent.service.skills.activated")
+        self.assertEqual(messages[8].data["skill_id"], self.other_skill_id)
+        self.assertEqual(messages[9].msg_type, f"{self.other_skill_id}.activate")
+        self.assertEqual(messages[10].msg_type, "ovos.session.update_default")
 
-            # verify default session is now updated
-            self.assertEqual(messages[12].msg_type, "ovos.session.update_default")
-            self.assertEqual(messages[12].data["session_data"]["session_id"], "default")
-            # test deserialization of payload
-            sess = Session.deserialize(messages[12].data["session_data"])
-            self.assertEqual(sess.session_id, "default")
+        # verify intent execution
+        self.assertEqual(messages[11].msg_type, "enclosure.active_skill")
+        self.assertEqual(messages[11].data["skill_id"], self.other_skill_id)
+        self.assertEqual(messages[12].msg_type, "speak")
+        self.assertEqual(messages[12].data["lang"], "en-us")
+        self.assertFalse(messages[12].data["expect_response"])
+        self.assertEqual(messages[12].data["meta"]["skill"], self.other_skill_id)
+        self.assertEqual(messages[13].msg_type, "mycroft.skill.handler.complete")
+        self.assertEqual(messages[13].data["name"], "HelloWorldSkill.handle_hello_world_intent")
 
-            # test that active skills list has been updated
-            self.assertEqual(sess.active_skills[0][0], self.other_skill_id)
-            self.assertEqual(sess.active_skills[1][0], self.skill_id)
-            self.assertEqual(messages[12].data["session_data"]["active_skills"][0][0], self.other_skill_id)
-            self.assertEqual(messages[12].data["session_data"]["active_skills"][1][0], self.skill_id)
+        # verify default session is now updated
+        self.assertEqual(messages[14].msg_type, "ovos.session.update_default")
+        self.assertEqual(messages[14].data["session_data"]["session_id"], "default")
+        # test deserialization of payload
+        sess = Session.deserialize(messages[14].data["session_data"])
+        self.assertEqual(sess.session_id, "default")
 
-            messages = []
+        # test that active skills list has been updated
+        self.assertEqual(sess.active_skills[0][0], self.other_skill_id)
+        self.assertEqual(sess.active_skills[1][0], self.skill_id)
+        self.assertEqual(messages[14].data["session_data"]["active_skills"][0][0], self.other_skill_id)
+        self.assertEqual(messages[14].data["session_data"]["active_skills"][1][0], self.skill_id)
 
-        hello_world()
+        messages = []
 
+        ######################################
+        # STEP 3
         # both skills are now active
         # trigger skill intent that makes it return True in next converse
         # verify active skills list gets swapped (test, hello)
-        def skill_converse_yes():
-            nonlocal messages
+        utt = Message("recognizer_loop:utterance",
+                      {"utterances": ["yes"]})  # converse returns True
+        self.core.bus.emit(utt)
 
-            utt = Message("recognizer_loop:utterance",
-                          {"utterances": ["yes"]})  # converse returns True
-            self.core.bus.emit(utt)
+        # confirm all expected messages are sent
+        expected_messages = [
+            "recognizer_loop:utterance",  # no session
+            f"{self.skill_id}.converse.ping",  # default session injected
+            f"{self.other_skill_id}.converse.ping",
+            "skill.converse.pong",
+            "skill.converse.pong",
+            f"{self.skill_id}.converse.request",
+            "skill.converse.response",  # does not want to converse
+            # skill selected
+            "intent.service.skills.activate",
+            "intent.service.skills.activated",
+            f"{self.skill_id}.activate",
+            "ovos.session.update_default",
 
-            # confirm all expected messages are sent
-            expected_messages = [
-                "recognizer_loop:utterance",  # no session
-                f"{self.skill_id}.converse.ping",  # default session injected
-                f"{self.other_skill_id}.converse.ping",
-                "skill.converse.pong",
-                "skill.converse.pong",
-                f"{self.skill_id}.converse.request",
-                "skill.converse.response",  # does not want to converse
-                # skill selected
-                "intent.service.skills.activated",
-                f"{self.skill_id}.activate",
-                f"{self.skill_id}:converse_on.intent",
-                # skill executing
-                "mycroft.skill.handler.start",
-                "enclosure.active_skill",
-                "speak",
-                "mycroft.skill.handler.complete",
-                # session updated
-                "ovos.session.update_default"
-            ]
-            wait_for_n_messages(len(expected_messages))
+            f"{self.skill_id}:converse_on.intent",
+            # skill executing
+            "mycroft.skill.handler.start",
+            "enclosure.active_skill",
+            "speak",
+            "mycroft.skill.handler.complete",
+            # session updated
+            "ovos.session.update_default"
+        ]
+        wait_for_n_messages(len(expected_messages))
 
-            self.assertEqual(len(expected_messages), len(messages))
+        self.assertEqual(len(expected_messages), len(messages))
 
-            mtypes = [m.msg_type for m in messages]
-            for m in expected_messages:
-                self.assertTrue(m in mtypes)
+        mtypes = [m.msg_type for m in messages]
+        for m in expected_messages:
+            self.assertTrue(m in mtypes)
 
-            # verify that "session" and "lang" is injected
-            # (missing in utterance message) and kept in all messages
-            for m in messages[1:]:
-                self.assertEqual(m.context["session"]["session_id"], "default")
-                self.assertEqual(m.context["lang"], "en-us")
+        # verify that "session" and "lang" is injected
+        # (missing in utterance message) and kept in all messages
+        for m in messages[1:]:
+            self.assertEqual(m.context["session"]["session_id"], "default")
+            self.assertEqual(m.context["lang"], "en-us")
 
-            # converse
-            self.assertEqual(messages[1].msg_type, f"{self.other_skill_id}.converse.ping")
-            self.assertEqual(messages[2].msg_type, "skill.converse.pong")
-            self.assertEqual(messages[2].data["skill_id"], messages[2].context["skill_id"])
-            self.assertFalse(messages[2].data["can_handle"])
-            self.assertEqual(messages[3].msg_type, f"{self.skill_id}.converse.ping")
-            self.assertEqual(messages[4].msg_type, "skill.converse.pong")
-            self.assertEqual(messages[4].data["skill_id"], messages[4].context["skill_id"])
-            self.assertTrue(messages[4].data["can_handle"])
+        # converse
+        self.assertEqual(messages[1].msg_type, f"{self.other_skill_id}.converse.ping")
+        self.assertEqual(messages[2].msg_type, "skill.converse.pong")
+        self.assertEqual(messages[2].data["skill_id"], messages[2].context["skill_id"])
+        self.assertFalse(messages[2].data["can_handle"])
+        self.assertEqual(messages[3].msg_type, f"{self.skill_id}.converse.ping")
+        self.assertEqual(messages[4].msg_type, "skill.converse.pong")
+        self.assertEqual(messages[4].data["skill_id"], messages[4].context["skill_id"])
+        self.assertTrue(messages[4].data["can_handle"])
 
-            # verify answer from skill that it does not want to converse
-            self.assertEqual(messages[5].msg_type, f"{self.skill_id}.converse.request")
-            self.assertEqual(messages[6].msg_type, "skill.converse.response")
-            self.assertEqual(messages[6].data["skill_id"], self.skill_id)
-            self.assertFalse(messages[6].data["result"])  # do not want to converse
+        # verify answer from skill that it does not want to converse
+        self.assertEqual(messages[5].msg_type, f"{self.skill_id}.converse.request")
+        self.assertEqual(messages[6].msg_type, "skill.converse.response")
+        self.assertEqual(messages[6].data["skill_id"], self.skill_id)
+        self.assertFalse(messages[6].data["result"])  # do not want to converse
 
-            # verify skill is activated by intent service (intent pipeline matched)
-            self.assertEqual(messages[7].msg_type, "intent.service.skills.activated")
-            self.assertEqual(messages[7].data["skill_id"], self.skill_id)
-            self.assertEqual(messages[8].msg_type, f"{self.skill_id}.activate")
+        # verify intent triggers
+        self.assertEqual(messages[7].msg_type, f"{self.skill_id}:converse_on.intent")
+        # verify skill_id is now present in every message.context
+        for m in messages[7:]:
+            self.assertEqual(m.context["skill_id"], self.skill_id)
 
-            # verify intent triggers
-            self.assertEqual(messages[9].msg_type, f"{self.skill_id}:converse_on.intent")
-            # verify skill_id is now present in every message.context
-            for m in messages[9:]:
-                self.assertEqual(m.context["skill_id"], self.skill_id)
+        # verify intent execution
+        self.assertEqual(messages[8].msg_type, "mycroft.skill.handler.start")
+        self.assertEqual(messages[8].data["name"], "TestAbortSkill.handle_converse_on")
 
-            # verify intent execution
-            self.assertEqual(messages[10].msg_type, "mycroft.skill.handler.start")
-            self.assertEqual(messages[10].data["name"], "TestAbortSkill.handle_converse_on")
-            self.assertEqual(messages[11].msg_type, "enclosure.active_skill")
-            self.assertEqual(messages[11].data["skill_id"], self.skill_id)
-            self.assertEqual(messages[12].msg_type, "speak")
-            self.assertEqual(messages[12].data["lang"], "en-us")
-            self.assertFalse(messages[12].data["expect_response"])
-            self.assertEqual(messages[12].data["meta"]["skill"], self.skill_id)
-            self.assertEqual(messages[13].msg_type, "mycroft.skill.handler.complete")
-            self.assertEqual(messages[13].data["name"], "TestAbortSkill.handle_converse_on")
+        # verify skill is activated by intent service (intent pipeline matched)
+        self.assertEqual(messages[9].msg_type, "intent.service.skills.activate")
+        self.assertEqual(messages[9].data["skill_id"], self.skill_id)
+        self.assertEqual(messages[10].msg_type, "intent.service.skills.activated")
+        self.assertEqual(messages[10].data["skill_id"], self.skill_id)
+        self.assertEqual(messages[11].msg_type, f"{self.skill_id}.activate")
+        self.assertEqual(messages[12].msg_type, "ovos.session.update_default")
 
-            # verify default session is now updated
-            self.assertEqual(messages[14].msg_type, "ovos.session.update_default")
-            self.assertEqual(messages[14].data["session_data"]["session_id"], "default")
-            # test deserialization of payload
-            sess = Session.deserialize(messages[14].data["session_data"])
-            self.assertEqual(sess.session_id, "default")
+        self.assertEqual(messages[13].msg_type, "enclosure.active_skill")
+        self.assertEqual(messages[13].data["skill_id"], self.skill_id)
+        self.assertEqual(messages[14].msg_type, "speak")
+        self.assertEqual(messages[14].data["lang"], "en-us")
+        self.assertFalse(messages[14].data["expect_response"])
+        self.assertEqual(messages[14].data["meta"]["skill"], self.skill_id)
+        self.assertEqual(messages[15].msg_type, "mycroft.skill.handler.complete")
+        self.assertEqual(messages[15].data["name"], "TestAbortSkill.handle_converse_on")
 
-            # test that active skills list has been updated
-            self.assertEqual(sess.active_skills[0][0], self.skill_id)
-            self.assertEqual(sess.active_skills[1][0], self.other_skill_id)
-            self.assertEqual(messages[14].data["session_data"]["active_skills"][0][0], self.skill_id)
-            self.assertEqual(messages[14].data["session_data"]["active_skills"][1][0], self.other_skill_id)
+        # verify default session is now updated
+        self.assertEqual(messages[16].msg_type, "ovos.session.update_default")
+        self.assertEqual(messages[16].data["session_data"]["session_id"], "default")
+        # test deserialization of payload
+        sess = Session.deserialize(messages[16].data["session_data"])
+        self.assertEqual(sess.session_id, "default")
 
-            messages = []
+        # test that active skills list has been updated
+        self.assertEqual(sess.active_skills[0][0], self.skill_id)
+        self.assertEqual(sess.active_skills[1][0], self.other_skill_id)
+        self.assertEqual(messages[16].data["session_data"]["active_skills"][0][0], self.skill_id)
+        self.assertEqual(messages[16].data["session_data"]["active_skills"][1][0], self.other_skill_id)
 
-        skill_converse_yes()
+        messages = []
 
+        ######################################
+        # STEP 4
         # test converse capture, hello world utterance wont reach hello world skill
-        def converse_capture():
-            nonlocal messages
-            utt = Message("recognizer_loop:utterance",
-                          {"utterances": ["hello world"]})
-            self.core.bus.emit(utt)
+        utt = Message("recognizer_loop:utterance",
+                      {"utterances": ["hello world"]})
+        self.core.bus.emit(utt)
 
-            # confirm all expected messages are sent
-            expected_messages = [
-                "recognizer_loop:utterance",  # no session
-                f"{self.skill_id}.converse.ping",  # default session injected
-                f"{self.other_skill_id}.converse.ping",
-                "skill.converse.pong",
-                "skill.converse.pong",
-                f"{self.skill_id}.converse.request",
-                "skill.converse.response",  # CONVERSED
-                # skill selected
-                "intent.service.skills.activated",
-                f"{self.skill_id}.activate",
-                # session updated
-                "ovos.session.update_default"
-            ]
-            wait_for_n_messages(len(expected_messages))
+        # confirm all expected messages are sent
+        expected_messages = [
+            "recognizer_loop:utterance",  # no session
+            f"{self.skill_id}.converse.ping",  # default session injected
+            f"{self.other_skill_id}.converse.ping",
+            "skill.converse.pong",
+            "skill.converse.pong",
+            f"{self.skill_id}.converse.request",
+            # skill selected
+            "intent.service.skills.activate",
+            "intent.service.skills.activated",
+            f"{self.skill_id}.activate",
+            "ovos.session.update_default",
+            "skill.converse.response",  # CONVERSED
+            # session updated
+            "ovos.session.update_default"
+        ]
+        wait_for_n_messages(len(expected_messages))
 
-            self.assertEqual(len(expected_messages), len(messages))
+        self.assertEqual(len(expected_messages), len(messages))
 
-            mtypes = [m.msg_type for m in messages]
-            for m in expected_messages:
-                print(m)
-                self.assertTrue(m in mtypes)
+        mtypes = [m.msg_type for m in messages]
+        for m in expected_messages:
+            print(m)
+            self.assertTrue(m in mtypes)
 
-            # verify that "session" and "lang" is injected
-            # (missing in utterance message) and kept in all messages
-            for m in messages[1:]:
-                self.assertEqual(m.context["session"]["session_id"], "default")
-                self.assertEqual(m.context["lang"], "en-us")
+        # verify that "session" and "lang" is injected
+        # (missing in utterance message) and kept in all messages
+        for m in messages[1:]:
+            self.assertEqual(m.context["session"]["session_id"], "default")
+            self.assertEqual(m.context["lang"], "en-us")
 
-            # converse
-            self.assertEqual(messages[1].msg_type, f"{self.skill_id}.converse.ping")
-            self.assertEqual(messages[2].msg_type, "skill.converse.pong")
-            self.assertEqual(messages[2].data["skill_id"], messages[2].context["skill_id"])
-            self.assertTrue(messages[2].data["can_handle"])
-            self.assertEqual(messages[3].msg_type, f"{self.other_skill_id}.converse.ping")
-            self.assertEqual(messages[4].msg_type, "skill.converse.pong")
-            self.assertEqual(messages[4].data["skill_id"], messages[4].context["skill_id"])
-            self.assertFalse(messages[4].data["can_handle"])
+        # converse
+        self.assertEqual(messages[1].msg_type, f"{self.skill_id}.converse.ping")
+        self.assertEqual(messages[2].msg_type, "skill.converse.pong")
+        self.assertEqual(messages[2].data["skill_id"], messages[2].context["skill_id"])
+        self.assertTrue(messages[2].data["can_handle"])
+        self.assertEqual(messages[3].msg_type, f"{self.other_skill_id}.converse.ping")
+        self.assertEqual(messages[4].msg_type, "skill.converse.pong")
+        self.assertEqual(messages[4].data["skill_id"], messages[4].context["skill_id"])
+        self.assertFalse(messages[4].data["can_handle"])
 
-            # verify answer from skill that it does not want to converse
-            self.assertEqual(messages[5].msg_type, f"{self.skill_id}.converse.request")
-            self.assertEqual(messages[6].msg_type, "skill.converse.response")
-            self.assertEqual(messages[6].data["skill_id"], self.skill_id)
-            self.assertTrue(messages[6].data["result"])  # CONVERSED
+        # verify answer from skill that it does not want to converse
+        self.assertEqual(messages[5].msg_type, f"{self.skill_id}.converse.request")
 
-            # verify skill is activated by intent service (intent pipeline matched)
-            self.assertEqual(messages[7].msg_type, "intent.service.skills.activated")
-            self.assertEqual(messages[7].data["skill_id"], self.skill_id)
-            self.assertEqual(messages[8].msg_type, f"{self.skill_id}.activate")
+        # verify skill is activated by intent service (intent pipeline matched)
+        self.assertEqual(messages[6].msg_type, "intent.service.skills.activate")
+        self.assertEqual(messages[6].data["skill_id"], self.skill_id)
+        self.assertEqual(messages[7].msg_type, "intent.service.skills.activated")
+        self.assertEqual(messages[7].data["skill_id"], self.skill_id)
+        self.assertEqual(messages[8].msg_type, f"{self.skill_id}.activate")
+        self.assertEqual(messages[9].msg_type, "ovos.session.update_default")
 
-            # verify default session is now updated
-            self.assertEqual(messages[9].msg_type, "ovos.session.update_default")
-            self.assertEqual(messages[9].data["session_data"]["session_id"], "default")
-            # test deserialization of payload
-            sess = Session.deserialize(messages[9].data["session_data"])
-            self.assertEqual(sess.session_id, "default")
+        # verify skill conversed
+        self.assertEqual(messages[10].msg_type, "skill.converse.response")
+        self.assertEqual(messages[10].data["skill_id"], self.skill_id)
+        self.assertTrue(messages[10].data["result"])  # CONVERSED
 
-            # test that active skills list has been updated
-            self.assertEqual(sess.active_skills[0][0], self.skill_id)
-            self.assertEqual(sess.active_skills[1][0], self.other_skill_id)
-            self.assertEqual(messages[9].data["session_data"]["active_skills"][0][0], self.skill_id)
-            self.assertEqual(messages[9].data["session_data"]["active_skills"][1][0], self.other_skill_id)
+        # verify default session is now updated
+        self.assertEqual(messages[11].msg_type, "ovos.session.update_default")
+        self.assertEqual(messages[11].data["session_data"]["session_id"], "default")
+        # test deserialization of payload
+        sess = Session.deserialize(messages[11].data["session_data"])
+        self.assertEqual(sess.session_id, "default")
 
-            messages = []
+        # test that active skills list has been updated
+        self.assertEqual(sess.active_skills[0][0], self.skill_id)
+        self.assertEqual(sess.active_skills[1][0], self.other_skill_id)
+        self.assertEqual(messages[11].data["session_data"]["active_skills"][0][0], self.skill_id)
+        self.assertEqual(messages[11].data["session_data"]["active_skills"][1][0], self.other_skill_id)
 
-        converse_capture()
+        messages = []
 
-        def external_deactivate():
-            nonlocal messages
+        ######################################
+        # STEP 5 - xternal deactivate
+        utt = Message("test_deactivate")
+        self.core.bus.emit(utt)
 
-            utt = Message("test_deactivate")
-            self.core.bus.emit(utt)
+        self.assertEqual(SessionManager.default_session.active_skills[0][0], self.other_skill_id)
+        # confirm all expected messages are sent
+        expected_messages = [
+            "test_deactivate",
+            "intent.service.skills.deactivate",
+            "intent.service.skills.deactivated",
+            "ovos-tskill-abort.openvoiceos.deactivate",
+            "ovos.session.update_default"
+        ]
+        wait_for_n_messages(len(expected_messages))
 
-            self.assertEqual(SessionManager.default_session.active_skills[0][0], self.other_skill_id)
-            # confirm all expected messages are sent
-            expected_messages = [
-                "test_deactivate",
-                "intent.service.skills.deactivate",
-                "intent.service.skills.deactivated",
-                "ovos-tskill-abort.openvoiceos.deactivate",
-                "ovos.session.update_default"
-            ]
-            wait_for_n_messages(len(expected_messages))
+        self.assertEqual(len(expected_messages), len(messages))
 
-            self.assertEqual(len(expected_messages), len(messages))
+        mtypes = [m.msg_type for m in messages]
+        for m in expected_messages:
+            self.assertTrue(m in mtypes)
 
-            mtypes = [m.msg_type for m in messages]
-            for m in expected_messages:
-                self.assertTrue(m in mtypes)
+        # verify skill is no longer in active skills
+        self.assertEqual(SessionManager.default_session.active_skills[0][0], self.other_skill_id)
+        self.assertEqual(len(SessionManager.default_session.active_skills), 1)
 
-            # verify skill is no longer in active skills
-            self.assertEqual(SessionManager.default_session.active_skills[0][0], self.other_skill_id)
-            self.assertEqual(len(SessionManager.default_session.active_skills), 1)
+        # verify default session is now updated
+        self.assertEqual(messages[-1].msg_type, "ovos.session.update_default")
+        self.assertEqual(messages[-1].data["session_data"]["session_id"], "default")
+        # test deserialization of payload
+        sess = Session.deserialize(messages[-1].data["session_data"])
+        self.assertEqual(sess.session_id, "default")
+        # test that active skills list has been updated
+        self.assertEqual(len(sess.active_skills), 1)
+        self.assertEqual(sess.active_skills[0][0], self.other_skill_id)
+        self.assertEqual(len(messages[-1].data["session_data"]["active_skills"]), 1)
+        self.assertEqual(messages[-1].data["session_data"]["active_skills"][0][0], self.other_skill_id)
 
-            # verify default session is now updated
-            self.assertEqual(messages[-1].msg_type, "ovos.session.update_default")
-            self.assertEqual(messages[-1].data["session_data"]["session_id"], "default")
-            # test deserialization of payload
-            sess = Session.deserialize(messages[-1].data["session_data"])
-            self.assertEqual(sess.session_id, "default")
-            # test that active skills list has been updated
-            self.assertEqual(len(sess.active_skills), 1)
-            self.assertEqual(sess.active_skills[0][0], self.other_skill_id)
-            self.assertEqual(len(messages[-1].data["session_data"]["active_skills"]), 1)
-            self.assertEqual(messages[-1].data["session_data"]["active_skills"][0][0], self.other_skill_id)
+        messages = []
 
-            messages = []
+        ######################################
+        # STEP 6 - external activate
+        self.assertEqual(SessionManager.default_session.active_skills[0][0], self.other_skill_id)
+        utt = Message("test_activate")
+        self.core.bus.emit(utt)
+        self.assertEqual(SessionManager.default_session.active_skills[0][0], self.skill_id)
+        # confirm all expected messages are sent
+        expected_messages = [
+            "test_activate",
+            "intent.service.skills.activate",
+            "intent.service.skills.activated",
+            f"{self.skill_id}.activate",
+            "ovos.session.update_default"
+        ]
+        wait_for_n_messages(len(expected_messages))
 
-        external_deactivate()
+        self.assertEqual(len(expected_messages), len(messages))
 
-        def external_activate():
-            nonlocal messages
+        mtypes = [m.msg_type for m in messages]
+        for m in expected_messages:
+            self.assertTrue(m in mtypes)
 
-            self.assertEqual(SessionManager.default_session.active_skills[0][0], self.other_skill_id)
-            utt = Message("test_activate")
-            self.core.bus.emit(utt)
-            self.assertEqual(SessionManager.default_session.active_skills[0][0], self.skill_id)
-            # confirm all expected messages are sent
-            expected_messages = [
-                "test_activate",
-                "intent.service.skills.activate",
-                "intent.service.skills.activated",
-                f"{self.skill_id}.activate",
-                "ovos.session.update_default",
-                "active_skill_request",  # backwards compat namespace classic core
-                "intent.service.skills.activated",
-                f"{self.skill_id}.activate",
-                "ovos.session.update_default"
-            ]
-            wait_for_n_messages(len(expected_messages))
+        # verify skill is again in active skills
+        self.assertEqual(SessionManager.default_session.active_skills[0][0], self.skill_id)
+        self.assertEqual(len(SessionManager.default_session.active_skills), 2)
 
-            self.assertEqual(len(expected_messages), len(messages))
+        # verify default session is now updated
+        self.assertEqual(messages[-1].msg_type, "ovos.session.update_default")
+        self.assertEqual(messages[-1].data["session_data"]["session_id"], "default")
+        # test deserialization of payload
+        sess = Session.deserialize(messages[-1].data["session_data"])
+        self.assertEqual(sess.session_id, "default")
+        # test that active skills list has been updated
+        self.assertEqual(len(sess.active_skills), 2)
+        self.assertEqual(sess.active_skills[0][0], self.skill_id)
+        self.assertEqual(len(messages[-1].data["session_data"]["active_skills"]), 2)
+        self.assertEqual(messages[-1].data["session_data"]["active_skills"][0][0], self.skill_id)
 
-            mtypes = [m.msg_type for m in messages]
-            for m in expected_messages:
-                self.assertTrue(m in mtypes)
-
-            # verify skill is again in active skills
-            self.assertEqual(SessionManager.default_session.active_skills[0][0], self.skill_id)
-            self.assertEqual(len(SessionManager.default_session.active_skills), 2)
-
-            # verify default session is now updated
-            self.assertEqual(messages[-1].msg_type, "ovos.session.update_default")
-            self.assertEqual(messages[-1].data["session_data"]["session_id"], "default")
-            # test deserialization of payload
-            sess = Session.deserialize(messages[-1].data["session_data"])
-            self.assertEqual(sess.session_id, "default")
-            # test that active skills list has been updated
-            self.assertEqual(len(sess.active_skills), 2)
-            self.assertEqual(sess.active_skills[0][0], self.skill_id)
-            self.assertEqual(len(messages[-1].data["session_data"]["active_skills"]), 2)
-            self.assertEqual(messages[-1].data["session_data"]["active_skills"][0][0], self.skill_id)
-
-            messages = []
-
-        external_activate()
+        messages = []

--- a/test/end2end/session/test_fallback_v1.py
+++ b/test/end2end/session/test_fallback_v1.py
@@ -70,16 +70,11 @@ class TestFallback(TestCase):
             "mycroft.skill.handler.start",
             "enclosure.active_skill",
             "speak",
-            # self activation from skill, instead of from core
+            # activation from skill, because fallback consumed utterance
             "intent.service.skills.activate",
             "intent.service.skills.activated",
             f"{self.skill_id}.activate",
-            "ovos.session.update_default",  # because it comes from skill
-            # backwards compat activation for older cores
-            "active_skill_request",
-            "intent.service.skills.activated",
-            f"{self.skill_id}.activate",
-            "ovos.session.update_default",  # because it comes from skill
+            "ovos.session.update_default",
             # report handling
             "mycroft.skill.handler.complete",
             "mycroft.skills.fallback.response",
@@ -143,23 +138,16 @@ class TestFallback(TestCase):
         self.assertEqual(messages[14].data["skill_id"], self.skill_id)
         self.assertEqual(messages[15].msg_type, f"{self.skill_id}.activate")
         self.assertEqual(messages[16].msg_type, 'ovos.session.update_default')
-        # skill making itself active again - backwards compat namespace
-        self.assertEqual(messages[17].msg_type, "active_skill_request")
-        self.assertEqual(messages[17].data["skill_id"], self.skill_id)
-        self.assertEqual(messages[18].msg_type, "intent.service.skills.activated")
-        self.assertEqual(messages[18].data["skill_id"], self.skill_id)
-        self.assertEqual(messages[19].msg_type, f"{self.skill_id}.activate")
-        self.assertEqual(messages[20].msg_type, 'ovos.session.update_default')
 
         # fallback execution response
-        self.assertEqual(messages[21].msg_type, "mycroft.skill.handler.complete")
-        self.assertEqual(messages[21].data["handler"], "fallback")
-        self.assertEqual(messages[22].msg_type, "mycroft.skills.fallback.response")
-        self.assertTrue(messages[22].data["handled"])
+        self.assertEqual(messages[17].msg_type, "mycroft.skill.handler.complete")
+        self.assertEqual(messages[17].data["handler"], "fallback")
+        self.assertEqual(messages[18].msg_type, "mycroft.skills.fallback.response")
+        self.assertTrue(messages[18].data["handled"])
 
         # verify default session is now updated
-        self.assertEqual(messages[23].msg_type, "ovos.session.update_default")
-        self.assertEqual(messages[23].data["session_data"]["session_id"], "default")
+        self.assertEqual(messages[19].msg_type, "ovos.session.update_default")
+        self.assertEqual(messages[19].data["session_data"]["session_id"], "default")
 
         # test second message with no session resumes default active skills
         messages = []

--- a/test/end2end/session/test_get_response.py
+++ b/test/end2end/session/test_get_response.py
@@ -635,33 +635,29 @@ class TestSessions(TestCase):
         # captured utterance sent to get_response handler that is waiting
         self.assertEqual(messages[15].msg_type, f"{self.skill_id}.converse.get_response")
         self.assertEqual(messages[15].data["utterances"], ["ok"])
-
-        # converse pipeline activates the skill last_used timestamp
-        self.assertEqual(messages[16].msg_type, "intent.service.skills.activated")
-        self.assertEqual(messages[17].msg_type, f"{self.skill_id}.activate")
-        self.assertEqual(messages[18].msg_type, "ovos.session.update_default")
+        self.assertEqual(messages[16].msg_type, "ovos.session.update_default")
 
         # disable get_response for this session
-        self.assertEqual(messages[19].msg_type, "skill.converse.get_response.disable")
-        self.assertEqual(messages[20].msg_type, "ovos.session.update_default")
+        self.assertEqual(messages[17].msg_type, "skill.converse.get_response.disable")
+        self.assertEqual(messages[18].msg_type, "ovos.session.update_default")
 
         # post self.get_response intent code
-        self.assertEqual(messages[21].msg_type, "enclosure.active_skill")
-        self.assertEqual(messages[21].data["skill_id"], self.skill_id)
-        self.assertEqual(messages[22].msg_type, "speak")
-        self.assertEqual(messages[22].data["lang"], "en-us")
-        self.assertFalse(messages[22].data["expect_response"])
-        self.assertEqual(messages[22].data["utterance"], "ok")
-        self.assertEqual(messages[22].data["meta"]["skill"], self.skill_id)
+        self.assertEqual(messages[19].msg_type, "enclosure.active_skill")
+        self.assertEqual(messages[19].data["skill_id"], self.skill_id)
+        self.assertEqual(messages[20].msg_type, "speak")
+        self.assertEqual(messages[20].data["lang"], "en-us")
+        self.assertFalse(messages[20].data["expect_response"])
+        self.assertEqual(messages[20].data["utterance"], "ok")
+        self.assertEqual(messages[20].data["meta"]["skill"], self.skill_id)
 
-        self.assertEqual(messages[23].msg_type, "mycroft.skill.handler.complete")
-        self.assertEqual(messages[23].data["name"], "TestAbortSkill.handle_test_get_response3")
+        self.assertEqual(messages[21].msg_type, "mycroft.skill.handler.complete")
+        self.assertEqual(messages[21].data["name"], "TestAbortSkill.handle_test_get_response3")
 
         # verify default session is now updated
-        self.assertEqual(messages[24].msg_type, "ovos.session.update_default")
-        self.assertEqual(messages[24].data["session_data"]["session_id"], "default")
+        self.assertEqual(messages[22].msg_type, "ovos.session.update_default")
+        self.assertEqual(messages[22].data["session_data"]["session_id"], "default")
         # test deserialization of payload
-        sess = Session.deserialize(messages[24].data["session_data"])
+        sess = Session.deserialize(messages[22].data["session_data"])
         self.assertEqual(sess.session_id, "default")
 
     def test_nested(self):

--- a/test/end2end/session/test_get_response.py
+++ b/test/end2end/session/test_get_response.py
@@ -60,15 +60,16 @@ class TestSessions(TestCase):
 
         # confirm all expected messages are sent
         expected_messages = [
-            "recognizer_loop:utterance",  # no session
-
+            "recognizer_loop:utterance",  # trigger intent to start the test
             # skill selected
-            "intent.service.skills.activated",  # default session injected
-            f"{self.skill_id}.activate",
             f"{self.skill_id}:test_get_response.intent",
-
-            # skill executing
             "mycroft.skill.handler.start",
+            # skill activated (because of selection)
+            "intent.service.skills.activate",
+            "intent.service.skills.activated",
+            f"{self.skill_id}.activate",
+            "ovos.session.update_default",  # sync skill activation
+            # intent code
             "skill.converse.get_response.enable",  # start of get_response
             "ovos.session.update_default",  # sync get_response status
             "enclosure.active_skill",
@@ -79,11 +80,11 @@ class TestSessions(TestCase):
             # "recognizer_loop:utterance" would be here if user answered
             "skill.converse.get_response.disable",  # end of get_response
             "ovos.session.update_default",  # sync get_response status
+            # intent code post self.get_response
             "enclosure.active_skill",  # from speak inside intent
             "speak",  # speak "ERROR" inside intent
             "recognizer_loop:audio_output_start",
             "recognizer_loop:audio_output_end",
-
             "mycroft.skill.handler.complete",  # original intent finished executing
 
             # session updated at end of intent pipeline
@@ -104,61 +105,64 @@ class TestSessions(TestCase):
             self.assertEqual(m.context["session"]["session_id"], "default")
             self.assertEqual(m.context["lang"], "en-us")
 
-            # verify skill is activated by intent service (intent pipeline matched)
-        self.assertEqual(messages[1].msg_type, "intent.service.skills.activated")
-        self.assertEqual(messages[1].data["skill_id"], self.skill_id)
-        self.assertEqual(messages[2].msg_type, f"{self.skill_id}.activate")
-
         # verify intent triggers
-        self.assertEqual(messages[3].msg_type, f"{self.skill_id}:test_get_response.intent")
+        self.assertEqual(messages[1].msg_type, f"{self.skill_id}:test_get_response.intent")
         # verify skill_id is now present in every message.context
-        for m in messages[3:]:
+        for m in messages[1:]:
             self.assertEqual(m.context["skill_id"], self.skill_id)
 
         # verify intent execution
-        self.assertEqual(messages[4].msg_type, "mycroft.skill.handler.start")
-        self.assertEqual(messages[4].data["name"], "TestAbortSkill.handle_test_get_response")
+        self.assertEqual(messages[2].msg_type, "mycroft.skill.handler.start")
+        self.assertEqual(messages[2].data["name"], "TestAbortSkill.handle_test_get_response")
 
-        # enable get_response for this session
-        self.assertEqual(messages[5].msg_type, "skill.converse.get_response.enable")
+        # verify skill is activated
+        self.assertEqual(messages[3].msg_type, "intent.service.skills.activate")
+        self.assertEqual(messages[3].data["skill_id"], self.skill_id)
+        self.assertEqual(messages[4].msg_type, "intent.service.skills.activated")
+        self.assertEqual(messages[4].data["skill_id"], self.skill_id)
+        self.assertEqual(messages[5].msg_type, f"{self.skill_id}.activate")
         self.assertEqual(messages[6].msg_type, "ovos.session.update_default")
 
+        # enable get_response for this session
+        self.assertEqual(messages[7].msg_type, "skill.converse.get_response.enable")
+        self.assertEqual(messages[8].msg_type, "ovos.session.update_default")
+
         # question dialog
-        self.assertEqual(messages[7].msg_type, "enclosure.active_skill")
-        self.assertEqual(messages[7].data["skill_id"], self.skill_id)
-        self.assertEqual(messages[8].msg_type, "speak")
-        self.assertEqual(messages[8].data["lang"], "en-us")
-        self.assertTrue(messages[8].data["expect_response"])  # listen after dialog
-        self.assertEqual(messages[8].data["meta"]["skill"], self.skill_id)
-        self.assertEqual(messages[9].msg_type, "recognizer_loop:audio_output_start")
-        self.assertEqual(messages[10].msg_type, "recognizer_loop:audio_output_end")
+        self.assertEqual(messages[9].msg_type, "enclosure.active_skill")
+        self.assertEqual(messages[9].data["skill_id"], self.skill_id)
+        self.assertEqual(messages[10].msg_type, "speak")
+        self.assertEqual(messages[10].data["lang"], "en-us")
+        self.assertTrue(messages[10].data["expect_response"])  # listen after dialog
+        self.assertEqual(messages[10].data["meta"]["skill"], self.skill_id)
+        self.assertEqual(messages[11].msg_type, "recognizer_loop:audio_output_start")
+        self.assertEqual(messages[12].msg_type, "recognizer_loop:audio_output_end")
 
         # user response would be here
 
         # disable get_response for this session
-        self.assertEqual(messages[11].msg_type, "skill.converse.get_response.disable")
-        self.assertEqual(messages[12].msg_type, "ovos.session.update_default")
+        self.assertEqual(messages[13].msg_type, "skill.converse.get_response.disable")
+        self.assertEqual(messages[14].msg_type, "ovos.session.update_default")
 
         # post self.get_response intent code
-        self.assertEqual(messages[13].msg_type, "enclosure.active_skill")
-        self.assertEqual(messages[13].data["skill_id"], self.skill_id)
-        self.assertEqual(messages[14].msg_type, "speak")
-        self.assertEqual(messages[14].data["lang"], "en-us")
-        self.assertFalse(messages[14].data["expect_response"])
-        self.assertEqual(messages[14].data["utterance"], "ERROR")
-        self.assertEqual(messages[14].data["meta"]["skill"], self.skill_id)
+        self.assertEqual(messages[15].msg_type, "enclosure.active_skill")
+        self.assertEqual(messages[15].data["skill_id"], self.skill_id)
+        self.assertEqual(messages[16].msg_type, "speak")
+        self.assertEqual(messages[16].data["lang"], "en-us")
+        self.assertFalse(messages[16].data["expect_response"])
+        self.assertEqual(messages[16].data["utterance"], "ERROR")
+        self.assertEqual(messages[16].data["meta"]["skill"], self.skill_id)
 
-        self.assertEqual(messages[15].msg_type, "recognizer_loop:audio_output_start")
-        self.assertEqual(messages[16].msg_type, "recognizer_loop:audio_output_end")
+        self.assertEqual(messages[17].msg_type, "recognizer_loop:audio_output_start")
+        self.assertEqual(messages[18].msg_type, "recognizer_loop:audio_output_end")
 
-        self.assertEqual(messages[17].msg_type, "mycroft.skill.handler.complete")
-        self.assertEqual(messages[17].data["name"], "TestAbortSkill.handle_test_get_response")
+        self.assertEqual(messages[19].msg_type, "mycroft.skill.handler.complete")
+        self.assertEqual(messages[19].data["name"], "TestAbortSkill.handle_test_get_response")
 
         # verify default session is now updated
-        self.assertEqual(messages[18].msg_type, "ovos.session.update_default")
-        self.assertEqual(messages[18].data["session_data"]["session_id"], "default")
+        self.assertEqual(messages[20].msg_type, "ovos.session.update_default")
+        self.assertEqual(messages[20].data["session_data"]["session_id"], "default")
         # test deserialization of payload
-        sess = Session.deserialize(messages[18].data["session_data"])
+        sess = Session.deserialize(messages[20].data["session_data"])
         self.assertEqual(sess.session_id, "default")
 
     def test_with_response(self):
@@ -211,15 +215,16 @@ class TestSessions(TestCase):
 
         # confirm all expected messages are sent
         expected_messages = [
-            "recognizer_loop:utterance",  # no session
-
+            "recognizer_loop:utterance",  # trigger intent to start the test
             # skill selected
+            f"{self.skill_id}:test_get_response.intent",
+            "mycroft.skill.handler.start",
+            # skill activated (because of selection)
+            "intent.service.skills.activate",
             "intent.service.skills.activated",
             f"{self.skill_id}.activate",
-            f"{self.skill_id}:test_get_response.intent",
-
-            # intent code before self.get_response
-            "mycroft.skill.handler.start",
+            "ovos.session.update_default",  # sync skill activation
+            # intent code
             "skill.converse.get_response.enable",  # start of get_response
             "ovos.session.update_default",  # sync get_response status
             "enclosure.active_skill",
@@ -228,18 +233,14 @@ class TestSessions(TestCase):
             "recognizer_loop:audio_output_end",
 
             "recognizer_loop:utterance",  # answer to get_response from user,
-            # converse pipeline start
+            # converse check
             f"{self.skill_id}.converse.ping",
             "skill.converse.pong",
+            # get response handling
             f"{self.skill_id}.converse.get_response",  # returning user utterance to running intent self.get_response
-            # skill selected by converse pipeline
-            "intent.service.skills.activated",
-            f"{self.skill_id}.activate",
             "ovos.session.update_default",  # sync skill activated by converse
-
             "skill.converse.get_response.disable",  # end of get_response
             "ovos.session.update_default",  # sync get_response status
-
             # intent code post self.get_response
             "enclosure.active_skill",  # from speak inside intent
             "speak",  # speak "ok" inside intent
@@ -265,45 +266,47 @@ class TestSessions(TestCase):
             print(m.msg_type, m.context["session"]["session_id"])
             self.assertEqual(m.context["session"]["session_id"], "default")
 
-        # verify skill is activated by intent service (intent pipeline matched)
-        self.assertEqual(messages[1].msg_type, "intent.service.skills.activated")
-        self.assertEqual(messages[1].data["skill_id"], self.skill_id)
-        self.assertEqual(messages[2].msg_type, f"{self.skill_id}.activate")
-
         # verify intent triggers
-        self.assertEqual(messages[3].msg_type, f"{self.skill_id}:test_get_response.intent")
+        self.assertEqual(messages[1].msg_type, f"{self.skill_id}:test_get_response.intent")
 
         # verify intent execution
-        self.assertEqual(messages[4].msg_type, "mycroft.skill.handler.start")
-        self.assertEqual(messages[4].data["name"], "TestAbortSkill.handle_test_get_response")
+        self.assertEqual(messages[2].msg_type, "mycroft.skill.handler.start")
+        self.assertEqual(messages[2].data["name"], "TestAbortSkill.handle_test_get_response")
 
-        # enable get_response for this session
-        self.assertEqual(messages[5].msg_type, "skill.converse.get_response.enable")
+        # verify skill is activated
+        self.assertEqual(messages[3].msg_type, "intent.service.skills.activate")
+        self.assertEqual(messages[3].data["skill_id"], self.skill_id)
+        self.assertEqual(messages[4].msg_type, "intent.service.skills.activated")
+        self.assertEqual(messages[4].data["skill_id"], self.skill_id)
+        self.assertEqual(messages[5].msg_type, f"{self.skill_id}.activate")
         self.assertEqual(messages[6].msg_type, "ovos.session.update_default")
 
-        self.assertEqual(messages[7].msg_type, "enclosure.active_skill")
-        self.assertEqual(messages[7].data["skill_id"], self.skill_id)
-        self.assertEqual(messages[8].msg_type, "speak")
-        self.assertEqual(messages[8].data["utterance"], "give me an answer", )
-        self.assertEqual(messages[8].data["lang"], "en-us")
-        self.assertTrue(messages[8].data["expect_response"])  # listen after dialog
-        self.assertEqual(messages[8].data["meta"]["skill"], self.skill_id)
+        # enable get_response for this session
+        self.assertEqual(messages[7].msg_type, "skill.converse.get_response.enable")
+        self.assertEqual(messages[8].msg_type, "ovos.session.update_default")
+
+        # question dialog
+        self.assertEqual(messages[9].msg_type, "enclosure.active_skill")
+        self.assertEqual(messages[9].data["skill_id"], self.skill_id)
+        self.assertEqual(messages[10].msg_type, "speak")
+        self.assertEqual(messages[10].data["utterance"], "give me an answer", )
+        self.assertEqual(messages[10].data["lang"], "en-us")
+        self.assertTrue(messages[10].data["expect_response"])  # listen after dialog
+        self.assertEqual(messages[10].data["meta"]["skill"], self.skill_id)
         # ovos-audio speak execution (simulated)
-        self.assertEqual(messages[9].msg_type, "recognizer_loop:audio_output_start")
-        self.assertEqual(messages[10].msg_type, "recognizer_loop:audio_output_end")
+        self.assertEqual(messages[11].msg_type, "recognizer_loop:audio_output_start")
+        self.assertEqual(messages[12].msg_type, "recognizer_loop:audio_output_end")
 
         # check utterance goes through converse cycle
-        self.assertEqual(messages[11].msg_type, "recognizer_loop:utterance")
-        self.assertEqual(messages[12].msg_type, f"{self.skill_id}.converse.ping")
-        self.assertEqual(messages[13].msg_type, "skill.converse.pong")
+        self.assertEqual(messages[13].msg_type, "recognizer_loop:utterance")
+        self.assertEqual(messages[14].msg_type, f"{self.skill_id}.converse.ping")
+        self.assertEqual(messages[15].msg_type, "skill.converse.pong")
 
         # captured utterance sent to get_response handler that is waiting
-        self.assertEqual(messages[14].msg_type, f"{self.skill_id}.converse.get_response")
-        self.assertEqual(messages[14].data["utterances"], ["ok"])
+        self.assertEqual(messages[16].msg_type, f"{self.skill_id}.converse.get_response")
+        self.assertEqual(messages[16].data["utterances"], ["ok"])
 
         # converse pipeline activates the skill last_used timestamp
-        self.assertEqual(messages[15].msg_type, "intent.service.skills.activated")
-        self.assertEqual(messages[16].msg_type, f"{self.skill_id}.activate")
         self.assertEqual(messages[17].msg_type, "ovos.session.update_default")
 
         # disable get_response for this session
@@ -381,15 +384,16 @@ class TestSessions(TestCase):
 
         # confirm all expected messages are sent
         expected_messages = [
-            "recognizer_loop:utterance",  # no session
-
+            "recognizer_loop:utterance",  # trigger intent to start the test
             # skill selected
+            f"{self.skill_id}:test_get_response.intent",
+            "mycroft.skill.handler.start",
+            # skill activated (because of selection)
+            "intent.service.skills.activate",
             "intent.service.skills.activated",
             f"{self.skill_id}.activate",
-            f"{self.skill_id}:test_get_response.intent",
-
-            # intent code before self.get_response
-            "mycroft.skill.handler.start",
+            "ovos.session.update_default",  # sync skill activation
+            # intent code
             "skill.converse.get_response.enable",  # start of get_response
             "ovos.session.update_default",  # sync get_response status
             "enclosure.active_skill",
@@ -398,18 +402,14 @@ class TestSessions(TestCase):
             "recognizer_loop:audio_output_end",
 
             "recognizer_loop:utterance",  # answer to get_response from user,
-            # converse pipeline start
+            # converse check
             f"{self.skill_id}.converse.ping",
             "skill.converse.pong",
+            # get response handling
             f"{self.skill_id}.converse.get_response",  # returning user utterance to running intent self.get_response
-            # skill selected by converse pipeline
-            "intent.service.skills.activated",
-            f"{self.skill_id}.activate",
             "ovos.session.update_default",  # sync skill activated by converse
-
             "skill.converse.get_response.disable",  # end of get_response
             "ovos.session.update_default",  # sync get_response status
-
             # intent code post self.get_response
             "enclosure.active_skill",  # from speak inside intent
             "speak",  # speak "ERROR" inside intent
@@ -435,45 +435,47 @@ class TestSessions(TestCase):
             print(m.msg_type, m.context["session"]["session_id"])
             self.assertEqual(m.context["session"]["session_id"], "default")
 
-        # verify skill is activated by intent service (intent pipeline matched)
-        self.assertEqual(messages[1].msg_type, "intent.service.skills.activated")
-        self.assertEqual(messages[1].data["skill_id"], self.skill_id)
-        self.assertEqual(messages[2].msg_type, f"{self.skill_id}.activate")
-
         # verify intent triggers
-        self.assertEqual(messages[3].msg_type, f"{self.skill_id}:test_get_response.intent")
+        self.assertEqual(messages[1].msg_type, f"{self.skill_id}:test_get_response.intent")
 
         # verify intent execution
-        self.assertEqual(messages[4].msg_type, "mycroft.skill.handler.start")
-        self.assertEqual(messages[4].data["name"], "TestAbortSkill.handle_test_get_response")
+        self.assertEqual(messages[2].msg_type, "mycroft.skill.handler.start")
+        self.assertEqual(messages[2].data["name"], "TestAbortSkill.handle_test_get_response")
 
-        # enable get_response for this session
-        self.assertEqual(messages[5].msg_type, "skill.converse.get_response.enable")
+        # verify skill is activated
+        self.assertEqual(messages[3].msg_type, "intent.service.skills.activate")
+        self.assertEqual(messages[3].data["skill_id"], self.skill_id)
+        self.assertEqual(messages[4].msg_type, "intent.service.skills.activated")
+        self.assertEqual(messages[4].data["skill_id"], self.skill_id)
+        self.assertEqual(messages[5].msg_type, f"{self.skill_id}.activate")
         self.assertEqual(messages[6].msg_type, "ovos.session.update_default")
 
-        self.assertEqual(messages[7].msg_type, "enclosure.active_skill")
-        self.assertEqual(messages[7].data["skill_id"], self.skill_id)
-        self.assertEqual(messages[8].msg_type, "speak")
-        self.assertEqual(messages[8].data["utterance"], "give me an answer", )
-        self.assertEqual(messages[8].data["lang"], "en-us")
-        self.assertTrue(messages[8].data["expect_response"])  # listen after dialog
-        self.assertEqual(messages[8].data["meta"]["skill"], self.skill_id)
+        # enable get_response for this session
+        self.assertEqual(messages[7].msg_type, "skill.converse.get_response.enable")
+        self.assertEqual(messages[8].msg_type, "ovos.session.update_default")
+
+        # question dialog
+        self.assertEqual(messages[9].msg_type, "enclosure.active_skill")
+        self.assertEqual(messages[9].data["skill_id"], self.skill_id)
+        self.assertEqual(messages[10].msg_type, "speak")
+        self.assertEqual(messages[10].data["utterance"], "give me an answer", )
+        self.assertEqual(messages[10].data["lang"], "en-us")
+        self.assertTrue(messages[10].data["expect_response"])  # listen after dialog
+        self.assertEqual(messages[10].data["meta"]["skill"], self.skill_id)
         # ovos-audio speak execution (simulated)
-        self.assertEqual(messages[9].msg_type, "recognizer_loop:audio_output_start")
-        self.assertEqual(messages[10].msg_type, "recognizer_loop:audio_output_end")
+        self.assertEqual(messages[11].msg_type, "recognizer_loop:audio_output_start")
+        self.assertEqual(messages[12].msg_type, "recognizer_loop:audio_output_end")
 
         # check utterance goes through converse cycle
-        self.assertEqual(messages[11].msg_type, "recognizer_loop:utterance")
-        self.assertEqual(messages[12].msg_type, f"{self.skill_id}.converse.ping")
-        self.assertEqual(messages[13].msg_type, "skill.converse.pong")
+        self.assertEqual(messages[13].msg_type, "recognizer_loop:utterance")
+        self.assertEqual(messages[14].msg_type, f"{self.skill_id}.converse.ping")
+        self.assertEqual(messages[15].msg_type, "skill.converse.pong")
 
         # captured utterance sent to get_response handler that is waiting
-        self.assertEqual(messages[14].msg_type, f"{self.skill_id}.converse.get_response")
-        self.assertEqual(messages[14].data["utterances"], ["cancel"])  # was canceled by user, returned None
+        self.assertEqual(messages[16].msg_type, f"{self.skill_id}.converse.get_response")
+        self.assertEqual(messages[16].data["utterances"], ["cancel"])  # was canceled by user, returned None
 
         # converse pipeline activates the skill last_used timestamp
-        self.assertEqual(messages[15].msg_type, "intent.service.skills.activated")
-        self.assertEqual(messages[16].msg_type, f"{self.skill_id}.activate")
         self.assertEqual(messages[17].msg_type, "ovos.session.update_default")
 
         # disable get_response for this session
@@ -553,15 +555,16 @@ class TestSessions(TestCase):
 
         # confirm all expected messages are sent
         expected_messages = [
-            "recognizer_loop:utterance",  # no session
-
+            "recognizer_loop:utterance",  # trigger intent to start the test
             # skill selected
+            f"{self.skill_id}:test_get_response3.intent",
+            "mycroft.skill.handler.start",
+            # skill activated (because of selection)
+            "intent.service.skills.activate",
             "intent.service.skills.activated",
             f"{self.skill_id}.activate",
-            f"{self.skill_id}:test_get_response3.intent",
-
-            # intent code before self.get_response
-            "mycroft.skill.handler.start",
+            "ovos.session.update_default",  # sync skill activation
+            # intent code
             "skill.converse.get_response.enable",  # start of get_response
             "ovos.session.update_default",  # sync get_response status
             "mycroft.mic.listen",  # no dialog in self.get_response
@@ -569,18 +572,14 @@ class TestSessions(TestCase):
             "mycroft.mic.listen",
 
             "recognizer_loop:utterance",  # answer to get_response from user,
-            # converse pipeline start
+            # converse check
             f"{self.skill_id}.converse.ping",
             "skill.converse.pong",
+            # get response handling
             f"{self.skill_id}.converse.get_response",  # returning user utterance to running intent self.get_response
-            # skill selected by converse pipeline
-            "intent.service.skills.activated",
-            f"{self.skill_id}.activate",
             "ovos.session.update_default",  # sync skill activated by converse
-
             "skill.converse.get_response.disable",  # end of get_response
             "ovos.session.update_default",  # sync get_response status
-
             # intent code post self.get_response
             "enclosure.active_skill",  # from speak inside intent
             "speak",  # speak "ok" inside intent
@@ -604,62 +603,65 @@ class TestSessions(TestCase):
             print(m.msg_type, m.context["session"]["session_id"])
             self.assertEqual(m.context["session"]["session_id"], "default")
 
-        # verify skill is activated by intent service (intent pipeline matched)
-        self.assertEqual(messages[1].msg_type, "intent.service.skills.activated")
-        self.assertEqual(messages[1].data["skill_id"], self.skill_id)
-        self.assertEqual(messages[2].msg_type, f"{self.skill_id}.activate")
-
         # verify intent triggers
-        self.assertEqual(messages[3].msg_type, f"{self.skill_id}:test_get_response3.intent")
+        self.assertEqual(messages[1].msg_type, f"{self.skill_id}:test_get_response3.intent")
 
         # verify intent execution
-        self.assertEqual(messages[4].msg_type, "mycroft.skill.handler.start")
-        self.assertEqual(messages[4].data["name"], "TestAbortSkill.handle_test_get_response3")
+        self.assertEqual(messages[2].msg_type, "mycroft.skill.handler.start")
+        self.assertEqual(messages[2].data["name"], "TestAbortSkill.handle_test_get_response3")
 
-        # enable get_response for this session
-        self.assertEqual(messages[5].msg_type, "skill.converse.get_response.enable")
+        # verify skill is activated
+        self.assertEqual(messages[3].msg_type, "intent.service.skills.activate")
+        self.assertEqual(messages[3].data["skill_id"], self.skill_id)
+        self.assertEqual(messages[4].msg_type, "intent.service.skills.activated")
+        self.assertEqual(messages[4].data["skill_id"], self.skill_id)
+        self.assertEqual(messages[5].msg_type, f"{self.skill_id}.activate")
         self.assertEqual(messages[6].msg_type, "ovos.session.update_default")
 
+        # enable get_response for this session
+        self.assertEqual(messages[7].msg_type, "skill.converse.get_response.enable")
+        self.assertEqual(messages[8].msg_type, "ovos.session.update_default")
+
         # 3 sound prompts (no dialog in this test)
-        self.assertEqual(messages[7].msg_type, "mycroft.mic.listen")
-        self.assertEqual(messages[8].msg_type, "mycroft.mic.listen")
         self.assertEqual(messages[9].msg_type, "mycroft.mic.listen")
+        self.assertEqual(messages[10].msg_type, "mycroft.mic.listen")
+        self.assertEqual(messages[11].msg_type, "mycroft.mic.listen")
 
         # check utterance goes through converse cycle
-        self.assertEqual(messages[10].msg_type, "recognizer_loop:utterance")
-        self.assertEqual(messages[11].msg_type, f"{self.skill_id}.converse.ping")
-        self.assertEqual(messages[12].msg_type, "skill.converse.pong")
+        self.assertEqual(messages[12].msg_type, "recognizer_loop:utterance")
+        self.assertEqual(messages[13].msg_type, f"{self.skill_id}.converse.ping")
+        self.assertEqual(messages[14].msg_type, "skill.converse.pong")
 
         # captured utterance sent to get_response handler that is waiting
-        self.assertEqual(messages[13].msg_type, f"{self.skill_id}.converse.get_response")
-        self.assertEqual(messages[13].data["utterances"], ["ok"])
+        self.assertEqual(messages[15].msg_type, f"{self.skill_id}.converse.get_response")
+        self.assertEqual(messages[15].data["utterances"], ["ok"])
 
         # converse pipeline activates the skill last_used timestamp
-        self.assertEqual(messages[14].msg_type, "intent.service.skills.activated")
-        self.assertEqual(messages[15].msg_type, f"{self.skill_id}.activate")
-        self.assertEqual(messages[16].msg_type, "ovos.session.update_default")
-
-        # disable get_response for this session
-        self.assertEqual(messages[17].msg_type, "skill.converse.get_response.disable")
+        self.assertEqual(messages[16].msg_type, "intent.service.skills.activated")
+        self.assertEqual(messages[17].msg_type, f"{self.skill_id}.activate")
         self.assertEqual(messages[18].msg_type, "ovos.session.update_default")
 
-        # post self.get_response intent code
-        self.assertEqual(messages[19].msg_type, "enclosure.active_skill")
-        self.assertEqual(messages[19].data["skill_id"], self.skill_id)
-        self.assertEqual(messages[20].msg_type, "speak")
-        self.assertEqual(messages[20].data["lang"], "en-us")
-        self.assertFalse(messages[20].data["expect_response"])
-        self.assertEqual(messages[20].data["utterance"], "ok")
-        self.assertEqual(messages[20].data["meta"]["skill"], self.skill_id)
+        # disable get_response for this session
+        self.assertEqual(messages[19].msg_type, "skill.converse.get_response.disable")
+        self.assertEqual(messages[20].msg_type, "ovos.session.update_default")
 
-        self.assertEqual(messages[21].msg_type, "mycroft.skill.handler.complete")
-        self.assertEqual(messages[21].data["name"], "TestAbortSkill.handle_test_get_response3")
+        # post self.get_response intent code
+        self.assertEqual(messages[21].msg_type, "enclosure.active_skill")
+        self.assertEqual(messages[21].data["skill_id"], self.skill_id)
+        self.assertEqual(messages[22].msg_type, "speak")
+        self.assertEqual(messages[22].data["lang"], "en-us")
+        self.assertFalse(messages[22].data["expect_response"])
+        self.assertEqual(messages[22].data["utterance"], "ok")
+        self.assertEqual(messages[22].data["meta"]["skill"], self.skill_id)
+
+        self.assertEqual(messages[23].msg_type, "mycroft.skill.handler.complete")
+        self.assertEqual(messages[23].data["name"], "TestAbortSkill.handle_test_get_response3")
 
         # verify default session is now updated
-        self.assertEqual(messages[22].msg_type, "ovos.session.update_default")
-        self.assertEqual(messages[22].data["session_data"]["session_id"], "default")
+        self.assertEqual(messages[24].msg_type, "ovos.session.update_default")
+        self.assertEqual(messages[24].data["session_data"]["session_id"], "default")
         # test deserialization of payload
-        sess = Session.deserialize(messages[22].data["session_data"])
+        sess = Session.deserialize(messages[24].data["session_data"])
         self.assertEqual(sess.session_id, "default")
 
     def test_nested(self):
@@ -720,12 +722,17 @@ class TestSessions(TestCase):
             "recognizer_loop:utterance",  # no session
 
             # skill selected
-            "intent.service.skills.activated",  # default session injected
-            f"{self.skill_id}.activate",
+
             f"{self.skill_id}:test_get_response_cascade.intent",
 
-            # intent code before self.get_response
+            # skill activated
             "mycroft.skill.handler.start",
+            "intent.service.skills.activate",
+            "intent.service.skills.activated",
+            f"{self.skill_id}.activate",
+            "ovos.session.update_default",
+
+            # intent code before self.get_response
             "enclosure.active_skill",
             "speak",  # "give me items"
 
@@ -737,9 +744,7 @@ class TestSessions(TestCase):
             f"{self.skill_id}.converse.ping",
             "skill.converse.pong",
             f"{self.skill_id}.converse.get_response",  # A
-            "intent.service.skills.activated",
-            f"{self.skill_id}.activate",
-            "ovos.session.update_default",  # sync skill trigger
+            "ovos.session.update_default",
             "skill.converse.get_response.disable",
             "ovos.session.update_default",  # sync get_response status
 
@@ -751,8 +756,6 @@ class TestSessions(TestCase):
             f"{self.skill_id}.converse.ping",
             "skill.converse.pong",
             f"{self.skill_id}.converse.get_response",  # B
-            "intent.service.skills.activated",
-            f"{self.skill_id}.activate",
             "ovos.session.update_default",  # sync skill trigger
             "skill.converse.get_response.disable",
             "ovos.session.update_default",  # sync get_response status
@@ -765,8 +768,6 @@ class TestSessions(TestCase):
             f"{self.skill_id}.converse.ping",
             "skill.converse.pong",
             f"{self.skill_id}.converse.get_response",  # C
-            "intent.service.skills.activated",
-            f"{self.skill_id}.activate",
             "ovos.session.update_default",  # sync skill trigger
             "skill.converse.get_response.disable",
             "ovos.session.update_default",  # sync get_response status
@@ -779,8 +780,6 @@ class TestSessions(TestCase):
             f"{self.skill_id}.converse.ping",
             "skill.converse.pong",
             f"{self.skill_id}.converse.get_response",  # cancel
-            "intent.service.skills.activated",
-            f"{self.skill_id}.activate",
             "ovos.session.update_default",  # sync skill trigger
             "skill.converse.get_response.disable",
             "ovos.session.update_default",  # sync get_response status
@@ -804,33 +803,36 @@ class TestSessions(TestCase):
         # verify that "session" is injected
         # (missing in utterance message) and kept in all messages
         for m in messages[1:]:
-            print(m.msg_type, m.context["session"]["session_id"])
             self.assertEqual(m.context["session"]["session_id"], "default")
 
-        # verify skill is activated by intent service (intent pipeline matched)
-        self.assertEqual(messages[1].msg_type, "intent.service.skills.activated")
-        self.assertEqual(messages[1].data["skill_id"], self.skill_id)
-        self.assertEqual(messages[2].msg_type, f"{self.skill_id}.activate")
-
         # verify intent triggers
-        self.assertEqual(messages[3].msg_type, f"{self.skill_id}:test_get_response_cascade.intent")
+        self.assertEqual(messages[1].msg_type, f"{self.skill_id}:test_get_response_cascade.intent")
 
         # verify intent execution
-        self.assertEqual(messages[4].msg_type, "mycroft.skill.handler.start")
-        self.assertEqual(messages[4].data["name"], "TestAbortSkill.handle_test_get_response_cascade")
+        self.assertEqual(messages[2].msg_type, "mycroft.skill.handler.start")
+        self.assertEqual(messages[2].data["name"], "TestAbortSkill.handle_test_get_response_cascade")
+
+        # verify skill is activated
+        self.assertEqual(messages[3].msg_type, "intent.service.skills.activate")
+        self.assertEqual(messages[3].data["skill_id"], self.skill_id)
+        self.assertEqual(messages[4].msg_type, "intent.service.skills.activated")
+        self.assertEqual(messages[4].data["skill_id"], self.skill_id)
+        self.assertEqual(messages[5].msg_type, f"{self.skill_id}.activate")
+        self.assertEqual(messages[6].msg_type, "ovos.session.update_default")
 
         # post self.get_response intent code
-        self.assertEqual(messages[5].msg_type, "enclosure.active_skill")
-        self.assertEqual(messages[5].data["skill_id"], self.skill_id)
-        self.assertEqual(messages[6].msg_type, "speak")
-        self.assertEqual(messages[6].data["lang"], "en-us")
-        self.assertFalse(messages[6].data["expect_response"])
-        self.assertEqual(messages[6].data["utterance"], "give me items")
-        self.assertEqual(messages[6].data["meta"]["skill"], self.skill_id)
+        self.assertEqual(messages[7].msg_type, "enclosure.active_skill")
+        self.assertEqual(messages[7].data["skill_id"], self.skill_id)
+        self.assertEqual(messages[8].msg_type, "speak")
+        self.assertEqual(messages[8].data["lang"], "en-us")
+        self.assertFalse(messages[8].data["expect_response"])
+        self.assertEqual(messages[8].data["utterance"], "give me items")
+        self.assertEqual(messages[8].data["meta"]["skill"], self.skill_id)
 
         responses = ["A", "B", "C", "cancel"]
         for response in responses:
-            i = 6 + responses.index(response) * 12
+            i = 8 + responses.index(response) * 10
+            print(i, response)
             # enable get_response for this session
             self.assertEqual(messages[i + 1].msg_type, "skill.converse.get_response.enable")
             self.assertEqual(messages[i + 2].msg_type, "ovos.session.update_default")
@@ -848,20 +850,18 @@ class TestSessions(TestCase):
             self.assertEqual(messages[i + 7].data["utterances"], [response])
 
             # converse pipeline activates the skill last_used timestamp
-            self.assertEqual(messages[i + 8].msg_type, "intent.service.skills.activated")
-            self.assertEqual(messages[i + 9].msg_type, f"{self.skill_id}.activate")
-            self.assertEqual(messages[i + 10].msg_type, "ovos.session.update_default")
+            self.assertEqual(messages[i + 8].msg_type,  "ovos.session.update_default")
 
             # disable get_response for this session
-            self.assertEqual(messages[i + 11].msg_type, "skill.converse.get_response.disable")
-            self.assertEqual(messages[i + 12].msg_type, "ovos.session.update_default")
+            self.assertEqual(messages[i + 9].msg_type, "skill.converse.get_response.disable")
+            self.assertEqual(messages[i + 10].msg_type, "ovos.session.update_default")
 
         # intent return
-        self.assertEqual(messages[55].msg_type, "skill_items")
-        self.assertEqual(messages[55].data, {"items": ["A", "B", "C"]})
+        self.assertEqual(messages[49].msg_type, "skill_items")
+        self.assertEqual(messages[49].data, {"items": ["A", "B", "C"]})
 
         # report handler complete
-        self.assertEqual(messages[56].msg_type, "mycroft.skill.handler.complete")
-        self.assertEqual(messages[56].data["name"], "TestAbortSkill.handle_test_get_response_cascade")
+        self.assertEqual(messages[50].msg_type, "mycroft.skill.handler.complete")
+        self.assertEqual(messages[50].data["name"], "TestAbortSkill.handle_test_get_response_cascade")
 
-        self.assertEqual(messages[57].msg_type, "ovos.session.update_default")
+        self.assertEqual(messages[51].msg_type, "ovos.session.update_default")

--- a/test/end2end/session/test_sched.py
+++ b/test/end2end/session/test_sched.py
@@ -47,11 +47,13 @@ class TestSessions(TestCase):
 
         # confirm all expected messages are sent
         expected_messages = [
-            "recognizer_loop:utterance",  # no session
-            "intent.service.skills.activated",  # default session injected
-            f"{self.skill_id}.activate",
+            "recognizer_loop:utterance",
             f"{self.skill_id}:ScheduleIntent",
             "mycroft.skill.handler.start",
+            "intent.service.skills.activate",
+            "intent.service.skills.activated",
+            f"{self.skill_id}.activate",
+            "ovos.session.update_default",
             "enclosure.active_skill",
             "speak",
             "mycroft.scheduler.schedule_event",
@@ -76,55 +78,60 @@ class TestSessions(TestCase):
             self.assertEqual(m.context["session"]["session_id"], "default")
             self.assertEqual(m.context["lang"], "en-us")
 
-        # verify skill is activated by intent service (intent pipeline matched)
-        self.assertEqual(messages[1].msg_type, "intent.service.skills.activated")
-        self.assertEqual(messages[1].data["skill_id"], self.skill_id)
-        self.assertEqual(messages[2].msg_type, f"{self.skill_id}.activate")
-
         # verify intent triggers
-        self.assertEqual(messages[3].msg_type, f"{self.skill_id}:ScheduleIntent")
-        self.assertEqual(messages[3].data["intent_type"], f"{self.skill_id}:ScheduleIntent")
+        self.assertEqual(messages[1].msg_type, f"{self.skill_id}:ScheduleIntent")
+        self.assertEqual(messages[1].data["intent_type"], f"{self.skill_id}:ScheduleIntent")
         # verify skill_id is now present in every message.context
-        for m in messages[3:]:
+        for m in messages[1:]:
             self.assertEqual(m.context["skill_id"], self.skill_id)
 
         # verify intent execution
-        self.assertEqual(messages[4].msg_type, "mycroft.skill.handler.start")
-        self.assertEqual(messages[4].data["name"], "ScheduleSkill.handle_sched_intent")
-        self.assertEqual(messages[5].msg_type, "enclosure.active_skill")
-        self.assertEqual(messages[5].data["skill_id"], self.skill_id)
-        self.assertEqual(messages[6].msg_type, "speak")
-        self.assertEqual(messages[6].data["lang"], "en-us")
-        self.assertFalse(messages[6].data["expect_response"])
-        self.assertEqual(messages[6].data["meta"]["dialog"], "done")
-        self.assertEqual(messages[6].data["meta"]["skill"], self.skill_id)
-        self.assertEqual(messages[7].msg_type, "mycroft.scheduler.schedule_event")
-        self.assertEqual(messages[8].msg_type, "mycroft.skill.handler.complete")
-        self.assertEqual(messages[8].data["name"], "ScheduleSkill.handle_sched_intent")
+        self.assertEqual(messages[2].msg_type, "mycroft.skill.handler.start")
+        self.assertEqual(messages[2].data["name"], "ScheduleSkill.handle_sched_intent")
+
+        self.assertEqual(messages[3].msg_type, "intent.service.skills.activate")
+        self.assertEqual(messages[3].data["skill_id"], self.skill_id)
+        self.assertEqual(messages[4].msg_type, "intent.service.skills.activated")
+        self.assertEqual(messages[4].data["skill_id"], self.skill_id)
+        self.assertEqual(messages[5].msg_type, f"{self.skill_id}.activate")
+        self.assertEqual(messages[6].msg_type, "ovos.session.update_default")
+
+        self.assertEqual(messages[7].msg_type, "enclosure.active_skill")
+        self.assertEqual(messages[7].data["skill_id"], self.skill_id)
+        self.assertEqual(messages[8].msg_type, "speak")
+        self.assertEqual(messages[8].data["lang"], "en-us")
+        self.assertFalse(messages[8].data["expect_response"])
+        self.assertEqual(messages[8].data["meta"]["dialog"], "done")
+        self.assertEqual(messages[8].data["meta"]["skill"], self.skill_id)
+        self.assertEqual(messages[9].msg_type, "mycroft.scheduler.schedule_event")
+        self.assertEqual(messages[10].msg_type, "mycroft.skill.handler.complete")
+        self.assertEqual(messages[10].data["name"], "ScheduleSkill.handle_sched_intent")
 
         # verify default session is now updated
-        self.assertEqual(messages[9].msg_type, "ovos.session.update_default")
-        self.assertEqual(messages[9].data["session_data"]["session_id"], "default")
+        self.assertEqual(messages[11].msg_type, "ovos.session.update_default")
+        self.assertEqual(messages[11].data["session_data"]["session_id"], "default")
         # test deserialization of payload
-        sess = Session.deserialize(messages[9].data["session_data"])
+        sess = Session.deserialize(messages[11].data["session_data"])
         self.assertEqual(sess.session_id, "default")
 
         # test that active skills list has been updated
         self.assertEqual(sess.active_skills[0][0], self.skill_id)
-        self.assertEqual(messages[9].data["session_data"]["active_skills"][0][0], self.skill_id)
+        self.assertEqual(messages[11].data["session_data"]["active_skills"][0][0], self.skill_id)
 
         # ensure context in triggered event is the same from message that triggered the intent
-        intent_context = messages[3].context
-        self.assertEqual(messages[10].msg_type, "skill-ovos-schedule.openvoiceos:my_event")
-        self.assertEqual(messages[10].context, intent_context)
-        self.assertEqual(messages[11].msg_type, "enclosure.active_skill")
-        self.assertEqual(messages[11].context, intent_context)
-        self.assertEqual(messages[12].msg_type, "speak")
-        self.assertEqual(messages[12].data["lang"], "en-us")
-        self.assertFalse(messages[12].data["expect_response"])
-        self.assertEqual(messages[12].data["meta"]["dialog"], "trigger")
-        self.assertEqual(messages[12].data["meta"]["skill"], self.skill_id)
+        self.assertEqual(messages[4].msg_type, "intent.service.skills.activated")
+        intent_context = messages[4].context  # when skill added to active list (last context change)
+
+        self.assertEqual(messages[12].msg_type, "skill-ovos-schedule.openvoiceos:my_event")
         self.assertEqual(messages[12].context, intent_context)
+        self.assertEqual(messages[13].msg_type, "enclosure.active_skill")
+        self.assertEqual(messages[13].context, intent_context)
+        self.assertEqual(messages[14].msg_type, "speak")
+        self.assertEqual(messages[14].data["lang"], "en-us")
+        self.assertFalse(messages[14].data["expect_response"])
+        self.assertEqual(messages[14].data["meta"]["dialog"], "trigger")
+        self.assertEqual(messages[14].data["meta"]["skill"], self.skill_id)
+        self.assertEqual(messages[14].context, intent_context)
 
     def test_explicit_session(self):
         SessionManager.sessions = {}
@@ -165,10 +172,11 @@ class TestSessions(TestCase):
         # confirm all expected messages are sent
         expected_messages = [
             "recognizer_loop:utterance",
-            "intent.service.skills.activated",
-            f"{self.skill_id}.activate",
             f"{self.skill_id}:ScheduleIntent",
             "mycroft.skill.handler.start",
+            "intent.service.skills.activate",
+            "intent.service.skills.activated",
+            f"{self.skill_id}.activate",
             "enclosure.active_skill",
             "speak",
             "mycroft.scheduler.schedule_event",
@@ -191,44 +199,49 @@ class TestSessions(TestCase):
         for m in messages:
             self.assertEqual(m.context["session"]["session_id"], sess.session_id)
 
-        # verify skill is activated by intent service (intent pipeline matched)
-        self.assertEqual(messages[1].msg_type, "intent.service.skills.activated")
-        self.assertEqual(messages[1].data["skill_id"], self.skill_id)
-        self.assertEqual(messages[2].msg_type, f"{self.skill_id}.activate")
-
         # verify intent triggers
-        self.assertEqual(messages[3].msg_type, f"{self.skill_id}:ScheduleIntent")
-        self.assertEqual(messages[3].data["intent_type"], f"{self.skill_id}:ScheduleIntent")
+        self.assertEqual(messages[1].msg_type, f"{self.skill_id}:ScheduleIntent")
+        self.assertEqual(messages[1].data["intent_type"], f"{self.skill_id}:ScheduleIntent")
         # verify skill_id is now present in every message.context
-        for m in messages[3:]:
+        for m in messages[1:]:
             self.assertEqual(m.context["skill_id"], self.skill_id)
 
+        # verify skill is activated
+        self.assertEqual(messages[2].msg_type, "mycroft.skill.handler.start")
+        self.assertEqual(messages[2].data["name"], "ScheduleSkill.handle_sched_intent")
+        self.assertEqual(messages[3].msg_type, "intent.service.skills.activate")
+        self.assertEqual(messages[3].data["skill_id"], self.skill_id)
+        self.assertEqual(messages[4].msg_type, "intent.service.skills.activated")
+        self.assertEqual(messages[4].data["skill_id"], self.skill_id)
+        self.assertEqual(messages[5].msg_type, f"{self.skill_id}.activate")
+        self.assertEqual(messages[5].msg_type, f"{self.skill_id}.activate")
+
         # verify intent execution
-        self.assertEqual(messages[4].msg_type, "mycroft.skill.handler.start")
-        self.assertEqual(messages[4].data["name"], "ScheduleSkill.handle_sched_intent")
-        self.assertEqual(messages[5].msg_type, "enclosure.active_skill")
-        self.assertEqual(messages[5].data["skill_id"], self.skill_id)
-        self.assertEqual(messages[6].msg_type, "speak")
-        self.assertEqual(messages[6].data["lang"], "en-us")
-        self.assertFalse(messages[6].data["expect_response"])
-        self.assertEqual(messages[6].data["meta"]["dialog"], "done")
-        self.assertEqual(messages[6].data["meta"]["skill"], self.skill_id)
-        self.assertEqual(messages[7].msg_type, "mycroft.scheduler.schedule_event")
-        self.assertEqual(messages[8].msg_type, "mycroft.skill.handler.complete")
-        self.assertEqual(messages[8].data["name"], "ScheduleSkill.handle_sched_intent")
+        self.assertEqual(messages[6].msg_type, "enclosure.active_skill")
+        self.assertEqual(messages[6].data["skill_id"], self.skill_id)
+        self.assertEqual(messages[7].msg_type, "speak")
+        self.assertEqual(messages[7].data["lang"], "en-us")
+        self.assertFalse(messages[7].data["expect_response"])
+        self.assertEqual(messages[7].data["meta"]["dialog"], "done")
+        self.assertEqual(messages[7].data["meta"]["skill"], self.skill_id)
+        self.assertEqual(messages[8].msg_type, "mycroft.scheduler.schedule_event")
+        self.assertEqual(messages[9].msg_type, "mycroft.skill.handler.complete")
+        self.assertEqual(messages[9].data["name"], "ScheduleSkill.handle_sched_intent")
 
         # ensure context in triggered event is the same from message that triggered the intent
-        intent_context = messages[3].context
-        self.assertEqual(messages[9].msg_type, "skill-ovos-schedule.openvoiceos:my_event")
-        self.assertEqual(messages[9].context, intent_context)
-        self.assertEqual(messages[10].msg_type, "enclosure.active_skill")
+        self.assertEqual(messages[4].msg_type, "intent.service.skills.activated")
+        intent_context = messages[4].context  # when skill added to active list (last context change)
+
+        self.assertEqual(messages[10].msg_type, "skill-ovos-schedule.openvoiceos:my_event")
         self.assertEqual(messages[10].context, intent_context)
-        self.assertEqual(messages[11].msg_type, "speak")
-        self.assertEqual(messages[11].data["lang"], "en-us")
-        self.assertFalse(messages[11].data["expect_response"])
-        self.assertEqual(messages[11].data["meta"]["dialog"], "trigger")
-        self.assertEqual(messages[11].data["meta"]["skill"], self.skill_id)
+        self.assertEqual(messages[11].msg_type, "enclosure.active_skill")
         self.assertEqual(messages[11].context, intent_context)
+        self.assertEqual(messages[12].msg_type, "speak")
+        self.assertEqual(messages[12].data["lang"], "en-us")
+        self.assertFalse(messages[12].data["expect_response"])
+        self.assertEqual(messages[12].data["meta"]["dialog"], "trigger")
+        self.assertEqual(messages[12].data["meta"]["skill"], self.skill_id)
+        self.assertEqual(messages[12].context, intent_context)
 
     def tearDown(self) -> None:
         self.core.stop()

--- a/test/end2end/session/test_session.py
+++ b/test/end2end/session/test_session.py
@@ -52,10 +52,12 @@ class TestSessions(TestCase):
         # confirm all expected messages are sent
         expected_messages = [
             "recognizer_loop:utterance",  # no session
-            "intent.service.skills.activated",  # default session injected
-            f"{self.skill_id}.activate",
             f"{self.skill_id}:HelloWorldIntent",
             "mycroft.skill.handler.start",
+            "intent.service.skills.activate",
+            "intent.service.skills.activated",
+            f"{self.skill_id}.activate",
+            "ovos.session.update_default",
             "enclosure.active_skill",
             "speak",
             "mycroft.skill.handler.complete",
@@ -75,41 +77,45 @@ class TestSessions(TestCase):
             self.assertEqual(m.context["session"]["session_id"], "default")
             self.assertEqual(m.context["lang"], "en-us")
 
-        # verify skill is activated by intent service (intent pipeline matched)
-        self.assertEqual(messages[1].msg_type, "intent.service.skills.activated")
-        self.assertEqual(messages[1].data["skill_id"], self.skill_id)
-        self.assertEqual(messages[2].msg_type, f"{self.skill_id}.activate")
-
         # verify intent triggers
-        self.assertEqual(messages[3].msg_type, f"{self.skill_id}:HelloWorldIntent")
-        self.assertEqual(messages[3].data["intent_type"], f"{self.skill_id}:HelloWorldIntent")
+        self.assertEqual(messages[1].msg_type, f"{self.skill_id}:HelloWorldIntent")
+        self.assertEqual(messages[1].data["intent_type"], f"{self.skill_id}:HelloWorldIntent")
         # verify skill_id is now present in every message.context
-        for m in messages[3:]:
+        for m in messages[1:]:
             self.assertEqual(m.context["skill_id"], self.skill_id)
 
-        # verify intent execution
-        self.assertEqual(messages[4].msg_type, "mycroft.skill.handler.start")
-        self.assertEqual(messages[4].data["name"], "HelloWorldSkill.handle_hello_world_intent")
-        self.assertEqual(messages[5].msg_type, "enclosure.active_skill")
-        self.assertEqual(messages[5].data["skill_id"], self.skill_id)
-        self.assertEqual(messages[6].msg_type, "speak")
-        self.assertEqual(messages[6].data["lang"], "en-us")
-        self.assertFalse(messages[6].data["expect_response"])
-        self.assertEqual(messages[6].data["meta"]["dialog"], "hello.world")
-        self.assertEqual(messages[6].data["meta"]["skill"], self.skill_id)
-        self.assertEqual(messages[7].msg_type, "mycroft.skill.handler.complete")
-        self.assertEqual(messages[7].data["name"], "HelloWorldSkill.handle_hello_world_intent")
+        # verify intent
+        self.assertEqual(messages[2].msg_type, "mycroft.skill.handler.start")
+        self.assertEqual(messages[2].data["name"], "HelloWorldSkill.handle_hello_world_intent")
+        # verify skill is activated
+        self.assertEqual(messages[3].msg_type, "intent.service.skills.activate")
+        self.assertEqual(messages[3].data["skill_id"], self.skill_id)
+        self.assertEqual(messages[4].msg_type, "intent.service.skills.activated")
+        self.assertEqual(messages[4].data["skill_id"], self.skill_id)
+        self.assertEqual(messages[5].msg_type, f"{self.skill_id}.activate")
+        self.assertEqual(messages[6].msg_type, "ovos.session.update_default")
+        # verify intent code execution
+        self.assertEqual(messages[7].msg_type, "enclosure.active_skill")
+        self.assertEqual(messages[7].data["skill_id"], self.skill_id)
+        self.assertEqual(messages[8].msg_type, "speak")
+        self.assertEqual(messages[8].data["lang"], "en-us")
+        self.assertFalse(messages[8].data["expect_response"])
+        self.assertEqual(messages[8].data["meta"]["dialog"], "hello.world")
+        self.assertEqual(messages[8].data["meta"]["skill"], self.skill_id)
+        # intent complete
+        self.assertEqual(messages[9].msg_type, "mycroft.skill.handler.complete")
+        self.assertEqual(messages[9].data["name"], "HelloWorldSkill.handle_hello_world_intent")
 
         # verify default session is now updated
-        self.assertEqual(messages[8].msg_type, "ovos.session.update_default")
-        self.assertEqual(messages[8].data["session_data"]["session_id"], "default")
+        self.assertEqual(messages[10].msg_type, "ovos.session.update_default")
+        self.assertEqual(messages[10].data["session_data"]["session_id"], "default")
         # test deserialization of payload
-        sess = Session.deserialize(messages[8].data["session_data"])
+        sess = Session.deserialize(messages[10].data["session_data"])
         self.assertEqual(sess.session_id, "default")
 
         # test that active skills list has been updated
         self.assertEqual(sess.active_skills[0][0], self.skill_id)
-        self.assertEqual(messages[8].data["session_data"]["active_skills"][0][0], self.skill_id)
+        self.assertEqual(messages[10].data["session_data"]["active_skills"][0][0], self.skill_id)
 
     def test_explicit_default_session(self):
         SessionManager.sessions = {}
@@ -153,10 +159,12 @@ class TestSessions(TestCase):
             "recognizer_loop:utterance",
             f"{self.skill_id}.converse.ping",
             "skill.converse.pong",
-            "intent.service.skills.activated",
-            f"{self.skill_id}.activate",
             f"{self.skill_id}:HelloWorldIntent",
             "mycroft.skill.handler.start",
+            "intent.service.skills.activate",
+            "intent.service.skills.activated",
+            f"{self.skill_id}.activate",
+            "ovos.session.update_default",
             "enclosure.active_skill",
             "speak",
             "mycroft.skill.handler.complete",
@@ -182,41 +190,43 @@ class TestSessions(TestCase):
         self.assertEqual(messages[2].context["skill_id"], self.skill_id)
         self.assertFalse(messages[2].data["can_handle"])
 
-        # verify skill is activated by intent service (intent pipeline matched)
-        self.assertEqual(messages[3].msg_type, "intent.service.skills.activated")
-        self.assertEqual(messages[3].data["skill_id"], self.skill_id)
-        self.assertEqual(messages[4].msg_type, f"{self.skill_id}.activate")
-
         # verify intent triggers
-        self.assertEqual(messages[5].msg_type, f"{self.skill_id}:HelloWorldIntent")
-        self.assertEqual(messages[5].data["intent_type"], f"{self.skill_id}:HelloWorldIntent")
+        self.assertEqual(messages[3].msg_type, f"{self.skill_id}:HelloWorldIntent")
+        self.assertEqual(messages[3].data["intent_type"], f"{self.skill_id}:HelloWorldIntent")
         # verify skill_id is now present in every message.context
-        for m in messages[5:]:
+        for m in messages[3:]:
             self.assertEqual(m.context["skill_id"], self.skill_id)
 
-        # verify intent execution
-        self.assertEqual(messages[6].msg_type, "mycroft.skill.handler.start")
-        self.assertEqual(messages[6].data["name"], "HelloWorldSkill.handle_hello_world_intent")
-        self.assertEqual(messages[7].msg_type, "enclosure.active_skill")
-        self.assertEqual(messages[7].data["skill_id"], self.skill_id)
-        self.assertEqual(messages[8].msg_type, "speak")
-        self.assertEqual(messages[8].data["lang"], "en-us")
-        self.assertFalse(messages[8].data["expect_response"])
-        self.assertEqual(messages[8].data["meta"]["dialog"], "hello.world")
-        self.assertEqual(messages[8].data["meta"]["skill"], self.skill_id)
-        self.assertEqual(messages[9].msg_type, "mycroft.skill.handler.complete")
-        self.assertEqual(messages[9].data["name"], "HelloWorldSkill.handle_hello_world_intent")
+        self.assertEqual(messages[4].msg_type, "mycroft.skill.handler.start")
+        # verify skill is activated
+        self.assertEqual(messages[5].msg_type, "intent.service.skills.activate")
+        self.assertEqual(messages[5].data["skill_id"], self.skill_id)
+        self.assertEqual(messages[6].msg_type, "intent.service.skills.activated")
+        self.assertEqual(messages[6].data["skill_id"], self.skill_id)
+        self.assertEqual(messages[7].msg_type, f"{self.skill_id}.activate")
+        self.assertEqual(messages[8].msg_type, "ovos.session.update_default")
+        # verify intent code execution
+        self.assertEqual(messages[9].msg_type, "enclosure.active_skill")
+        self.assertEqual(messages[9].data["skill_id"], self.skill_id)
+        self.assertEqual(messages[10].msg_type, "speak")
+        self.assertEqual(messages[10].data["lang"], "en-us")
+        self.assertFalse(messages[10].data["expect_response"])
+        self.assertEqual(messages[10].data["meta"]["dialog"], "hello.world")
+        self.assertEqual(messages[10].data["meta"]["skill"], self.skill_id)
+        # intent complete
+        self.assertEqual(messages[11].msg_type, "mycroft.skill.handler.complete")
+        self.assertEqual(messages[11].data["name"], "HelloWorldSkill.handle_hello_world_intent")
 
         # verify default session is now updated
-        self.assertEqual(messages[10].msg_type, "ovos.session.update_default")
-        self.assertEqual(messages[10].data["session_data"]["session_id"], "default")
+        self.assertEqual(messages[12].msg_type, "ovos.session.update_default")
+        self.assertEqual(messages[12].data["session_data"]["session_id"], "default")
 
         # test deserialization of payload
-        sess = Session.deserialize(messages[10].data["session_data"])
+        sess = Session.deserialize(messages[12].data["session_data"])
         self.assertEqual(sess.session_id, "default")
 
         # test that active skills list has been updated
-        self.assertEqual(messages[10].data["session_data"]["active_skills"][0][0], self.skill_id)
+        self.assertEqual(messages[12].data["session_data"]["active_skills"][0][0], self.skill_id)
         self.assertEqual(sess.active_skills[0][0], self.skill_id)
         self.assertNotEqual(sess.active_skills[0][1], now)
 
@@ -267,10 +277,11 @@ class TestSessions(TestCase):
             "recognizer_loop:utterance",
             f"{self.skill_id}.converse.ping",
             "skill.converse.pong",
-            "intent.service.skills.activated",
-            f"{self.skill_id}.activate",
             f"{self.skill_id}:HelloWorldIntent",
             "mycroft.skill.handler.start",
+            "intent.service.skills.activate",
+            "intent.service.skills.activated",
+            f"{self.skill_id}.activate",
             "enclosure.active_skill",
             "speak",
             "mycroft.skill.handler.complete"
@@ -295,33 +306,35 @@ class TestSessions(TestCase):
         self.assertEqual(messages[2].context["skill_id"], self.skill_id)
         self.assertFalse(messages[2].data["can_handle"])
 
-        # verify skill is activated by intent service (intent pipeline matched)
-        self.assertEqual(messages[3].msg_type, "intent.service.skills.activated")
-        self.assertEqual(messages[3].data["skill_id"], self.skill_id)
-        self.assertEqual(messages[4].msg_type, f"{self.skill_id}.activate")
-
         # verify intent triggers
-        self.assertEqual(messages[5].msg_type, f"{self.skill_id}:HelloWorldIntent")
-        self.assertEqual(messages[5].data["intent_type"], f"{self.skill_id}:HelloWorldIntent")
+        self.assertEqual(messages[3].msg_type, f"{self.skill_id}:HelloWorldIntent")
+        self.assertEqual(messages[3].data["intent_type"], f"{self.skill_id}:HelloWorldIntent")
         # verify skill_id is now present in every message.context
-        for m in messages[5:]:
+        for m in messages[3:]:
             self.assertEqual(m.context["skill_id"], self.skill_id)
 
         # verify intent execution
-        self.assertEqual(messages[6].msg_type, "mycroft.skill.handler.start")
-        self.assertEqual(messages[6].data["name"], "HelloWorldSkill.handle_hello_world_intent")
-        self.assertEqual(messages[7].msg_type, "enclosure.active_skill")
-        self.assertEqual(messages[7].data["skill_id"], self.skill_id)
-        self.assertEqual(messages[8].msg_type, "speak")
-        self.assertEqual(messages[8].data["lang"], "en-us")
-        self.assertFalse(messages[8].data["expect_response"])
-        self.assertEqual(messages[8].data["meta"]["dialog"], "hello.world")
-        self.assertEqual(messages[8].data["meta"]["skill"], self.skill_id)
-        self.assertEqual(messages[9].msg_type, "mycroft.skill.handler.complete")
-        self.assertEqual(messages[9].data["name"], "HelloWorldSkill.handle_hello_world_intent")
+        self.assertEqual(messages[4].msg_type, "mycroft.skill.handler.start")
+        self.assertEqual(messages[4].data["name"], "HelloWorldSkill.handle_hello_world_intent")
+        # verify skill is activated
+        self.assertEqual(messages[5].msg_type, "intent.service.skills.activate")
+        self.assertEqual(messages[5].data["skill_id"], self.skill_id)
+        self.assertEqual(messages[6].msg_type, "intent.service.skills.activated")
+        self.assertEqual(messages[6].data["skill_id"], self.skill_id)
+        self.assertEqual(messages[7].msg_type, f"{self.skill_id}.activate")
+
+        self.assertEqual(messages[8].msg_type, "enclosure.active_skill")
+        self.assertEqual(messages[8].data["skill_id"], self.skill_id)
+        self.assertEqual(messages[9].msg_type, "speak")
+        self.assertEqual(messages[9].data["lang"], "en-us")
+        self.assertFalse(messages[9].data["expect_response"])
+        self.assertEqual(messages[9].data["meta"]["dialog"], "hello.world")
+        self.assertEqual(messages[9].data["meta"]["skill"], self.skill_id)
+        self.assertEqual(messages[10].msg_type, "mycroft.skill.handler.complete")
+        self.assertEqual(messages[10].data["name"], "HelloWorldSkill.handle_hello_world_intent")
 
         # test that active skills list has been updated
-        sess = SessionManager.sessions[sess.session_id]
+        sess = Session.from_message(messages[-1])
         self.assertEqual(sess.active_skills[0][0], self.skill_id)
         self.assertNotEqual(sess.active_skills[0][1], now)
         # test that default session remains unchanged

--- a/test/end2end/session/test_stop.py
+++ b/test/end2end/session/test_stop.py
@@ -4,7 +4,6 @@ from unittest import TestCase
 
 from ovos_bus_client.message import Message
 from ovos_bus_client.session import SessionManager, Session
-
 from ..minicroft import get_minicroft
 
 
@@ -54,152 +53,146 @@ class TestSessions(TestCase):
                            "adapt_high",
                            "stop_medium"
                        ])
-
-        # old style global stop, even if nothing active
-        def skill_not_active():
-            nonlocal messages, sess
-            utt = Message("recognizer_loop:utterance",
-                          {"utterances": ["stop"]},
-                          {"session": sess.serialize()})
-            self.core.bus.emit(utt)
-
-            # confirm all expected messages are sent
-            expected_messages = [
-                "recognizer_loop:utterance",
-                # global stop trigger
-                "mycroft.stop",
-
-                # skill reporting
-                f"{self.skill_id}.stop",  # internal, @killable_events
-                f"{self.skill_id}.stop.response",  # skill reporting nothing to stop
-
-                # sanity check in test skill that method was indeed called
-                "enclosure.active_skill",
-                "speak",  # "utterance":"old stop called"
-
-                # NOTE: messages below might show up before enclosure.active_skill
-                f"{self.new_skill_id}.stop",  # internal, @killable_events
-                f"{self.new_skill_id}.stop.response",  # skill reporting nothing to stop
-
-            ]
-
-            wait_for_n_messages(len(expected_messages))
-
-            mtypes = [m.msg_type for m in messages]
-            for m in expected_messages:
-                self.assertTrue(m in mtypes)
-
-            # sanity check stop triggered
-            for m in messages:
-                if m.msg_type == "speak":
-                    self.assertEqual(m.data["utterance"], "old stop called")
-
-            messages = []
-
-        # get the skill in active list
-        def old_world():
-            nonlocal messages, sess
-            utt = Message("recognizer_loop:utterance",
-                          {"utterances": ["old world"]},
-                          {"session": sess.serialize()})
-            self.core.bus.emit(utt)
-
-            # confirm all expected messages are sent
-            expected_messages = [
-                "recognizer_loop:utterance",
-                # skill selected
-                "intent.service.skills.activated",
-                f"{self.skill_id}.activate",
-                f"{self.skill_id}:OldWorldIntent",
-                # skill executing
-                "mycroft.skill.handler.start",
-                "enclosure.active_skill",
-                "speak",
-                "mycroft.skill.handler.complete"
-            ]
-
-            wait_for_n_messages(len(expected_messages))
-
-            mtypes = [m.msg_type for m in messages]
-            for m in expected_messages:
-                self.assertTrue(m in mtypes)
-
-            # sanity check correct intent triggered
-            self.assertEqual(messages[6].data["utterance"], "hello world")
-
-            # test that active skills list has been updated
-            sess = Session.deserialize(messages[-1].context["session"])
-            self.assertEqual(sess.active_skills[0][0], self.skill_id)
-
-            messages = []
-
-        # stop should now go over active skills list
-        def skill_active():
-            nonlocal messages, sess
-            utt = Message("recognizer_loop:utterance",
-                          {"utterances": ["stop"]},
-                          {"session": sess.serialize()})
-            self.core.bus.emit(utt)
-
-            # confirm all expected messages are sent
-            expected_messages = [
-                "recognizer_loop:utterance",
-
-                # stop_high
-                f"{self.skill_id}.stop.ping",  # check if active skill wants to stop
-                "skill.stop.pong",  # "can_handle":true
-                f"{self.skill_id}.stop",  # skill specific stop trigger
-                f"{self.skill_id}.stop.response",  # skill fails to stop  (old style)
-
-                # stop medium
-                f"{self.skill_id}.stop.ping",
-                "skill.stop.pong",
-                f"{self.skill_id}.stop",  # skill specific stop trigger
-                f"{self.skill_id}.stop.response",  # skill fails to stop  (old style)
-
-                # stop fallback
-                "mycroft.stop",  # global stop for backwards compat
-                f"{self.skill_id}.stop",
-                f"{self.skill_id}.stop.response",  # apparently fails to stop  (old style)
-
-                # test in skill that global stop was called
-                "enclosure.active_skill",
-                "speak",  # "utterance":"stop"
-
-                # report old-style stop handled event
-                "mycroft.stop.handled",  # {"by":"skill:skill-old-stop.openvoiceos"}
-
-                # old style unwanted side effects (global stop is global)
-                f"{self.new_skill_id}.stop",
-                f"{self.new_skill_id}.stop.response",
-                "enclosure.active_skill",  # other test skill also speaks
-                "speak"  # "utterance":"old stop called"
-            ]
-
-            wait_for_n_messages(len(expected_messages))
-
-            mtypes = [m.msg_type for m in messages]
-            for m in expected_messages:
-                self.assertTrue(m in mtypes)
-
-            # confirm all skills self.stop methods called
-            for m in messages:
-                # sanity check stop triggered
-                if m.msg_type == "speak":
-                    self.assertIn(m.data["utterance"],
-                                  ["old stop called", "stop"])
-                # confirm "skill-old-stop" was the one that reported success
-                if m.msg_type == "mycroft.stop.handled":
-                    self.assertEqual(m.data["by"], f"skill:{self.skill_id}")
-
-            messages = []
-
+        ########################################
+        # STEP 1
         # nothing to stop
-        skill_not_active()
+        # old style global stop, even if nothing active
+        utt = Message("recognizer_loop:utterance",
+                      {"utterances": ["stop"]},
+                      {"session": sess.serialize()})
+        self.core.bus.emit(utt)
 
+        # confirm all expected messages are sent
+        expected_messages = [
+            "recognizer_loop:utterance",
+            # global stop trigger
+            "mycroft.stop",
+
+            # skill reporting
+            f"{self.skill_id}.stop",  # internal, @killable_events
+            f"{self.skill_id}.stop.response",  # skill reporting nothing to stop
+
+            # sanity check in test skill that method was indeed called
+            "enclosure.active_skill",
+            "speak",  # "utterance":"old stop called"
+
+            # NOTE: messages below might show up before enclosure.active_skill
+            f"{self.new_skill_id}.stop",  # internal, @killable_events
+            f"{self.new_skill_id}.stop.response",  # skill reporting nothing to stop
+
+        ]
+
+        wait_for_n_messages(len(expected_messages))
+
+        mtypes = [m.msg_type for m in messages]
+        for m in expected_messages:
+            self.assertTrue(m in mtypes)
+
+        # sanity check stop triggered
+        for m in messages:
+            if m.msg_type == "speak":
+                self.assertEqual(m.data["utterance"], "old stop called")
+
+        messages = []
+
+        ########################################
+        # STEP 2
         # get the skill in active list
-        old_world()
-        skill_active()
+        utt = Message("recognizer_loop:utterance",
+                      {"utterances": ["old world"]},
+                      {"session": sess.serialize()})
+        self.core.bus.emit(utt)
+
+        # confirm all expected messages are sent
+        expected_messages = [
+            "recognizer_loop:utterance",
+            # skill selected
+            f"{self.skill_id}:OldWorldIntent",
+            "mycroft.skill.handler.start",
+            "intent.service.skills.activate",
+            "intent.service.skills.activated",
+            f"{self.skill_id}.activate",
+            # skill code executing
+            "enclosure.active_skill",
+            "speak",
+            "mycroft.skill.handler.complete"
+        ]
+
+        wait_for_n_messages(len(expected_messages))
+
+        mtypes = [m.msg_type for m in messages]
+        for m in expected_messages:
+            self.assertTrue(m in mtypes)
+
+        # sanity check correct intent triggered
+        self.assertEqual(messages[7].data["utterance"], "hello world")
+
+        # test that active skills list has been updated
+        sess = Session.deserialize(messages[-1].context["session"])
+        self.assertEqual(sess.active_skills[0][0], self.skill_id)
+
+        messages = []
+
+        ########################################
+        # STEP 3
+        # stop should now go over active skills list
+        utt = Message("recognizer_loop:utterance",
+                      {"utterances": ["stop"]},
+                      {"session": sess.serialize()})
+        self.core.bus.emit(utt)
+
+        # confirm all expected messages are sent
+        expected_messages = [
+            "recognizer_loop:utterance",
+
+            # stop_high
+            f"{self.skill_id}.stop.ping",  # check if active skill wants to stop
+            "skill.stop.pong",  # "can_handle":true
+            f"{self.skill_id}.stop",  # skill specific stop trigger
+            f"{self.skill_id}.stop.response",  # skill fails to stop  (old style)
+
+            # stop medium
+            f"{self.skill_id}.stop.ping",
+            "skill.stop.pong",
+            f"{self.skill_id}.stop",  # skill specific stop trigger
+            f"{self.skill_id}.stop.response",  # skill fails to stop  (old style)
+
+            # stop fallback
+            "mycroft.stop",  # global stop for backwards compat
+            f"{self.skill_id}.stop",
+            f"{self.skill_id}.stop.response",  # apparently fails to stop  (old style)
+
+            # test in skill that global stop was called
+            "enclosure.active_skill",
+            "speak",  # "utterance":"stop"
+
+            # report old-style stop handled event
+            "mycroft.stop.handled",  # {"by":"skill:skill-old-stop.openvoiceos"}
+
+            # old style unwanted side effects (global stop is global)
+            f"{self.new_skill_id}.stop",
+            f"{self.new_skill_id}.stop.response",
+            "enclosure.active_skill",  # other test skill also speaks
+            "speak"  # "utterance":"old stop called"
+        ]
+
+        wait_for_n_messages(len(expected_messages))
+
+        mtypes = [m.msg_type for m in messages]
+        for m in expected_messages:
+            self.assertTrue(m in mtypes)
+
+        # confirm all skills self.stop methods called
+        for m in messages:
+            # sanity check stop triggered
+            if m.msg_type == "speak":
+                self.assertIn(m.data["utterance"],
+                              ["old stop called", "stop"])
+            # confirm "skill-old-stop" was the one that reported success
+            if m.msg_type == "mycroft.stop.handled":
+                self.assertEqual(m.data["by"], f"skill:{self.skill_id}")
+
+        messages = []
 
     def test_new_stop(self):
         SessionManager.sessions = {}
@@ -238,185 +231,180 @@ class TestSessions(TestCase):
                            "stop_medium"
                        ])
 
+        ########################################
+        # STEP 1
+        # no skills active yet, nothing to stop
         # old style global stop, even if nothing active
-        def skill_not_active():
-            nonlocal messages, sess
-            utt = Message("recognizer_loop:utterance",
-                          {"utterances": ["stop"]},
-                          {"session": sess.serialize()})
-            self.core.bus.emit(utt)
+        utt = Message("recognizer_loop:utterance",
+                      {"utterances": ["stop"]},
+                      {"session": sess.serialize()})
+        self.core.bus.emit(utt)
 
-            # confirm all expected messages are sent
-            expected_messages = [
-                "recognizer_loop:utterance",
-                # global stop trigger
-                "mycroft.stop",
-                f"{self.skill_id}.stop",  # internal, @killable_events
-                f"{self.skill_id}.stop.response",  # skill reporting nothing to stop
-                f"{self.new_skill_id}.stop",  # internal, @killable_events
-                f"{self.new_skill_id}.stop.response",  # skill reporting nothing to stop
+        # confirm all expected messages are sent
+        expected_messages = [
+            "recognizer_loop:utterance",
+            # global stop trigger
+            "mycroft.stop",
+            f"{self.skill_id}.stop",  # internal, @killable_events
+            f"{self.skill_id}.stop.response",  # skill reporting nothing to stop
+            f"{self.new_skill_id}.stop",  # internal, @killable_events
+            f"{self.new_skill_id}.stop.response",  # skill reporting nothing to stop
 
-                # sanity check in test skill that method was indeed called
-                "enclosure.active_skill",
-                "speak"  # "utterance":"old stop called"
+            # sanity check in test skill that method was indeed called
+            "enclosure.active_skill",
+            "speak"  # "utterance":"old stop called"
 
-            ]
+        ]
 
-            wait_for_n_messages(len(expected_messages))
+        wait_for_n_messages(len(expected_messages))
 
-            mtypes = [m.msg_type for m in messages]
-            for m in expected_messages:
-                self.assertTrue(m in mtypes)
+        mtypes = [m.msg_type for m in messages]
+        for m in expected_messages:
+            self.assertTrue(m in mtypes)
 
-            for m in messages:
-                # sanity check stop triggered
-                if m.msg_type == "speak":
-                    self.assertEqual(m.data["utterance"], "old stop called")
+        for m in messages:
+            # sanity check stop triggered
+            if m.msg_type == "speak":
+                self.assertEqual(m.data["utterance"], "old stop called")
 
-            messages = []
+        messages = []
 
-        # get the skill in active list
-        def new_world():
-            nonlocal messages, sess
-            utt = Message("recognizer_loop:utterance",
-                          {"utterances": ["new world"]},
-                          {"session": sess.serialize()})
-            self.core.bus.emit(utt)
+        ########################################
+        # STEP 2
+        # get a skill in active list
+        utt = Message("recognizer_loop:utterance",
+                      {"utterances": ["new world"]},
+                      {"session": sess.serialize()})
+        self.core.bus.emit(utt)
 
-            # confirm all expected messages are sent
-            expected_messages = [
-                "recognizer_loop:utterance",
-                # skill selected
-                "intent.service.skills.activated",
-                f"{self.new_skill_id}.activate",
-                f"{self.new_skill_id}:NewWorldIntent",
-                # skill executing
-                "mycroft.skill.handler.start",
-                "enclosure.active_skill",
-                "speak",
-                "mycroft.skill.handler.complete"
-            ]
+        # confirm all expected messages are sent
+        expected_messages = [
+            "recognizer_loop:utterance",
+            # skill selected
+            f"{self.new_skill_id}:NewWorldIntent",
+            "mycroft.skill.handler.start",
+            "intent.service.skills.activate",
+            "intent.service.skills.activated",
+            f"{self.new_skill_id}.activate",
+            # skill code executing
+            "enclosure.active_skill",
+            "speak",
+            "mycroft.skill.handler.complete"
+        ]
 
-            wait_for_n_messages(len(expected_messages))
+        wait_for_n_messages(len(expected_messages))
 
-            mtypes = [m.msg_type for m in messages]
-            for m in expected_messages:
-                self.assertTrue(m in mtypes)
+        mtypes = [m.msg_type for m in messages]
+        for m in expected_messages:
+            self.assertTrue(m in mtypes)
 
-            # sanity check correct intent triggered
+        # sanity check correct intent triggered
 
-            for m in messages:
-                # sanity check stop triggered
-                if m.msg_type == "speak":
-                    self.assertEqual(m.data["utterance"], "hello world")
+        for m in messages:
+            # sanity check stop triggered
+            if m.msg_type == "speak":
+                self.assertEqual(m.data["utterance"], "hello world")
 
-            # test that active skills list has been updated
-            sess = Session.deserialize(messages[-1].context["session"])
-            self.assertEqual(sess.active_skills[0][0], self.new_skill_id)
+        # test that active skills list has been updated
+        sess = Session.deserialize(messages[-1].context["session"])
+        self.assertEqual(sess.active_skills[0][0], self.new_skill_id)
 
-            messages = []
+        messages = []
 
+        ########################################
+        # STEP 3
+        # we got active skills
         # stop should now go over active skills list
-        def skill_active():
-            nonlocal messages, sess
-            utt = Message("recognizer_loop:utterance",
-                          {"utterances": ["stop"]},
-                          {"session": sess.serialize()})
-            self.core.bus.emit(utt)
+        # reports success
+        utt = Message("recognizer_loop:utterance",
+                      {"utterances": ["stop"]},
+                      {"session": sess.serialize()})
+        self.core.bus.emit(utt)
 
-            # confirm all expected messages are sent
-            expected_messages = [
-                "recognizer_loop:utterance",
+        # confirm all expected messages are sent
+        expected_messages = [
+            "recognizer_loop:utterance",
 
-                # stop_high
-                f"{self.new_skill_id}.stop.ping",  # check if active skill wants to stop
-                "skill.stop.pong",  # "can_handle":true
-                f"{self.new_skill_id}.stop",  # skill specific stop trigger
+            # stop_high
+            f"{self.new_skill_id}.stop.ping",  # check if active skill wants to stop
+            "skill.stop.pong",  # "can_handle":true
+            f"{self.new_skill_id}.stop",  # skill specific stop trigger
 
-                # test session specific stop was called
-                "enclosure.active_skill",
-                "speak",  # "utterance":"stop 123"
+            # test session specific stop was called
+            "enclosure.active_skill",
+            "speak",  # "utterance":"stop 123"
 
-                f"{self.new_skill_id}.stop.response",  # skill reports it stopped (new style)
-                "intent.service.skills.activated",  # pipeline match reports skill_id
-                f"{self.new_skill_id}.activate",  # can now converse
-            ]
+            f"{self.new_skill_id}.stop.response",  # skill reports it stopped (new style)
+        ]
 
-            wait_for_n_messages(len(expected_messages))
+        wait_for_n_messages(len(expected_messages))
 
-            mtypes = [m.msg_type for m in messages]
-            for m in expected_messages:
-                self.assertTrue(m in mtypes)
+        mtypes = [m.msg_type for m in messages]
+        for m in expected_messages:
+            self.assertTrue(m in mtypes)
 
-            # confirm skill self.stop methods called
+        # confirm skill self.stop methods called
 
-            for m in messages:
-                # sanity check stop triggered
-                if m.msg_type == "speak":
-                    self.assertEqual(m.data["utterance"], "stop 123")
+        for m in messages:
+            # sanity check stop triggered
+            if m.msg_type == "speak":
+                self.assertEqual(m.data["utterance"], "stop 123")
 
-            # confirm "skill-new-stop" was the one that reported success
-            handler = messages[-3]
-            self.assertEqual(handler.msg_type, f"{self.new_skill_id}.stop.response")
-            self.assertEqual(handler.data["result"], True)
+        # confirm "skill-new-stop" was the one that reported success
+        handler = messages[-1]
+        self.assertEqual(handler.msg_type, f"{self.new_skill_id}.stop.response")
+        self.assertEqual(handler.data["result"], True)
 
-            messages = []
+        messages = []
 
-        def skill_already_stop():
-            nonlocal messages, sess
-            utt = Message("recognizer_loop:utterance",
-                          {"utterances": ["stop"]},
-                          {"session": sess.serialize()})
-            self.core.bus.emit(utt)
+        ########################################
+        # STEP 4
+        # skill already stopped
+        # reports failure
+        utt = Message("recognizer_loop:utterance",
+                      {"utterances": ["stop"]},
+                      {"session": sess.serialize()})
+        self.core.bus.emit(utt)
 
-            # confirm all expected messages are sent
-            expected_messages = [
-                "recognizer_loop:utterance",
+        # confirm all expected messages are sent
+        expected_messages = [
+            "recognizer_loop:utterance",
 
-                # stop_high
-                f"{self.new_skill_id}.stop.ping",  # check if active skill wants to stop
-                "skill.stop.pong",  # "can_handle":true
-                f"{self.new_skill_id}.stop",  # skill specific stop trigger
-                f"{self.new_skill_id}.stop.response",  # dont want to stop (new style)
+            # stop_high
+            f"{self.new_skill_id}.stop.ping",  # check if active skill wants to stop
+            "skill.stop.pong",  # "can_handle":true
+            f"{self.new_skill_id}.stop",  # skill specific stop trigger
+            f"{self.new_skill_id}.stop.response",  # dont want to stop (new style)
 
-                # rest of pipeline
-                # stop low
-                f"{self.new_skill_id}.stop.ping",
-                "skill.stop.pong",
-                f"{self.new_skill_id}.stop",  # skill specific stop trigger
-                f"{self.new_skill_id}.stop.response",  # dont want to stop (new style)
+            # rest of pipeline
+            # stop low
+            f"{self.new_skill_id}.stop.ping",
+            "skill.stop.pong",
+            f"{self.new_skill_id}.stop",  # skill specific stop trigger
+            f"{self.new_skill_id}.stop.response",  # dont want to stop (new style)
 
-                # global stop fallback
-                "mycroft.stop",
-                f"{self.skill_id}.stop",  # skill specific stop trigger
-                f"{self.skill_id}.stop.response",  # old style, never stops
-                f"{self.new_skill_id}.stop",  # skill specific stop trigger
-                f"{self.skill_id}.stop.response",  # dont want to stop (new style)
+            # global stop fallback
+            "mycroft.stop",
+            f"{self.skill_id}.stop",  # skill specific stop trigger
+            f"{self.skill_id}.stop.response",  # old style, never stops
+            f"{self.new_skill_id}.stop",  # skill specific stop trigger
+            f"{self.skill_id}.stop.response",  # dont want to stop (new style)
 
-                # check the global stop handlers are called
-                "enclosure.active_skill",
-                "speak",  # "utterance":"old stop called"
-            ]
+            # check the global stop handlers are called
+            "enclosure.active_skill",
+            "speak",  # "utterance":"old stop called"
+        ]
 
-            wait_for_n_messages(len(expected_messages))
+        wait_for_n_messages(len(expected_messages))
 
-            mtypes = [m.msg_type for m in messages]
-            for m in expected_messages:
-                self.assertTrue(m in mtypes)
+        mtypes = [m.msg_type for m in messages]
+        for m in expected_messages:
+            self.assertTrue(m in mtypes)
 
-            # confirm self.stop method called
-            for m in messages:
-                # sanity check stop triggered
-                if m.msg_type == "speak":
-                    self.assertEqual(m.data["utterance"], "old stop called")
+        # confirm self.stop method called
+        for m in messages:
+            # sanity check stop triggered
+            if m.msg_type == "speak":
+                self.assertEqual(m.data["utterance"], "old stop called")
 
-            messages = []
-
-        # nothing to stop
-        skill_not_active()
-
-        # get the skill in active list
-        new_world()
-        skill_active()  # reports success
-
-        skill_already_stop()  # reports failure
+        messages = []

--- a/test/end2end/skill-converse_test/__init__.py
+++ b/test/end2end/skill-converse_test/__init__.py
@@ -15,15 +15,25 @@ class TestAbortSkill(OVOSSkill):
     def initialize(self):
         self.stop_called = False
         self._converse = False
+        self._converse_deactivate = False
         self.items = []
         self.bus.on("test_activate", self.do_activate)
         self.bus.on("test_deactivate", self.do_deactivate)
+        self.bus.on("converse_deactivate", self.do_deactivate_converse)
+
+    def do_deactivate_converse(self, message):
+        self._converse_deactivate = True
 
     def do_activate(self, message):
         self.activate()
 
     def do_deactivate(self, message):
         self.deactivate()
+
+    @intent_handler("deactivate.intent")
+    def handle_deactivated(self, message):
+        self.deactivate()
+        self.speak("deactivated")
 
     @intent_handler("converse_on.intent")
     def handle_converse_on(self, message):
@@ -94,4 +104,8 @@ class TestAbortSkill(OVOSSkill):
         self.stop_called = True
 
     def converse(self, message):
+        if self._converse_deactivate:
+            self.deactivate()
+            self._converse_deactivate = False
+            return True
         return self._converse

--- a/test/end2end/skill-converse_test/locale/en-us/deactivate.intent
+++ b/test/end2end/skill-converse_test/locale/en-us/deactivate.intent
@@ -1,0 +1,1 @@
+deactivate skill

--- a/test/unittests/common_query/test_common_query.py
+++ b/test/unittests/common_query/test_common_query.py
@@ -133,6 +133,10 @@ class TestCommonQuery(unittest.TestCase):
                       'callback_data': {'query': 'what is the speed of light',
                                         'answer': 'answer 1'}},
              'context': qq_ans_ctxt},  # destination: audio from this message forward
+            # skill was select, make it an active skill
+            {'context': qq_ans_ctxt,
+             'data': {'skill_id': 'wiki.test', 'timeout': 5.0},
+             'type': 'intent.service.skills.activate'},
             # tell enclosure about active skill (speak method). This is the
             # skill that provided the response and may follow-up with actions
             # in a callback method


### PR DESCRIPTION
closes https://github.com/OpenVoiceOS/ovos-core/issues/450

needs https://github.com/OpenVoiceOS/OVOS-workshop/pull/198


CAVEATS:
- `self.deactivate()` can now be called inside intent handlers
- `self.deactivate()` can now be called inside converse handlers, but ONLY if they **return False**
- `self.deactivate()` can now be called inside fallback handlers, but ONLY if they **return False**


if converse/fallback returns True (to consume the utterance) the skill is reactivated right after the handler

if you need to deactivate a skill and also consume the utterance, then you need to use the callback instead

```python

class MySkill(OVOSSkill):
    def converse(self, message):  # or fallback skill handler
        self.do_deactivation = True
        return True

    def handle_activate(self, message: Message):
		"""called after converse return True (but not False)"""
        if self.do_deactivation:
			self.deactivate()
       	self.do_deactivation = False
```


solving this limitation will require deeper changes in ovos-workshop and is not a trivial fix, a test case is included with a TODO

```python
expected_messages = [
    "recognizer_loop:utterance", # converse gets it
    f"{self.skill_id}.converse.ping",
    "skill.converse.pong",
    f"{self.skill_id}.converse.request",
    # converse code
    "intent.service.skills.deactivate",
    "intent.service.skills.deactivated",
    f"{self.skill_id}.deactivate",
    "ovos.session.update_default",
    ###########
    # TODO - activate is called here if converse return True
    "intent.service.skills.activate",
    "intent.service.skills.activated",
    f"{self.skill_id}.activate",
    "ovos.session.update_default",
    # /TODO - ovos-workshop PR needed
    ###########
    "skill.converse.response",  # conversed!
    # session updated
    "ovos.session.update_default"
]
```
