### PR TITLE
feat/blacklist_from_session

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -33,6 +33,7 @@ jobs:
           pip install ./test/end2end/skill-old-stop
           pip install ./test/end2end/skill-fake-fm
           pip install ./test/end2end/skill-fake-fm-legacy
+          pip install ./test/end2end/skill-ovos-fakewiki
           pip install ./test/end2end/metadata-test-plugin
     - name: Install core repo
       run: |

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -60,6 +60,7 @@ jobs:
           pip install ./test/end2end/skill-old-stop
           pip install ./test/end2end/skill-fake-fm
           pip install ./test/end2end/skill-fake-fm-legacy
+          pip install ./test/end2end/skill-ovos-fakewiki
           pip install ./test/end2end/metadata-test-plugin
       - name: Install core repo
         run: |

--- a/ovos_core/intent_services/__init__.py
+++ b/ovos_core/intent_services/__init__.py
@@ -360,6 +360,12 @@ class IntentService:
             for match_func in self.get_pipeline(session=sess):
                 match = match_func(utterances, lang, message)
                 if match:
+                    if match.skill_id and match.skill_id in sess.blacklisted_skills:
+                        LOG.debug(f"ignoring match, skill_id '{match.skill_id}' blacklisted by Session '{sess.session_id}'")
+                        continue
+                    if match.intent_type and match.intent_type in sess.blacklisted_intents:
+                        LOG.debug(f"ignoring match, intent '{match.intent_type}' blacklisted by Session '{sess.session_id}'")
+                        continue
                     try:
                         self._emit_match_message(match, message)
                         break

--- a/ovos_core/intent_services/adapt_service.py
+++ b/ovos_core/intent_services/adapt_service.py
@@ -177,7 +177,7 @@ class AdaptService:
             return match
         return None
 
-    @lru_cache(maxsize=3)
+    @lru_cache(maxsize=3)  # NOTE - message is a string because of this
     def match_intent(self, utterances: Tuple[str],
                            lang: Optional[str] = None,
                            message: Optional[str] = None):
@@ -197,6 +197,9 @@ class AdaptService:
         Returns:
             Intent structure, or None if no match was found.
         """
+
+        if message:
+            message = Message.deserialize(message)
         sess = SessionManager.get(message)
 
         # we call flatten in case someone is sending the old style list of tuples
@@ -224,8 +227,6 @@ class AdaptService:
                 # TODO - Shouldn't Adapt do this?
                 best_intent['utterance'] = utt
 
-        if message:
-            message = Message.deserialize(message)
         sess = SessionManager.get(message)
         for utt in utterances:
             try:

--- a/ovos_core/intent_services/adapt_service.py
+++ b/ovos_core/intent_services/adapt_service.py
@@ -197,6 +197,8 @@ class AdaptService:
         Returns:
             Intent structure, or None if no match was found.
         """
+        sess = SessionManager.get(message)
+
         # we call flatten in case someone is sending the old style list of tuples
         utterances = flatten_list(utterances)
 
@@ -215,7 +217,9 @@ class AdaptService:
             nonlocal best_intent
             best = best_intent.get('confidence', 0.0) if best_intent else 0.0
             conf = intent.get('confidence', 0.0)
-            if best < conf:
+            skill = intent['intent_type'].split(":")[0]
+            if best < conf and intent["intent_type"] not in sess.blacklisted_intents \
+                    and skill not in sess.blacklisted_skills:
                 best_intent = intent
                 # TODO - Shouldn't Adapt do this?
                 best_intent['utterance'] = utt

--- a/ovos_core/intent_services/commonqa_service.py
+++ b/ovos_core/intent_services/commonqa_service.py
@@ -172,6 +172,11 @@ class CommonQAService(OVOSAbstractApplication):
         searching = message.data.get('searching')
         answer = message.data.get('answer')
 
+        sess = SessionManager.get(message)
+        if skill_id in sess.blacklisted_skills:
+            LOG.debug(f"ignoring match, skill_id '{skill_id}' blacklisted by Session '{sess.session_id}'")
+            return
+
         query = self.active_queries.get(SessionManager.get(message).session_id)
         if not query:
             LOG.warning(f"Late answer received from {skill_id}, no active query for: {search_phrase}")

--- a/ovos_core/intent_services/converse_service.py
+++ b/ovos_core/intent_services/converse_service.py
@@ -320,6 +320,9 @@ class ConverseService:
         self._check_converse_timeout(message)
         # check if any skill wants to handle utterance
         for skill_id in self._collect_converse_skills(message):
