### PR TITLE
enable ocp with utils 0.0.38 compat

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -47,6 +47,10 @@ jobs:
         sudo apt install libfann-dev
         pip install .[lgpl]
         pytest --cov-append --cov=ovos_core --cov-report xml test/unittests/skills
+    - name: Generate coverage report with utils 0.0.38
+      run: |
+        pip install ovos-utils==0.0.38
+        pytest --cov-append --cov=ovos_core --cov-report xml test/end2end
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3
       with:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -83,6 +83,10 @@ jobs:
       - name: Run unittests with padatious
         run: |
           pytest --cov-append --cov=ovos_core --cov-report xml test/unittests/skills
+      - name: Run unittests with utils 0.0.38
+        run: |
+          pip install ovos-utils==0.0.38
+          pytest --cov-append --cov=ovos_core --cov-report xml test/end2end
       - name: Upload coverage
         if: "${{ matrix.python-version == '3.9' }}"
         env:

--- a/ovos_core/intent_services/ocp_service.py
+++ b/ovos_core/intent_services/ocp_service.py
@@ -387,16 +387,16 @@ except ImportError:
     class OCPInterface(_OIF):
 
         # needs utils 0.1.0 in ovos-bus-client
-        @staticmethod
-        def norm_tracks(tracks: list):
+        @classmethod
+        def norm_tracks(cls, tracks: list):
             """ensures a list of tracks contains only MediaEntry or Playlist items"""
             assert isinstance(tracks, list)
             # support Playlist and MediaEntry objects in tracks
             for idx, track in enumerate(tracks):
                 if isinstance(track, dict):
-                    tracks[idx] = dict2entry(track)
+                    tracks[idx] = MediaEntry.from_dict(track)
                 if isinstance(track, list) and not isinstance(track, Playlist):
-                    tracks[idx] = OCPInterface.norm_tracks(track)
+                    tracks[idx] = cls.norm_tracks(track)
                 elif not isinstance(track, MediaEntry):
                     # TODO - support string uris
                     # let it fail in next assert
@@ -418,6 +418,14 @@ except ImportError:
         ]
 
         # needs utils 0.1.0 in ovos-bus-client
+        def __init__(self, query, bus, media_type=MediaType.GENERIC, config=None):
+            LOG.debug(f"Created {media_type.name} query: {query}")
+            self.query = query
+            self.media_type = media_type
+            self.bus = bus
+            self.config = config or {}
+            self.reset()
+
         def wait(self):
             # if there is no match type defined, lets increase timeout a bit
             # since all skills need to search

--- a/ovos_core/intent_services/ocp_service.py
+++ b/ovos_core/intent_services/ocp_service.py
@@ -5,6 +5,7 @@ from os.path import join, dirname
 from threading import RLock
 from typing import List, Tuple, Optional, Union
 
+import orjson
 from ovos_classifiers.skovos.classifier import SklearnOVOSClassifier
 from ovos_classifiers.skovos.features import ClassifierProbaVectorizer, KeywordFeaturesVectorizer
 from padacioso import IntentContainer
@@ -19,9 +20,364 @@ from ovos_plugin_manager.ocp import load_stream_extractors, available_extractors
 from ovos_utils import classproperty
 from ovos_utils.log import LOG
 from ovos_utils.messagebus import FakeBus
-from ovos_utils.ocp import (MediaType, PlaybackType, PlaybackMode, PlayerState, OCP_ID,
-                            MediaEntry, Playlist, MediaState, TrackState)
 from ovos_workshop.app import OVOSAbstractApplication
