### PR TITLE
fix/ocp_per_session

### DIFF
--- a/ovos_core/intent_services/ocp_service.py
+++ b/ovos_core/intent_services/ocp_service.py
@@ -750,9 +750,9 @@ class OCPPipelineMatcher(OVOSAbstractApplication):
         @param message: Message providing new "state" data
         """
         player = self.get_player(message)
-        pstate = message.data.get("player_state")
-        mstate = message.data.get("media_state")
-        mtype = message.data.get("media_type")
+        pstate: int = message.data.get("player_state")
+        mstate: int = message.data.get("media_state")
+        mtype: int = message.data.get("media_type")
         if pstate is not None:
             player.player_state = PlayerState(pstate)
             LOG.debug(f"Session: {player.session_id} PlayerState: {player.player_state}")

--- a/ovos_core/intent_services/ocp_service.py
+++ b/ovos_core/intent_services/ocp_service.py
@@ -1013,11 +1013,9 @@ class OCPPipelineMatcher(OVOSAbstractApplication):
         else:
             LOG.info("Requesting OCP to stop")
             self.ocp_api.stop()
-            # old ocp doesnt report stopped state ...
-            # TODO - remove this once proper events are emitted
-            player = self.get_player(message)
-            player.player_state = PlayerState.STOPPED
-            self.update_player_proxy(player)
+        player = self.get_player(message)
+        player.player_state = PlayerState.STOPPED
+        self.update_player_proxy(player)
 
     def handle_next_intent(self, message: Message):
         player = self.get_player(message)
@@ -1045,6 +1043,9 @@ class OCPPipelineMatcher(OVOSAbstractApplication):
         else:
             LOG.info("Requesting OCP to go to pause")
             self.ocp_api.pause()
+        player = self.get_player(message)
+        player.player_state = PlayerState.PAUSED
+        self.update_player_proxy(player)
 
     def handle_resume_intent(self, message: Message):
         player = self.get_player(message)
@@ -1054,6 +1055,9 @@ class OCPPipelineMatcher(OVOSAbstractApplication):
         else:
             LOG.info("Requesting OCP to go to resume")
             self.ocp_api.resume()
+        player = self.get_player(message)
+        player.player_state = PlayerState.PLAYING
+        self.update_player_proxy(player)
 
     def handle_search_error_intent(self, message: Message):
         self.bus.emit(message.forward("mycroft.audio.play_sound",

--- a/ovos_core/intent_services/ocp_service.py
+++ b/ovos_core/intent_services/ocp_service.py
@@ -661,7 +661,7 @@ class OCPPipelineMatcher(OVOSAbstractApplication):
         """
         sess = SessionManager.get(message)
         self._available_SEI[sess.session_id] = message.data["SEI"]
-        LOG.info(f"Available stream extractor plugins: {self._available_SEI[sess.session_id]}")
+        LOG.info(f"Session: {sess.session_id} Available stream extractor plugins: {self._available_SEI[sess.session_id]}")
 
     def handle_skill_register(self, message: Message):
         """ register skill names as keywords to match their MediaType"""
@@ -1196,7 +1196,7 @@ class OCPPipelineMatcher(OVOSAbstractApplication):
                     nonlocal seis
                     s = SessionManager.get(m)
                     if s.session_id == sess.session_id:
-                        seis.append(m.data["SEI"])
+                        seis = m.data["SEI"]
                         ev.set()
 
                 self.bus.on("ovos.common_play.SEI.get.response", handle_m)

--- a/test/end2end/session/test_ocp.py
+++ b/test/end2end/session/test_ocp.py
@@ -216,6 +216,19 @@ class TestOCPPipeline(TestCase):
         self.assertEqual(self.core.intent_service.ocp.ocp_sessions[sess.session_id].available_extractors,
                          ["test"])
 
+        # test OCP player state sync
+        self.assertEqual(self.core.intent_service.ocp.ocp_sessions[sess.session_id].player_state,
+                         PlayerState.STOPPED)
+        messages = []
+        utt = Message("ovos.common_play.status.response",
+                      {"player_state": PlayerState.PLAYING.value},
+                      {"session": sess.serialize(),  # explicit
+                       })
+        self.core.bus.emit(utt)
+
+        self.assertEqual(self.core.intent_service.ocp.ocp_sessions[sess.session_id].player_state,
+                         PlayerState.PLAYING)
+
     def test_radio_media_match(self):
         self.assertIsNotNone(self.core.intent_service.ocp)
         messages = []

--- a/test/unittests/skills/test_intent_service.py
+++ b/test/unittests/skills/test_intent_service.py
@@ -302,7 +302,6 @@ class TestIntentServiceApi(TestCase):
                           'ocp:prev',
                           'ocp:resume',
                           'ocp:search_error',
-                          'ovos.common_play.SEI.get.response',
                           'ovos.common_play.activate',
                           'ovos.common_play.announce',
                           'ovos.common_play.converse.get_response',


### PR DESCRIPTION
tracks available stream extractors per session, this allows running OCP satellite side

> NOTE: with hivemind we need to whitelist "ovos.common_play.SEI.get.response" in the listener


```
2024-06-05 01:21:25.379 - skills - ovos_core.intent_services.ocp_service:handle_get_SEIs:664 - INFO - Session: 5937ce7a-71e3-4d21-8403-142102c5f759 Available stream extractor plugins: ['rss', 'news', 'm3u', 'pls', 'file', 'youtube', 'ydl', 'youtube.channel.live', 'pytube', 'invidious', 'bandcamp']
2024-06-05 01:21:25.384 - skills - ovos_core.intent_services.ocp_service:_search:1301 - DEBUG - Got 3 usable results
2024-06-05 01:21:25.385 - skills - ovos_core.intent_services.ocp_service:handle_play_intent:984 - DEBUG - Playing 3 results for: ozzy osbourne
2024-06-05 01:21:25.385 - skills - ovos_core.intent_services.ocp_service:select_best:1372 - INFO - OVOSCommonPlay selected: skill-ovos-youtube-music.openvoiceos - 94.61538461538461
```