+            if skill_id in session.blacklisted_skills:
+                LOG.debug(f"ignoring match, skill_id '{skill_id}' blacklisted by Session '{session.session_id}'")
+                continue
             if self.converse(utterances, skill_id, lang, message):
                 state = session.utterance_states.get(skill_id, UtteranceState.INTENT)
                 return ovos_core.intent_services.IntentMatch(intent_service='Converse',

--- a/ovos_core/intent_services/fallback_service.py
+++ b/ovos_core/intent_services/fallback_service.py
@@ -22,6 +22,7 @@ from ovos_config import Configuration
 import ovos_core.intent_services
 from ovos_utils import flatten_list
 from ovos_utils.log import LOG
+from ovos_bus_client.session import SessionManager
 from ovos_workshop.skills.fallback import FallbackMode
 
 FallbackRange = namedtuple('FallbackRange', ['start', 'stop'])
@@ -124,6 +125,10 @@ class FallbackService:
         Returns:
             handled (bool): True if handled otherwise False.
         """
+        sess = SessionManager.get(message)
+        if skill_id in sess.blacklisted_skills:
+            LOG.debug(f"ignoring match, skill_id '{skill_id}' blacklisted by Session '{sess.session_id}'")
+            return False
         if self._fallback_allowed(skill_id):
             fb_msg = message.reply(f"ovos.skills.fallback.{skill_id}.request",
                                    {"skill_id": skill_id,

--- a/ovos_core/intent_services/ocp_service.py
+++ b/ovos_core/intent_services/ocp_service.py
@@ -768,6 +768,11 @@ class OCPPipelineMatcher(OVOSAbstractApplication):
     def match_high(self, utterances: List[str], lang: str, message: Message = None):
         """ exact matches only, handles playback control
         recommended after high confidence intents pipeline stage """
+        sess = SessionManager.get(message)
+        if OCP_ID in sess.blacklisted_skills:
+            LOG.debug(f"ignoring match, skill_id '{OCP_ID}' blacklisted by Session '{sess.session_id}'")
+            return
+
         if lang not in self.intent_matchers:
             return None
 

--- a/ovos_core/intent_services/padacioso_service.py
+++ b/ovos_core/intent_services/padacioso_service.py
@@ -271,9 +271,8 @@ def _calc_padacioso_intent(utt: str,
     """
     try:
         intents = [i for i in intent_container.calc_intents(utt)
-                   if i is not None and i.get("name")]
-        intents = [i for i in intents
-                   if i["name"] not in sess.blacklisted_intents
+                   if i is not None
+                   and i["name"] not in sess.blacklisted_intents
                    and i["name"].split(":")[0] not in sess.blacklisted_skills]
         if len(intents) == 0:
             return None

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -7,7 +7,7 @@ padacioso~=0.2, >=0.2.1
 adapt-parser>=1.0.0, <2.0.0
 
 ovos-utils>=0.0.38
-ovos_bus_client<0.1.0, >=0.0.8
+ovos_bus_client<0.1.0, >=0.0.9a22
 ovos-plugin-manager<0.1.0, >=0.0.25
 ovos-config~=0.0,>=0.0.13a8
 ovos-lingua-franca>=0.4.7

--- a/test/end2end/minicroft.py
+++ b/test/end2end/minicroft.py
@@ -10,6 +10,8 @@ from ovos_utils.messagebus import FakeBus
 from ovos_utils.process_utils import ProcessState
 from ovos_workshop.skills.fallback import FallbackSkill
 
+LOG.set_level("DEBUG")
+
 
 class MiniCroft(SkillManager):
     def __init__(self, skill_ids, *args, **kwargs):

--- a/test/end2end/session/test_blacklist.py
+++ b/test/end2end/session/test_blacklist.py
@@ -1,0 +1,127 @@
+import time
+from time import sleep
+from unittest import TestCase
+
+from ovos_bus_client.message import Message
+from ovos_bus_client.session import SessionManager, Session
+from ..minicroft import get_minicroft
+
+
+class TestSessions(TestCase):
+
+    def setUp(self):
+        self.skill_id = "skill-ovos-hello-world.openvoiceos"
+        self.core = get_minicroft([self.skill_id])
+
+    def tearDown(self) -> None:
+        self.core.stop()
+
+    def test_blacklist(self):
+        SessionManager.sessions = {}
+        SessionManager.default_session = SessionManager.sessions["default"] = Session("default")
+        SessionManager.default_session.lang = "en-us"
+        SessionManager.default_session.pipeline = ["adapt_high"]
+        SessionManager.default_session.blacklisted_skills = []
+        SessionManager.default_session.blacklisted_intents = []
+
+        messages = []
+
+        def new_msg(msg):
+            nonlocal messages
+            m = Message.deserialize(msg)
+            if m.msg_type in ["ovos.skills.settings_changed", "ovos.common_play.status"]:
+                return  # skip these, only happen in 1st run
+            messages.append(m)
+            print(len(messages), msg)
+
+        def wait_for_n_messages(n):
+            nonlocal messages
+            t = time.time()
+            while len(messages) < n:
+                sleep(0.1)
+                if time.time() - t > 10:
+                    raise RuntimeError("did not get the number of expected messages under 10 seconds")
+
+        self.core.bus.on("message", new_msg)
+
+        ########################################
+        # empty blacklist
+        sess = Session("123")
+
+        utt = Message("recognizer_loop:utterance",
+                      {"utterances": ["hello world"]},
+                      {"session": sess.serialize()})
+        self.core.bus.emit(utt)
+
+        # confirm all expected messages are sent
+        expected_messages = [
+            "recognizer_loop:utterance",
+            # skill selected
+            f"{self.skill_id}:HelloWorldIntent",
+            "mycroft.skill.handler.start",
+            "intent.service.skills.activate",
+            "intent.service.skills.activated",
+            f"{self.skill_id}.activate",
+            # skill code executing
+            "enclosure.active_skill",
+            "speak",
+            "mycroft.skill.handler.complete",
+            "ovos.utterance.handled"  # handle_utterance returned (intent service)
+        ]
+
+        wait_for_n_messages(len(expected_messages))
+
+        for idx, m in enumerate(messages):
+            self.assertEqual(m.msg_type, expected_messages[idx])
+
+        # sanity check correct intent triggered
+        self.assertEqual(messages[7].data["meta"]["dialog"], "hello.world")
+
+        ########################################
+        # skill in blacklist
+        messages = []
+        sess.blacklisted_skills = [self.skill_id]
+
+        utt = Message("recognizer_loop:utterance",
+                      {"utterances": ["hello world"]},
+                      {"session": sess.serialize()})
+        self.core.bus.emit(utt)
+
+        # confirm complete intent failure
+        expected_messages = [
+            "recognizer_loop:utterance",
+            # complete intent failure
+            "mycroft.audio.play_sound",
+            "complete_intent_failure",
+            "ovos.utterance.handled"
+        ]
+
+        wait_for_n_messages(len(expected_messages))
+
+        for idx, m in enumerate(messages):
+            self.assertEqual(m.msg_type, expected_messages[idx])
+
+        ########################################
+        # intent in blacklist
+        messages = []
+        sess.blacklisted_skills = []
+        sess.blacklisted_intents = [f"{self.skill_id}:HelloWorldIntent"]
+
+        utt = Message("recognizer_loop:utterance",
+                      {"utterances": ["hello world"]},
+                      {"session": sess.serialize()})
+        self.core.bus.emit(utt)
+
+        # confirm complete intent failure
+        expected_messages = [
+            "recognizer_loop:utterance",
+            # complete intent failure
+            "mycroft.audio.play_sound",
+            "complete_intent_failure",
+            "ovos.utterance.handled"
+        ]
+
+        wait_for_n_messages(len(expected_messages))
+
+        for idx, m in enumerate(messages):
+            self.assertEqual(m.msg_type, expected_messages[idx])

--- a/test/end2end/session/test_blacklist.py
+++ b/test/end2end/session/test_blacklist.py
@@ -4,6 +4,7 @@ from unittest import TestCase
 
 from ovos_bus_client.message import Message
 from ovos_bus_client.session import SessionManager, Session
+from ovos_core.intent_services.ocp_service import PlayerState, MediaState, OCPPlayerProxy
 from ..minicroft import get_minicroft
 
 
@@ -118,6 +119,177 @@ class TestSessions(TestCase):
             # complete intent failure
             "mycroft.audio.play_sound",
             "complete_intent_failure",
+            "ovos.utterance.handled"
+        ]
+
+        wait_for_n_messages(len(expected_messages))
+
+        for idx, m in enumerate(messages):
+            self.assertEqual(m.msg_type, expected_messages[idx])
+
+
+class TestOCP(TestCase):
+
+    def setUp(self):
+        self.skill_id = "skill-fake-fm.openvoiceos"
+        self.core = get_minicroft([self.skill_id])
+
+    def tearDown(self) -> None:
+        self.core.stop()
+
+    def test_ocp(self):
+        self.assertIsNotNone(self.core.intent_service.ocp)
+        messages = []
+
+        def new_msg(msg):
+            nonlocal messages
+            m = Message.deserialize(msg)
+            if m.msg_type in ["ovos.skills.settings_changed", "gui.status.request"]:
+                return  # skip these, only happen in 1st run
+            messages.append(m)
+            print(len(messages), msg)
+
+        def wait_for_n_messages(n):
+            nonlocal messages
+            t = time.time()
+            while len(messages) < n:
+                sleep(0.1)
+                if time.time() - t > 10:
+                    raise RuntimeError("did not get the number of expected messages under 10 seconds")
+
+        self.core.bus.on("message", new_msg)
+
+        sess = Session("test-session",
+                       pipeline=[
+                           "ocp_high"
+                       ])
+        self.core.intent_service.ocp.ocp_sessions[sess.session_id] = OCPPlayerProxy(
+            session_id=sess.session_id, available_extractors=[], ocp_available=True,
+            player_state=PlayerState.STOPPED, media_state=MediaState.NO_MEDIA)
+        utt = Message("recognizer_loop:utterance",
+                      {"utterances": ["play Fake FM"]},  # auto derived from skill class name in this case
+                      {"session": sess.serialize(),
+                       })
+        self.core.bus.emit(utt)
+
+        # confirm all expected messages are sent
+        expected_messages = [
+            "recognizer_loop:utterance",
+            "ovos.common_play.status",
+            "intent.service.skills.activate",
+            "intent.service.skills.activated",
+            "ovos.common_play.activate",
+            "enclosure.active_skill",
+            "speak",
+            "ocp:play",
+            "ovos.common_play.search.start",
+            "enclosure.mouth.think",
+            "ovos.common_play.search.stop",  # any ongoing previous search
+            f"ovos.common_play.query.{self.skill_id}",  # explicitly search skill
+            # skill searching (explicit)
+            "ovos.common_play.skill.search_start",
+            "ovos.common_play.query.response",
+            "ovos.common_play.query.response",
+            "ovos.common_play.query.response",
+            "ovos.common_play.query.response",
+            "ovos.common_play.query.response",
+            "ovos.common_play.skill.search_end",
+            "ovos.common_play.search.end",
+            # good results
+            "ovos.common_play.reset",
+            "add_context",  # NowPlaying context
+            "ovos.common_play.play",  # OCP api
+            "ovos.utterance.handled"  # handle_utterance returned (intent service)
+        ]
+        wait_for_n_messages(len(expected_messages))
+
+        self.assertEqual(len(expected_messages), len(messages))
+
+        for idx, m in enumerate(messages):
+            self.assertEqual(m.msg_type, expected_messages[idx])
+
+        ########################################
+        # skill in blacklist - generic search
+        messages = []
+        sess.blacklisted_skills = [self.skill_id]
+
+        utt = Message("recognizer_loop:utterance",
+                      {"utterances": ["play some radio station"]},
+                      {"session": sess.serialize()})
+        self.core.bus.emit(utt)
+
+        # confirm complete intent failure
+        expected_messages = [
+            "recognizer_loop:utterance",
+            "ovos.common_play.status",
+            "intent.service.skills.activate",
+            "intent.service.skills.activated",
+            "ovos.common_play.activate",
+            "enclosure.active_skill",
+            "speak",
+            "ocp:play",
+            "ovos.common_play.search.start",
+            "enclosure.mouth.think",
+            "ovos.common_play.search.stop",  # any ongoing previous search
+            f"ovos.common_play.query",
+            # skill searching
+            "ovos.common_play.skill.search_start",
+            "ovos.common_play.query.response",
+            "ovos.common_play.query.response",
+            "ovos.common_play.query.response",
+            "ovos.common_play.query.response",
+            "ovos.common_play.query.response",
+            "ovos.common_play.skill.search_end",
+            "ovos.common_play.search.end",
+            'ovos.common_play.reset',
+            # playback failure - would play if not blacklisted
+            "enclosure.active_skill",
+            "speak",  # "dialog":"cant.play"
+            "ovos.utterance.handled"
+        ]
+
+        wait_for_n_messages(len(expected_messages))
+
+        for idx, m in enumerate(messages):
+            self.assertEqual(m.msg_type, expected_messages[idx])
+
+        ########################################
+        # skill in blacklist - search by name
+        messages = []
+        sess.blacklisted_skills = [self.skill_id]
+
+        utt = Message("recognizer_loop:utterance",
+                      {"utterances": ["play Fake FM"]},
+                      {"session": sess.serialize()})
+        self.core.bus.emit(utt)
+
+        # confirm complete intent failure
+        expected_messages = [
+            "recognizer_loop:utterance",
+            "ovos.common_play.status",
+            "intent.service.skills.activate",
+            "intent.service.skills.activated",
+            "ovos.common_play.activate",
+            "enclosure.active_skill",
+            "speak",
+            "ocp:play",
+            "ovos.common_play.search.start",
+            "enclosure.mouth.think",
+            "ovos.common_play.search.stop",  # any ongoing previous search
+            f"ovos.common_play.query",  # NOT explicitly searching skill, unlike first test
+            # skill searching (generic)
+            "ovos.common_play.skill.search_start",
+            "ovos.common_play.query.response",
+            "ovos.common_play.query.response",
+            "ovos.common_play.query.response",
+            "ovos.common_play.query.response",
+            "ovos.common_play.query.response",
+            "ovos.common_play.skill.search_end",
+            "ovos.common_play.search.end",
+            'ovos.common_play.reset',
+            # playback failure
+            "enclosure.active_skill",
+            "speak",  # "dialog":"cant.play"
             "ovos.utterance.handled"
         ]
 