+
+try:
+    from ovos_utils.ocp import (MediaType, PlaybackType, PlaybackMode, PlayerState, OCP_ID,
+                                MediaEntry, Playlist, MediaState, TrackState)
+except ImportError:
+    # already redefined in workshop for compat, no need to do it AGAIN
+    from ovos_workshop.decorators.ocp import (MediaType, PlaybackType, PlaybackMode, PlayerState,
+                                              MediaState, TrackState)
+    from dataclasses import dataclass
+    import inspect
+
+    OCP_ID = "ovos.common_play"
+
+
+    def find_mime(uri):
+        """ Determine mime type. """
+        import mimetypes
+        mime = mimetypes.guess_type(uri)
+        if mime:
+            return mime
+        else:
+            return None
+
+
+    @dataclass
+    class MediaEntry:
+        uri: str = ""
+        title: str = ""
+        artist: str = ""
+        match_confidence: int = 0  # 0 - 100
+        skill_id: str = OCP_ID
+        playback: PlaybackType = PlaybackType.UNDEFINED
+        status: TrackState = TrackState.DISAMBIGUATION
+        media_type: MediaType = MediaType.GENERIC
+        length: int = 0  # in seconds
+        image: str = ""
+        skill_icon: str = ""
+        javascript: str = ""  # to execute once webview is loaded
+
+        def update(self, entry: dict, skipkeys: list = None, newonly: bool = False):
+            """
+            Update this MediaEntry object with keys from the provided entry
+            @param entry: dict or MediaEntry object to update this object with
+            @param skipkeys: list of keys to not change
+            @param newonly: if True, only adds new keys; existing keys are unchanged
+            """
+            skipkeys = skipkeys or []
+            if isinstance(entry, MediaEntry):
+                entry = entry.as_dict
+            entry = entry or {}
+            for k, v in entry.items():
+                if k not in skipkeys and hasattr(self, k):
+                    if newonly and self.__getattribute__(k):
+                        # skip, do not replace existing values
+                        continue
+                    self.__setattr__(k, v)
+
+        @property
+        def infocard(self) -> dict:
+            """
+            Return dict data used for a UI display
+            """
+            return {
+                "duration": self.length,
+                "track": self.title,
+                "image": self.image,
+                "album": self.skill_id,
+                "source": self.skill_icon,
+                "uri": self.uri
+            }
+
+        @property
+        def mpris_metadata(self) -> dict:
+            """
+            Return dict data used by MPRIS
+            """
+            from dbus_next.service import Variant
+            meta = {"xesam:url": Variant('s', self.uri)}
+            if self.artist:
+                meta['xesam:artist'] = Variant('as', [self.artist])
+            if self.title:
+                meta['xesam:title'] = Variant('s', self.title)
+            if self.image:
+                meta['mpris:artUrl'] = Variant('s', self.image)
+            if self.length:
+                meta['mpris:length'] = Variant('d', self.length)
+            return meta
+
+        @property
+        def as_dict(self) -> dict:
+            """
+            Return a dict representation of this MediaEntry
+            """
+            # orjson handles dataclasses directly
+            return orjson.loads(orjson.dumps(self).decode("utf-8"))
+
+        @staticmethod
+        def from_dict(track: dict):
+            if track.get("playlist"):
+                kwargs = {k: v for k, v in track.items()
+                          if k in inspect.signature(Playlist).parameters}
+                playlist = Playlist(**kwargs)
+                for e in track["playlist"]:
+                    playlist.add_entry(e)
+                return playlist
+            else:
+                kwargs = {k: v for k, v in track.items()
+                          if k in inspect.signature(MediaEntry).parameters}
+                return MediaEntry(**kwargs)
+
+        @property
+        def mimetype(self) -> Optional[Tuple[Optional[str], Optional[str]]]:
+            """
+            Get the detected mimetype tuple (type, encoding) if it can be determined
+            """
+            if self.uri:
+                return find_mime(self.uri)
+
+        def __eq__(self, other):
+            if isinstance(other, MediaEntry):
+                other = other.infocard
+            # dict comparison
+            return other == self.infocard
+
+
+    @dataclass
+    class Playlist(list):
+        title: str = ""
+        position: int = 0
+        length: int = 0  # in seconds
+        image: str = ""
+        match_confidence: int = 0  # 0 - 100
+        skill_id: str = OCP_ID
+        skill_icon: str = ""
+
+        def __init__(self, *args, **kwargs):
+            super().__init__(**kwargs)
+            list.__init__(self, *args)
+
+        @property
+        def infocard(self) -> dict:
+            """
+            Return dict data used for a UI display
+            (model shared with MediaEntry)
+            """
+            return {
+                "duration": self.length,
+                "track": self.title,
+                "image": self.image,
+                "album": self.skill_id,
+                "source": self.skill_icon,
+                "uri": ""
+            }
+
+        @staticmethod
+        def from_dict(track: dict):
+            return MediaEntry.from_dict(track)
+
+        @property
+        def as_dict(self) -> dict:
+            """
+            Return a dict representation of this MediaEntry
+            """
+            data = {
+                "title": self.title,
+                "position": self.position,
+                "length": self.length,
+                "image": self.image,
+                "match_confidence": self.match_confidence,
+                "skill_id": self.skill_id,
+                "skill_icon": self.skill_icon,
+                "playlist": [e.as_dict for e in self.entries]
+            }
+            return data
+
+        @property
+        def entries(self) -> List[MediaEntry]:
+            """
+            Return a list of MediaEntry objects in the playlist
+            """
+            entries = []
+            for e in self:
+                if isinstance(e, dict):
+                    e = MediaEntry.from_dict(e)
+                if isinstance(e, MediaEntry):
+                    entries.append(e)
+            return entries
+
+        @property
+        def current_track(self) -> Optional[MediaEntry]:
+            """
+            Return the current MediaEntry or None if the playlist is empty
+            """
+            if len(self) == 0:
+                return None
+            self._validate_position()
+            track = self[self.position]
+            if isinstance(track, dict):
+                track = MediaEntry.from_dict(track)
+            return track
+
+        @property
+        def is_first_track(self) -> bool:
+            """
+            Return `True` if the current position is the first track or if the
+            playlist is empty
+            """
+            if len(self) == 0:
+                return True
+            return self.position == 0
+
+        @property
+        def is_last_track(self) -> bool:
+            """
+            Return `True` if the current position is the last track of if the
+            playlist is empty
+            """
+            if len(self) == 0:
+                return True
+            return self.position == len(self) - 1
+
+        def goto_start(self) -> None:
+            """
+            Move to the first entry in the playlist
+            """
+            self.position = 0
+
+        def clear(self) -> None:
+            """
+            Remove all entries from the Playlist and reset the position
+            """
+            super().clear()
+            self.position = 0
+
+        def sort_by_conf(self):
+            """
+            Sort the Playlist by `match_confidence` with high confidence first
+            """
+            self.sort(
+                key=lambda k: k.match_confidence if isinstance(k, (MediaEntry, Playlist))
+                else k.get("match_confidence", 0), reverse=True)
+
+        def add_entry(self, entry: MediaEntry, index: int = -1) -> None:
+            """
+            Add an entry at the requested index
+            @param entry: MediaEntry to add to playlist
+            @param index: index to insert entry at (default -1 to append)
+            """
+            assert isinstance(index, int)
+            if index > len(self):
+                raise ValueError(f"Invalid index {index} requested, "
+                                 f"playlist only has {len(self)} entries")
+
+            if isinstance(entry, dict):
+                entry = MediaEntry.from_dict(entry)
+
+            assert isinstance(entry, (MediaEntry, Playlist))
+
+            if index == -1:
+                index = len(self)
+
+            if index < self.position:
+                self.set_position(self.position + 1)
+
+            self.insert(index, entry)
+
+        def remove_entry(self, entry: Union[int, dict, MediaEntry]) -> None:
+            """
+            Remove the requested entry from the playlist or raise a ValueError
+            @param entry: index or MediaEntry to remove from the playlist
+            """
+            if isinstance(entry, int):
+                self.pop(entry)
+                return
+            if isinstance(entry, dict):
+                entry = MediaEntry.from_dict(entry)
+            assert isinstance(entry, MediaEntry)
+            for idx, e in enumerate(self.entries):
+                if e == entry:
+                    self.pop(idx)
+                    break
+            else:
+                raise ValueError(f"entry not in playlist: {entry}")
+
+        def replace(self, new_list: List[Union[dict, MediaEntry]]) -> None:
+            """
+            Replace the contents of this Playlist with new_list
+            @param new_list: list of MediaEntry or dict objects to set this list to
+            """
+            self.clear()
+            for e in new_list:
+                self.add_entry(e)
+
+        def set_position(self, idx: int):
+            """
+            Set the position in the playlist to a specific index
+            @param idx: Index to set position to
+            """
+            self.position = idx
+            self._validate_position()
+
+        def goto_track(self, track: Union[MediaEntry, dict]) -> None:
+            """
+            Go to the requested track in the playlist
+            @param track: MediaEntry to find and go to in the playlist
+            """
+            if isinstance(track, dict):
+                track = MediaEntry.from_dict(track)
+
+            assert isinstance(track, (MediaEntry, Playlist))
+
+            if isinstance(track, MediaEntry):
+                requested_uri = track.uri
+            else:
+                requested_uri = track.title
+
+            for idx, t in enumerate(self):
+                if isinstance(t, MediaEntry):
+                    pl_entry_uri = t.uri
+                else:
+                    pl_entry_uri = t.title
+
+                if requested_uri == pl_entry_uri:
+                    self.set_position(idx)
+                    LOG.debug(f"New playlist position: {self.position}")
+                    return
+            LOG.error(f"requested track not in the playlist: {track}")
+
+        def next_track(self) -> None:
+            """
+            Go to the next track in the playlist
+            """
+            self.set_position(self.position + 1)
+
+        def prev_track(self) -> None:
+            """
+            Go to the previous track in the playlist
+            """
+            self.set_position(self.position - 1)
+
+        def _validate_position(self) -> None:
+            """
+            Make sure the current position is valid; default `position` to 0
+            """
+            if self.position < 0 or self.position >= len(self):
+                LOG.error(f"Playlist pointer is in an invalid position "
+                          f"({self.position}! Going to start of playlist")
+                self.position = 0
+
+        def __contains__(self, item):
+            if isinstance(item, dict):
+                item = MediaEntry.from_dict(item)
+            if isinstance(item, MediaEntry):
+                for e in self.entries:
+                    if e.uri == item.uri:
+                        return True
+            return False
 
 try:
     from ovos_utils.ocp import dict2entry

