### PR TITLE
fix/several_OCP_issues

### DIFF
--- a/ovos_core/intent_services/ocp_service.py
+++ b/ovos_core/intent_services/ocp_service.py
@@ -5,15 +5,15 @@ from os.path import join, dirname
 from threading import RLock
 from typing import List, Tuple, Optional, Union
 
-from ovos_bus_client.apis.ocp import OCPInterface, OCPQuery, ClassicAudioServiceInterface
-from ovos_bus_client.message import Message
-from ovos_bus_client.util import wait_for_reply
 from ovos_classifiers.skovos.classifier import SklearnOVOSClassifier
 from ovos_classifiers.skovos.features import ClassifierProbaVectorizer, KeywordFeaturesVectorizer
 from padacioso import IntentContainer
 from sklearn.pipeline import FeatureUnion
 
 import ovos_core.intent_services
+from ovos_bus_client.apis.ocp import OCPInterface, OCPQuery, ClassicAudioServiceInterface
+from ovos_bus_client.message import Message
+from ovos_bus_client.util import wait_for_reply
 from ovos_config import Configuration
 from ovos_plugin_manager.ocp import load_stream_extractors, available_extractors
 from ovos_utils import classproperty
@@ -312,9 +312,10 @@ class OCPPipelineMatcher(OVOSAbstractApplication):
                              f"{message}")
         if isinstance(state, int):
             state = TrackState(state)
-        if state in [TrackState.PLAYING_AUDIO, TrackState.PLAYING_AUDIOSERVICE,
-                     TrackState.PLAYING_VIDEO, TrackState.PLAYING_WEBVIEW,
-                     TrackState.PLAYING_MPRIS]:
+        if self.player_state != PlayerState.PLAYING and \
+                state in [TrackState.PLAYING_AUDIO, TrackState.PLAYING_AUDIOSERVICE,
+                          TrackState.PLAYING_VIDEO, TrackState.PLAYING_WEBVIEW,
+                          TrackState.PLAYING_MPRIS]:
             self.player_state = PlayerState.PLAYING
             LOG.info(f"OCP PlayerState: {self.player_state}")
 

--- a/ovos_core/intent_services/ocp_service.py
+++ b/ovos_core/intent_services/ocp_service.py
@@ -584,6 +584,9 @@ class OCPPipelineMatcher(OVOSAbstractApplication):
         else:
             LOG.info("Requesting OCP to stop")
             self.ocp_api.stop()
+            # old ocp doesnt report stopped state ...
+            # TODO - remove this once proper events are emitted
+            self.player_state = PlayerState.STOPPED
 
     def handle_next_intent(self, message: Message):
         if self.use_legacy_audio:

--- a/ovos_core/intent_services/ocp_service.py
+++ b/ovos_core/intent_services/ocp_service.py
@@ -20,8 +20,13 @@ from ovos_utils import classproperty
 from ovos_utils.log import LOG
 from ovos_utils.messagebus import FakeBus
 from ovos_utils.ocp import (MediaType, PlaybackType, PlaybackMode, PlayerState, OCP_ID,
-                            MediaEntry, Playlist, MediaState, PluginStream, TrackState, dict2entry)
+                            MediaEntry, Playlist, MediaState, TrackState)
 from ovos_workshop.app import OVOSAbstractApplication
+
+try:
+    from ovos_utils.ocp import dict2entry
+except ImportError:  # older ovos-utils
+    dict2entry = MediaEntry.from_dict
 
 
 class OCPFeaturizer:
@@ -784,9 +789,7 @@ class OCPPipelineMatcher(OVOSAbstractApplication):
         if self.config.get("filter_SEI", True):
             # TODO - also check inside playlists
             bad_seis = [r for r in results if isinstance(r, MediaEntry) and
-                        not any(r.uri.startswith(sei) for sei in valid_starts)] + \
-                       [r for r in results if isinstance(r, PluginStream) and
-                        r.extractor_id not in self.available_SEI]
+                        not any(r.uri.startswith(sei) for sei in valid_starts)]
 
             results = [r for r in results if r not in bad_seis]
             plugs = set([s.uri.split('//')[0] for s in bad_seis if '//' in s.uri])


### PR DESCRIPTION
- prepares for handling of the new stream extractors mechanism ([dropping fake uris](https://github.com/OpenVoiceOS/ovos-ocp-audio-plugin/issues/114))
- fixes state sync of player, allowing stop to work with old OCP
- fix searching of specific skills, dont filter results in this case, if a skill is explicitly requested we dont want to drop low confidence matches

recommend also having https://github.com/OpenVoiceOS/ovos-utils/pull/246 + https://github.com/OpenVoiceOS/ovos-bus-client/pull/97 but will work without those