--- a/test/end2end/skill-ovos-fakewiki/__init__.py
+++ b/test/end2end/skill-ovos-fakewiki/__init__.py
@@ -1,0 +1,14 @@
+from ovos_workshop.skills.common_query_skill import CommonQuerySkill, CQSMatchLevel
+
+
+class UnWikiSkill(CommonQuerySkill):
+
+    # common query integration
+    def CQS_match_query_phrase(self, utt):
+        response = "42"
+        return (utt, CQSMatchLevel.EXACT, response,
+                {'query': utt, 'answer': response})
+
+    def CQS_action(self, phrase, data):
+        """ If selected show gui """
+        self.speak("selected")

--- a/test/end2end/skill-ovos-fakewiki/setup.py
+++ b/test/end2end/skill-ovos-fakewiki/setup.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+from setuptools import setup
+
+# skill_id=package_name:SkillClass
+PLUGIN_ENTRY_POINT = 'ovos-skill-fakewiki.openvoiceos=ovos_skill_fakewiki:UnWikiSkill'
+
+setup(
+    # this is the package name that goes on pip
+    name='ovos-skill-fakewiki',
+    version='0.0.1',
+    description='this is a OVOS test skill for the common query framework',
+    url='https://github.com/OpenVoiceOS/ovos-core',
+    author='JarbasAi',
+    author_email='jarbasai@mailfence.com',
+    license='Apache-2.0',
+    package_dir={"ovos_skill_fakewiki": ""},
+    package_data={'ovos_skill_fakewiki': ['locale/*']},
+    packages=['ovos_skill_fakewiki'],
+    include_package_data=True,
+    install_requires=["ovos-workshop"],
+    keywords='ovos skill plugin',
+    entry_points={'ovos.plugin.skill': PLUGIN_ENTRY_POINT}
+)