--- a/ovos_core/intent_services/ocp_service.py
+++ b/ovos_core/intent_services/ocp_service.py
@@ -1,7 +1,10 @@
+import inspect
 import os
 import random
 import time
+from dataclasses import dataclass
 from os.path import join, dirname
+from threading import Lock
 from threading import RLock
 from typing import List, Tuple, Optional, Union
 
@@ -12,12 +15,13 @@ from padacioso import IntentContainer
 from sklearn.pipeline import FeatureUnion
 
 import ovos_core.intent_services
-from ovos_bus_client.apis.ocp import OCPInterface, OCPQuery, ClassicAudioServiceInterface
+from ovos_bus_client.apis.ocp import ClassicAudioServiceInterface
 from ovos_bus_client.message import Message
 from ovos_bus_client.util import wait_for_reply
 from ovos_config import Configuration
 from ovos_plugin_manager.ocp import load_stream_extractors, available_extractors
 from ovos_utils import classproperty
+from ovos_utils.gui import is_gui_connected, is_gui_running
 from ovos_utils.log import LOG
 from ovos_utils.messagebus import FakeBus
 from ovos_workshop.app import OVOSAbstractApplication
@@ -25,12 +29,12 @@ from ovos_workshop.app import OVOSAbstractApplication
 try:
     from ovos_utils.ocp import (MediaType, PlaybackType, PlaybackMode, PlayerState, OCP_ID,
                                 MediaEntry, Playlist, MediaState, TrackState)
