### PR TITLE
cleanup/explicit_utterance_handled_message

### DIFF
--- a/ovos_core/intent_services/__init__.py
+++ b/ovos_core/intent_services/__init__.py
@@ -285,8 +285,13 @@ class IntentService:
             # ensure skill_id is present in message.context
             message.context["skill_id"] = match.skill_id
 
+        if match.intent_type is True:
+            # utterance fully handled
+            reply = message.reply("ovos.utterance.handled",
+                                  {"skill_id": match.skill_id})
+            self.bus.emit(reply)
         # Launch skill if not handled by the match function
-        if match.intent_type:
+        elif match.intent_type:
             # keep all original message.data and update with intent match
             data = dict(message.data)
             data.update(match.intent_data)

--- a/ovos_core/intent_services/commonqa_service.py
+++ b/ovos_core/intent_services/commonqa_service.py
@@ -115,8 +115,7 @@ class CommonQAService(OVOSAbstractApplication):
                 answered, skill_id = self.handle_question(message)
                 if answered:
                     match = ovos_core.intent_services.IntentMatch(intent_service='CommonQuery',
-                                                                  intent_type="ovos.utterance.handled",
-                                                                  # emit instead of intent message
+                                                                  intent_type=True,
                                                                   intent_data={},
                                                                   skill_id=skill_id,
                                                                   utterance=utterance)

--- a/ovos_core/intent_services/converse_service.py
+++ b/ovos_core/intent_services/converse_service.py
@@ -1,15 +1,15 @@
 import time
 from threading import Event
+
+import ovos_core.intent_services
 from ovos_bus_client.message import Message
 from ovos_bus_client.session import SessionManager, UtteranceState
+from ovos_bus_client.util import get_message_lang
 from ovos_config.config import Configuration
 from ovos_config.locale import setup_locale
 from ovos_utils import flatten_list
 from ovos_utils.log import LOG
-from ovos_bus_client.util import get_message_lang
 from ovos_workshop.permissions import ConverseMode, ConverseActivationMode
-
-import ovos_core.intent_services
 
 
 class ConverseService:
@@ -215,7 +215,7 @@ class ConverseService:
         # include all skills in get_response state
         want_converse = [skill_id for skill_id, state in session.utterance_states.items()
                          if state == UtteranceState.RESPONSE]
-        skill_ids += want_converse # dont wait for these pong answers (optimization)
+        skill_ids += want_converse  # dont wait for these pong answers (optimization)
 
         active_skills = self.get_active_skills()
 
@@ -230,11 +230,11 @@ class ConverseService:
 
             # validate the converse pong
             if all((skill_id not in want_converse,
-                   msg.data.get("can_handle", True),
-                   skill_id in active_skills)):
+                    msg.data.get("can_handle", True),
+                    skill_id in active_skills)):
                 want_converse.append(skill_id)
 
-            if skill_id not in skill_ids: # track which answer we got
+            if skill_id not in skill_ids:  # track which answer we got
                 skill_ids.append(skill_id)
 
             if all(s in skill_ids for s in active_skills):
@@ -326,7 +326,8 @@ class ConverseService:
             if self.converse(utterances, skill_id, lang, message):
                 state = session.utterance_states.get(skill_id, UtteranceState.INTENT)
                 return ovos_core.intent_services.IntentMatch(intent_service='Converse',
-                                                             intent_type="ovos.utterance.handled" if state != UtteranceState.RESPONSE else None, # emit instead of intent message
+                                                             intent_type=state != UtteranceState.RESPONSE,
+                                                             # intent_type == True -> emit "ovos.utterance.handled"
                                                              intent_data={},
                                                              skill_id=skill_id,
                                                              utterance=utterances[0])

--- a/ovos_core/intent_services/stop_service.py
+++ b/ovos_core/intent_services/stop_service.py
@@ -145,7 +145,7 @@ class StopService:
             # emit a global stop, full stop anything OVOS is doing
             self.bus.emit(message.reply("mycroft.stop", {}))
             return ovos_core.intent_services.IntentMatch(intent_service='Stop',
-                                                         intent_type="ovos.utterance.handled",
+                                                         intent_type=True,
                                                          intent_data={"conf": conf},
                                                          skill_id=None,
                                                          utterance=utterance)
@@ -159,7 +159,7 @@ class StopService:
 
                 if self.stop_skill(skill_id, message):
                     return ovos_core.intent_services.IntentMatch(intent_service='Stop',
-                                                                 intent_type="ovos.utterance.handled",
+                                                                 intent_type=True,
                                                                  intent_data={"conf": conf},
                                                                  skill_id=skill_id,
                                                                  utterance=utterance)
@@ -227,7 +227,7 @@ class StopService:
 
             if self.stop_skill(skill_id, message):
                 return ovos_core.intent_services.IntentMatch(intent_service='Stop',
-                                                             intent_type="ovos.utterance.handled",
+                                                             intent_type=True,
                                                              # emit instead of intent message
                                                              intent_data={"conf": conf},
                                                              skill_id=skill_id, utterance=utterance)
@@ -235,7 +235,7 @@ class StopService:
         # emit a global stop, full stop anything OVOS is doing
         self.bus.emit(message.reply("mycroft.stop", {}))
         return ovos_core.intent_services.IntentMatch(intent_service='Stop',
-                                                     intent_type="ovos.utterance.handled",
+                                                     intent_type=True,
                                                      # emit instead of intent message {"conf": conf},
                                                      intent_data={},
                                                      skill_id=None,


### PR DESCRIPTION
dont emit "ovos.utterance.handled" by pretending to be a intent_type, be explicit about handling this message

the non-intent pipeline components should not need to lie or know about this message type, now they only return True if that's the end of the utterance handling instead of a "magic string"