--- a/test/unittests/skills/test_utterance_intents.py
+++ b/test/unittests/skills/test_utterance_intents.py
@@ -83,8 +83,7 @@ class UtteranceIntentMatchingTest(unittest.TestCase):
 
         # fuzzy match - failure case
         intent = intent_service.calc_intent("this test", "en-US")
-        self.assertEqual(intent.conf, 0.0)
-        self.assertTrue(intent.name is None)
+        self.assertIsNone(intent)
 
         # regex match
         intent = intent_service.calc_intent("tell me about Mycroft", "en-US")
@@ -94,8 +93,7 @@ class UtteranceIntentMatchingTest(unittest.TestCase):
         # fuzzy regex match - failure case
         utterance = "tell me everything about Mycroft"
         intent = intent_service.calc_intent(utterance, "en-US")
-        self.assertEqual(intent.conf, 0.0)
-        self.assertTrue(intent.name is None)
+        self.assertIsNone(intent)
 
     def test_padacioso_fuzz_intent(self):
         intent_service = self.get_service(regex_only=True, fuzz=True)


### PR DESCRIPTION
allow skill_id and intents to be blacklisted in the Session, these will be ignored during the matching process

this allows finetuning utterances and permissions per client, taking it into account during the match process instead of filtering before/after the handling of the utterance

needed for hivemind RBAC

needs https://github.com/OpenVoiceOS/ovos-bus-client/pull/98

**NOTE**: this ensures skill blacklist is respected even when skills are launched in standalone mode. otherwise a standalone mode skill could bypass the blacklist, closes https://github.com/OpenVoiceOS/ovos-core/issues/493

```javascript
{
	"intents": {"blacklisted_intents": ["skill_id:intent_name"]},
	"skills": {"blacklisted_skills": ["skill_id"]},
}
```