+    from ovos_bus_client.apis.ocp import OCPInterface, OCPQuery
 except ImportError:
     # already redefined in workshop for compat, no need to do it AGAIN
     from ovos_workshop.decorators.ocp import (MediaType, PlaybackType, PlaybackMode, PlayerState,
                                               MediaState, TrackState)
-    from dataclasses import dataclass
-    import inspect
+    from ovos_bus_client.apis.ocp import OCPInterface as _OIF, OCPQuery as _OQ
 
     OCP_ID = "ovos.common_play"
 
@@ -378,6 +382,65 @@ except ImportError:
                     if e.uri == item.uri:
                         return True
             return False
+
+
+    class OCPInterface(_OIF):
+
+        # needs utils 0.1.0 in ovos-bus-client
+        @staticmethod
+        def norm_tracks(tracks: list):
+            """ensures a list of tracks contains only MediaEntry or Playlist items"""
+            assert isinstance(tracks, list)
+            # support Playlist and MediaEntry objects in tracks
+            for idx, track in enumerate(tracks):
+                if isinstance(track, dict):
+                    tracks[idx] = dict2entry(track)
+                if isinstance(track, list) and not isinstance(track, Playlist):
+                    tracks[idx] = OCPInterface.norm_tracks(track)
+                elif not isinstance(track, MediaEntry):
+                    # TODO - support string uris
+                    # let it fail in next assert
+                    # log all bad entries before failing
+                    LOG.error(f"Bad track, invalid type: {track}")
+            assert all(isinstance(t, (MediaEntry, Playlist)) for t in tracks)
+            return tracks
+
+
+    class OCPQuery(_OQ):
+        cast2audio = [
+            MediaType.MUSIC,
+            MediaType.PODCAST,
+            MediaType.AUDIOBOOK,
+            MediaType.RADIO,
+            MediaType.RADIO_THEATRE,
+            MediaType.VISUAL_STORY,
+            MediaType.NEWS
+        ]
+
+        # needs utils 0.1.0 in ovos-bus-client
+        def wait(self):
+            # if there is no match type defined, lets increase timeout a bit
+            # since all skills need to search
+            if self.media_type == MediaType.GENERIC:
+                timeout = self.config.get("max_timeout", 15) + 3  # timeout bonus
+            else:
+                timeout = self.config.get("max_timeout", 15)
+            while self.searching and time.time() - self.search_start <= timeout:
+                time.sleep(0.1)
+            self.searching = False
+            self.remove_events()
+
+        def reset(self):
+            self.active_skills = {}
+            self.active_skills_lock = Lock()
+            self.query_replies = []
+            self.searching = False
+            self.search_start = 0
+            self.query_timeouts = self.config.get("min_timeout", 5)
+            if self.config.get("playback_mode") in [PlaybackMode.AUDIO_ONLY]:
+                self.has_gui = False
+            else:
+                self.has_gui = is_gui_running() or is_gui_connected(self.bus)
 
 try:
     from ovos_utils.ocp import dict2entry

--- a/test/end2end/minicroft.py
+++ b/test/end2end/minicroft.py
@@ -65,11 +65,11 @@ class MiniCroft(SkillManager):
         SessionManager.default_session = SessionManager.sessions["default"] = Session("default")
 
 
-def get_minicroft(skill_id, ocp=False):
+def get_minicroft(skill_id):
     if isinstance(skill_id, str):
         skill_id = [skill_id]
     assert isinstance(skill_id, list)
-    croft1 = MiniCroft(skill_id, ocp=ocp)
+    croft1 = MiniCroft(skill_id)
     croft1.start()
     while croft1.status.state != ProcessState.READY:
         sleep(0.2)

--- a/test/end2end/minicroft.py
+++ b/test/end2end/minicroft.py
@@ -12,24 +12,24 @@ from ovos_workshop.skills.fallback import FallbackSkill
 
 
 class MiniCroft(SkillManager):
-    def __init__(self, skill_ids, ocp=False, *args, **kwargs):
+    def __init__(self, skill_ids, *args, **kwargs):
         bus = FakeBus()
         super().__init__(bus, *args, **kwargs)
         self.skill_ids = skill_ids
-        self.intent_service = self._register_intent_services(ocp=ocp)
+        self.intent_service = self._register_intent_services()
         self.scheduler = EventScheduler(bus, schedule_file="/tmp/schetest.json")
 
     def load_metadata_transformers(self, cfg):
         self.intent_service.metadata_plugins.config = cfg
         self.intent_service.metadata_plugins.load_plugins()
 
-    def _register_intent_services(self, ocp=False):
+    def _register_intent_services(self):
         """Start up the all intent services and connect them as needed.
 
         Args:
             bus: messagebus client to register the services on
         """
-        service = IntentService(self.bus, config={"experimental_ocp_pipeline": ocp})
+        service = IntentService(self.bus)
         # Register handler to trigger fallback system
         self.bus.on(
             'mycroft.skills.fallback',

--- a/test/end2end/session/test_ocp.py
+++ b/test/end2end/session/test_ocp.py
@@ -4,7 +4,7 @@ from unittest import TestCase
 
 from ovos_bus_client.message import Message
 from ovos_bus_client.session import Session
-from ovos_utils.ocp import PlayerState, MediaState
+from ovos_core.intent_services.ocp_service import PlayerState, MediaState
 from ..minicroft import get_minicroft
 
 

--- a/test/end2end/session/test_ocp.py
+++ b/test/end2end/session/test_ocp.py
@@ -12,7 +12,7 @@ class TestOCPPipeline(TestCase):
 
     def setUp(self):
         self.skill_id = "skill-fake-fm.openvoiceos"
-        self.core = get_minicroft(self.skill_id, ocp=True)
+        self.core = get_minicroft(self.skill_id)
 
     def tearDown(self) -> None:
         self.core.stop()
@@ -1040,7 +1040,7 @@ class TestLegacyCPSPipeline(TestCase):
 
     def setUp(self):
         self.skill_id = "skill-fake-fm-legacy.openvoiceos"
-        self.core = get_minicroft(self.skill_id, ocp=True)
+        self.core = get_minicroft(self.skill_id)
         self.core.intent_service.ocp.config = {"legacy_cps": True}
 
     def tearDown(self) -> None:

--- a/test/end2end/skill-fake-fm/__init__.py
+++ b/test/end2end/skill-fake-fm/__init__.py
@@ -1,6 +1,6 @@
 from os.path import join, dirname
 
-from ovos_utils.ocp import MediaType, PlaybackType
+from ovos_core.intent_services.ocp_service import MediaType, PlaybackType
 from ovos_workshop.decorators.ocp import ocp_search
 from ovos_workshop.skills.common_play import OVOSCommonPlaybackSkill
 

--- a/test/unittests/skills/test_intent_service.py
+++ b/test/unittests/skills/test_intent_service.py
@@ -256,46 +256,7 @@ class TestIntentServiceApi(TestCase):
         self.assertEqual(reply.data['intent'], None)
 
     def test_shutdown(self):
-        intent_service = IntentService(MockEmitter(), config={"experimental_ocp_pipeline": False,
-                                                              "padatious": {"disabled": True}})
-        intent_service.shutdown()
-        self.assertEqual(intent_service.bus.removed,
-                         ['padatious:register_intent',
-                          'padatious:register_entity',
-                          'detach_intent',
-                          'detach_skill',
-                          'question:query.response',
-                          'common_query.question',
-                          'ovos.common_query.pong',
-                          'mycroft.speech.recognition.unknown',
-                          'intent.service.skills.deactivate',
-                          'intent.service.skills.activate',
-                          'active_skill_request',
-                          'intent.service.active_skills.get',
-                          'skill.converse.get_response.enable',
-                          'skill.converse.get_response.disable',
-                          'ovos.skills.fallback.register',
-                          'ovos.skills.fallback.deregister',
-                          'register_vocab',
-                          'register_intent',
-                          'recognizer_loop:utterance',
-                          'detach_intent',
-                          'detach_skill',
-                          'add_context',
-                          'remove_context',
-                          'clear_context',
-                          'mycroft.skills.loaded',
-                          'intent.service.intent.get',
-                          'intent.service.skills.get',
-                          'intent.service.adapt.get',
-                          'intent.service.adapt.manifest.get',
-                          'intent.service.adapt.vocab.manifest.get',
-                          'intent.service.padatious.get',
-                          'intent.service.padatious.manifest.get',
-                          'intent.service.padatious.entities.manifest.get'])
-
-        intent_service = IntentService(MockEmitter(), config={"experimental_ocp_pipeline": True,
-                                                              "padatious": {"disabled": True}})
+        intent_service = IntentService(MockEmitter(), config={"padatious": {"disabled": True}})
         intent_service.shutdown()
         self.assertEqual(set(intent_service.bus.removed),
                          {'active_skill_request',

--- a/test/unittests/skills/test_ocp.py
+++ b/test/unittests/skills/test_ocp.py
@@ -8,8 +8,7 @@ from ovos_classifiers.skovos.features import ClassifierProbaVectorizer, KeywordF
 from sklearn.pipeline import FeatureUnion
 from ovos_utils.log import LOG
 from ovos_bus_client.message import Message
-from ovos_utils.ocp import MediaType
-
+from ovos_core.intent_services.ocp_service import MediaType
 
 
 class TestOCPFeaturizer(unittest.TestCase):


### PR DESCRIPTION
closes #490 

removes the need for a special flag to enable OCP pipeline, now it's just like other pipelines and needs only to be added to "pipeline" config, instead of requiring an additional boolean flag

NOTE: enabling OCP by default needs https://github.com/OpenVoiceOS/ovos-config/pull/96 , this PR just allows it to import with utils <=0.0.38