### PR TITLE
fix/activation_session

### DIFF
--- a/ovos_core/intent_services/__init__.py
+++ b/ovos_core/intent_services/__init__.py
@@ -292,20 +292,22 @@ class IntentService:
             self.bus.emit(reply)
         # Launch skill if not handled by the match function
         elif match.intent_type:
+            # keep all original message.data and update with intent match
+            data = dict(message.data)
+            data.update(match.intent_data)
+
+            # NOTE: message.reply to ensure correct message destination
+            reply = message.reply(match.intent_type, data)
+
             # let's activate the skill BEFORE the intent is triggered
             # to ensure an accurate Session
             # NOTE: this was previously done async by the skill,
             #   but then the skill was missing from Session.active_skills
-            sess = self.converse.activate_skill(message=message,
+            sess = self.converse.activate_skill(message=reply,
                                                 skill_id=match.skill_id)
             if sess:
-                message.context["session"] = sess.serialize()
+                reply.context["session"] = sess.serialize()
 
-            # keep all original message.data and update with intent match
-            data = dict(message.data)
-            data.update(match.intent_data)
-            # NOTE: message.reply to ensure correct message destination
-            reply = message.reply(match.intent_type, data)
             self.bus.emit(reply)
 
     def send_cancel_event(self, message):

--- a/ovos_core/intent_services/__init__.py
+++ b/ovos_core/intent_services/__init__.py
@@ -292,6 +292,15 @@ class IntentService:
             self.bus.emit(reply)
         # Launch skill if not handled by the match function
         elif match.intent_type:
+            # let's activate the skill BEFORE the intent is triggered
+            # to ensure an accurate Session
+            # NOTE: this was previously done async by the skill,
+            #   but then the skill was missing from Session.active_skills
+            sess = self.converse.activate_skill(message=message,
+                                                skill_id=match.skill_id)
+            if sess:
+                message.context["session"] = sess.serialize()
+
             # keep all original message.data and update with intent match
             data = dict(message.data)
             data.update(match.intent_data)

--- a/ovos_core/intent_services/converse_service.py
+++ b/ovos_core/intent_services/converse_service.py
@@ -105,6 +105,7 @@ class ConverseService:
             self.bus.emit(message)
             # update activation counter
             self._consecutive_activations[skill_id] += 1
+            return session
 
     def _activate_allowed(self, skill_id, source_skill=None):
         """Checks if a skill_id is allowed to jump to the front of active skills list

--- a/ovos_core/intent_services/ocp_service.py
+++ b/ovos_core/intent_services/ocp_service.py
@@ -730,7 +730,6 @@ class OCPPipelineMatcher(OVOSAbstractApplication):
             else:
                 return None
 
-        self.activate()  # mark skill_id as active, this is a catch all for all OCP skills
         return ovos_core.intent_services.IntentMatch(intent_service="OCP_intents",
                                                      intent_type=f'ocp:{match["name"]}',
                                                      intent_data=match,
@@ -756,7 +755,6 @@ class OCPPipelineMatcher(OVOSAbstractApplication):
         # extract the query string
         query = self.remove_voc(utterance, "Play", lang).strip()
 
-        self.activate()  # mark skill_id as active, this is a catch all for all OCP skills
         return ovos_core.intent_services.IntentMatch(intent_service="OCP_media",
                                                      intent_type=f"ocp:play",
                                                      intent_data={"media_type": media_type,
@@ -783,7 +781,7 @@ class OCPPipelineMatcher(OVOSAbstractApplication):
 
         # extract the query string
         query = self.remove_voc(utterance, "Play", lang).strip()
-        self.activate()  # mark skill_id as active, this is a catch all for all OCP skills
+
         return ovos_core.intent_services.IntentMatch(intent_service="OCP_fallback",
                                                      intent_type=f"ocp:play",
                                                      intent_data={"media_type": media_type,
@@ -795,8 +793,6 @@ class OCPPipelineMatcher(OVOSAbstractApplication):
 
     def _process_play_query(self, utterance: str, lang: str, match: dict = None,
                             message: Optional[Message] = None):
-
-        self.activate()  # mark skill_id as active, this is a catch all for all OCP skills
 
         match = match or {}
         player = self.get_player(message)
@@ -1412,8 +1408,6 @@ class OCPPipelineMatcher(OVOSAbstractApplication):
             return None
         if match["name"] == "play":
             LOG.info(f"Legacy Mycroft CommonPlay match: {match}")
-            # we dont call self.activate , the skill itself is activated on selection
-            # playback is happening outside of OCP
             utterance = match["entities"].pop("query")
             return ovos_core.intent_services.IntentMatch(intent_service="OCP_media",
                                                          intent_type=f"ocp:legacy_cps",

--- a/ovos_core/intent_services/ocp_service.py
+++ b/ovos_core/intent_services/ocp_service.py
@@ -816,8 +816,6 @@ class OCPPipelineMatcher(OVOSAbstractApplication):
                                                              skill_id=OCP_ID,
                                                              utterance=utterance)
 
-        self.speak_dialog("just.one.moment")
-
         sess = SessionManager.get(message)
         # if a skill was explicitly requested, search it first
         valid_skills = [
@@ -884,6 +882,9 @@ class OCPPipelineMatcher(OVOSAbstractApplication):
 
     # intent handlers
     def handle_play_intent(self, message: Message):
+
+        self.speak_dialog("just.one.moment")
+
         lang = message.data["lang"]
         query = message.data["query"]
         media_type = message.data["media_type"]

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -12,7 +12,7 @@ ovos-plugin-manager<0.1.0, >=0.0.25
 ovos-config~=0.0,>=0.0.13a8
 ovos-lingua-franca>=0.4.7
 ovos-backend-client~=0.1.0
-ovos-workshop<0.1.0, >=0.0.16a35
+ovos-workshop<0.1.0, >=0.0.16a36
 # provides plugins and classic machine learning framework
 ovos-classifiers<0.1.0, >=0.0.0a53
 

--- a/test/end2end/routing/test_sched.py
+++ b/test/end2end/routing/test_sched.py
@@ -81,7 +81,6 @@ class TestSched(TestCase):
                 self.assertEqual(messages[0].context["destination"], "B")
             # messages FROM ovos-core
             else:
-                print(m.serialize())
                 self.assertEqual(m.context["source"], "B")
                 self.assertEqual(m.context["destination"], "A")
 

--- a/test/end2end/routing/test_sched.py
+++ b/test/end2end/routing/test_sched.py
@@ -47,14 +47,10 @@ class TestSched(TestCase):
         # confirm all expected messages are sent
         expected_messages = [
             "recognizer_loop:utterance",  # no session
-            f"{self.skill_id}:ScheduleIntent",  # intent trigger
-            "mycroft.skill.handler.start",  # intent code start
-
-            "intent.service.skills.activate",  # request (from workshop)
             "intent.service.skills.activated",  # response (from core)
             f"{self.skill_id}.activate",  # skill callback
-            "ovos.session.update_default",  # session update (active skill list ync)
-
+            f"{self.skill_id}:ScheduleIntent",  # intent trigger
+            "mycroft.skill.handler.start",  # intent code start
             "enclosure.active_skill",
             "speak",
             "mycroft.scheduler.schedule_event",
@@ -72,17 +68,20 @@ class TestSched(TestCase):
 
         self.assertEqual(len(expected_messages), len(messages))
 
-        mtypes = [m.msg_type for m in messages]
-        for m in expected_messages:
-            self.assertTrue(m in mtypes)
+        for idx, m in enumerate(messages):
+            self.assertEqual(m.msg_type, expected_messages[idx])
 
         # verify that source and destination are swapped after intent trigger
-        self.assertEqual(messages[1].msg_type, f"{self.skill_id}:ScheduleIntent")
+        self.assertEqual(messages[3].msg_type, f"{self.skill_id}:ScheduleIntent")
         for m in messages:
-            if m.msg_type in ["recognizer_loop:utterance", "ovos.session.update_default"]:
+            # messages FOR ovos-core
+            if m.msg_type in ["recognizer_loop:utterance",
+                              "ovos.session.update_default"]:
                 self.assertEqual(messages[0].context["source"], "A")
                 self.assertEqual(messages[0].context["destination"], "B")
+            # messages FROM ovos-core
             else:
+                print(m.serialize())
                 self.assertEqual(m.context["source"], "B")
                 self.assertEqual(m.context["destination"], "A")
 

--- a/test/end2end/routing/test_session.py
+++ b/test/end2end/routing/test_session.py
@@ -50,12 +50,10 @@ class TestRouting(TestCase):
         # confirm all expected messages are sent
         expected_messages = [
             "recognizer_loop:utterance",  # no session
-            f"{self.skill_id}:HelloWorldIntent",
-            "mycroft.skill.handler.start",
-            "intent.service.skills.activate",
             "intent.service.skills.activated",
             f"{self.skill_id}.activate",
-            "ovos.session.update_default",
+            f"{self.skill_id}:HelloWorldIntent",
+            "mycroft.skill.handler.start",
             "enclosure.active_skill",
             "speak",
             "mycroft.skill.handler.complete",
@@ -66,9 +64,8 @@ class TestRouting(TestCase):
 
         self.assertEqual(len(expected_messages), len(messages))
 
-        mtypes = [m.msg_type for m in messages]
-        for m in expected_messages:
-            self.assertTrue(m in mtypes)
+        for idx, m in enumerate(messages):
+            self.assertEqual(m.msg_type, expected_messages[idx])
 
         # verify that "session" is injected
         # (missing in utterance message) and kept in all messages
@@ -76,7 +73,7 @@ class TestRouting(TestCase):
             self.assertEqual(m.context["session"]["session_id"], "default")
 
         # verify that source and destination are swapped after intent trigger
-        self.assertEqual(messages[1].msg_type, f"{self.skill_id}:HelloWorldIntent")
+        self.assertEqual(messages[3].msg_type, f"{self.skill_id}:HelloWorldIntent")
         for m in messages:
             if m.msg_type in ["recognizer_loop:utterance", "ovos.session.update_default"]:
                 self.assertEqual(messages[0].context["source"], "A")

--- a/test/end2end/session/test_blacklist.py
+++ b/test/end2end/session/test_blacklist.py
@@ -58,11 +58,10 @@ class TestSessions(TestCase):
         expected_messages = [
             "recognizer_loop:utterance",
             # skill selected
-            f"{self.skill_id}:HelloWorldIntent",
-            "mycroft.skill.handler.start",
-            "intent.service.skills.activate",
             "intent.service.skills.activated",
             f"{self.skill_id}.activate",
+            f"{self.skill_id}:HelloWorldIntent",
+            "mycroft.skill.handler.start",
             # skill code executing
             "enclosure.active_skill",
             "speak",
@@ -76,7 +75,7 @@ class TestSessions(TestCase):
             self.assertEqual(m.msg_type, expected_messages[idx])
 
         # sanity check correct intent triggered
-        self.assertEqual(messages[7].data["meta"]["dialog"], "hello.world")
+        self.assertEqual(messages[-3].data["meta"]["dialog"], "hello.world")
 
         ########################################
         # skill in blacklist
@@ -176,12 +175,11 @@ class TestOCP(TestCase):
         expected_messages = [
             "recognizer_loop:utterance",
             "ovos.common_play.status",
-            "intent.service.skills.activate",
             "intent.service.skills.activated",
             "ovos.common_play.activate",
+            "ocp:play",
             "enclosure.active_skill",
             "speak",
-            "ocp:play",
             "ovos.common_play.search.start",
             "enclosure.mouth.think",
             "ovos.common_play.search.stop",  # any ongoing previous search
@@ -222,12 +220,11 @@ class TestOCP(TestCase):
         expected_messages = [
             "recognizer_loop:utterance",
             "ovos.common_play.status",
-            "intent.service.skills.activate",
             "intent.service.skills.activated",
             "ovos.common_play.activate",
+            "ocp:play",
             "enclosure.active_skill",
             "speak",
-            "ocp:play",
             "ovos.common_play.search.start",
             "enclosure.mouth.think",
             "ovos.common_play.search.stop",  # any ongoing previous search
@@ -267,12 +264,11 @@ class TestOCP(TestCase):
         expected_messages = [
             "recognizer_loop:utterance",
             "ovos.common_play.status",
-            "intent.service.skills.activate",
             "intent.service.skills.activated",
             "ovos.common_play.activate",
+            "ocp:play",
             "enclosure.active_skill",
             "speak",
-            "ocp:play",
             "ovos.common_play.search.start",
             "enclosure.mouth.think",
             "ovos.common_play.search.stop",  # any ongoing previous search

--- a/test/end2end/session/test_converse.py
+++ b/test/end2end/session/test_converse.py
@@ -59,14 +59,12 @@ class TestSessions(TestCase):
         # confirm all expected messages are sent
         expected_messages = [
             "recognizer_loop:utterance",  # no session
+            "intent.service.skills.activated",
+            f"{self.skill_id}.activate",
             # skill selected
             f"{self.skill_id}:converse_off.intent",
             # skill triggering
             "mycroft.skill.handler.start",
-            "intent.service.skills.activate",
-            "intent.service.skills.activated",
-            f"{self.skill_id}.activate",
-            "ovos.session.update_default",
             # intent code executing
             "enclosure.active_skill",
             "speak",
@@ -88,31 +86,22 @@ class TestSessions(TestCase):
             self.assertEqual(m.context["session"]["session_id"], "default")
             self.assertEqual(m.context["lang"], "en-us")
 
+        # verify skill is activated
+        self.assertEqual(messages[1].msg_type, "intent.service.skills.activated")
+        self.assertEqual(messages[1].data["skill_id"], self.skill_id)
+        self.assertEqual(messages[2].msg_type, f"{self.skill_id}.activate")
         # verify intent triggers
-        self.assertEqual(messages[1].msg_type, f"{self.skill_id}:converse_off.intent")
-        # verify skill_id is now present in every message.context
+        self.assertEqual(messages[3].msg_type, f"{self.skill_id}:converse_off.intent")
+        # verify skill_id is present in every message.context
         for m in messages[1:]:
             self.assertEqual(m.context["skill_id"], self.skill_id)
 
-        self.assertEqual(messages[2].msg_type, "mycroft.skill.handler.start")
-        self.assertEqual(messages[2].data["name"], "TestAbortSkill.handle_converse_off")
-        # verify skill is activated
-        self.assertEqual(messages[3].msg_type, "intent.service.skills.activate")
-        self.assertEqual(messages[3].data["skill_id"], self.skill_id)
-        self.assertEqual(messages[4].msg_type, "intent.service.skills.activated")
-        self.assertEqual(messages[4].data["skill_id"], self.skill_id)
-        self.assertEqual(messages[5].msg_type, f"{self.skill_id}.activate")
-        self.assertEqual(messages[6].msg_type, "ovos.session.update_default")
         # verify intent execution
-        self.assertEqual(messages[7].msg_type, "enclosure.active_skill")
-        self.assertEqual(messages[7].data["skill_id"], self.skill_id)
-        self.assertEqual(messages[8].msg_type, "speak")
-        self.assertEqual(messages[8].data["lang"], "en-us")
-        self.assertFalse(messages[8].data["expect_response"])
-        self.assertEqual(messages[8].data["meta"]["skill"], self.skill_id)
-        self.assertEqual(messages[9].msg_type, "mycroft.skill.handler.complete")
-        self.assertEqual(messages[9].data["name"], "TestAbortSkill.handle_converse_off")
-        self.assertEqual(messages[10].msg_type, "ovos.utterance.handled")
+        self.assertEqual(messages[4].msg_type, "mycroft.skill.handler.start")
+        self.assertEqual(messages[4].data["name"], "TestAbortSkill.handle_converse_off")
+        self.assertEqual(messages[-3].msg_type, "mycroft.skill.handler.complete")
+        self.assertEqual(messages[-3].data["name"], "TestAbortSkill.handle_converse_off")
+        self.assertEqual(messages[-2].msg_type, "ovos.utterance.handled")
         # verify default session is now updated
         self.assertEqual(messages[-1].msg_type, "ovos.session.update_default")
         self.assertEqual(messages[-1].data["session_data"]["session_id"], "default")
@@ -143,13 +132,10 @@ class TestSessions(TestCase):
             f"{self.skill_id}.converse.request",
             "skill.converse.response",  # does not want to converse
             # skill selected
-            f"{self.other_skill_id}:HelloWorldIntent",
-            "mycroft.skill.handler.start",
-            # skill activated
-            "intent.service.skills.activate",
             "intent.service.skills.activated",
             f"{self.other_skill_id}.activate",
-            "ovos.session.update_default",
+            f"{self.other_skill_id}:HelloWorldIntent",
+            "mycroft.skill.handler.start",
             # skill executing
             "enclosure.active_skill",
             "speak",
@@ -187,35 +173,25 @@ class TestSessions(TestCase):
         self.assertEqual(messages[4].data["skill_id"], self.skill_id)
         self.assertFalse(messages[4].data["result"])  # does not want to converse
 
+        # verify skill is activated
+        self.assertEqual(messages[5].msg_type, "intent.service.skills.activated")
+        self.assertEqual(messages[5].data["skill_id"], self.other_skill_id)
+        self.assertEqual(messages[6].msg_type, f"{self.other_skill_id}.activate")
         # verify intent triggers
-        self.assertEqual(messages[5].msg_type, f"{self.other_skill_id}:HelloWorldIntent")
-        # verify skill_id is now present in every message.context
+        self.assertEqual(messages[7].msg_type, f"{self.other_skill_id}:HelloWorldIntent")
+        # verify skill_id is present in every message.context
         for m in messages[5:]:
             self.assertEqual(m.context["skill_id"], self.other_skill_id)
 
-        self.assertEqual(messages[6].msg_type, "mycroft.skill.handler.start")
-        self.assertEqual(messages[6].data["name"], "HelloWorldSkill.handle_hello_world_intent")
-
-        # verify skill is activated
-        self.assertEqual(messages[7].msg_type, "intent.service.skills.activate")
-        self.assertEqual(messages[7].data["skill_id"], self.other_skill_id)
-        self.assertEqual(messages[8].msg_type, "intent.service.skills.activated")
-        self.assertEqual(messages[8].data["skill_id"], self.other_skill_id)
-        self.assertEqual(messages[9].msg_type, f"{self.other_skill_id}.activate")
-        self.assertEqual(messages[10].msg_type, "ovos.session.update_default")
+        self.assertEqual(messages[8].msg_type, "mycroft.skill.handler.start")
+        self.assertEqual(messages[8].data["name"], "HelloWorldSkill.handle_hello_world_intent")
 
         # verify intent execution
-        self.assertEqual(messages[11].msg_type, "enclosure.active_skill")
-        self.assertEqual(messages[11].data["skill_id"], self.other_skill_id)
-        self.assertEqual(messages[12].msg_type, "speak")
-        self.assertEqual(messages[12].data["lang"], "en-us")
-        self.assertFalse(messages[12].data["expect_response"])
-        self.assertEqual(messages[12].data["meta"]["skill"], self.other_skill_id)
-        self.assertEqual(messages[13].msg_type, "mycroft.skill.handler.complete")
-        self.assertEqual(messages[13].data["name"], "HelloWorldSkill.handle_hello_world_intent")
+        self.assertEqual(messages[-3].msg_type, "mycroft.skill.handler.complete")
+        self.assertEqual(messages[-3].data["name"], "HelloWorldSkill.handle_hello_world_intent")
 
         # verify default session is now updated
-        self.assertEqual(messages[14].msg_type, "ovos.utterance.handled")
+        self.assertEqual(messages[-2].msg_type, "ovos.utterance.handled")
         self.assertEqual(messages[-1].msg_type, "ovos.session.update_default")
         self.assertEqual(messages[-1].data["session_data"]["session_id"], "default")
         # test deserialization of payload
@@ -249,11 +225,8 @@ class TestSessions(TestCase):
             f"{self.skill_id}.converse.request",
             "skill.converse.response",  # does not want to converse
             # skill selected
-            "intent.service.skills.activate",
             "intent.service.skills.activated",
             f"{self.skill_id}.activate",
-            "ovos.session.update_default",
-
             f"{self.skill_id}:converse_on.intent",
             # skill executing
             "mycroft.skill.handler.start",
@@ -294,35 +267,26 @@ class TestSessions(TestCase):
         self.assertEqual(messages[6].data["skill_id"], self.skill_id)
         self.assertFalse(messages[6].data["result"])  # do not want to converse
 
+        # verify skill is activated by intent service (intent pipeline matched)
+        self.assertEqual(messages[7].msg_type, "intent.service.skills.activated")
+        self.assertEqual(messages[7].data["skill_id"], self.skill_id)
+        self.assertEqual(messages[8].msg_type, f"{self.skill_id}.activate")
+
         # verify intent triggers
-        self.assertEqual(messages[7].msg_type, f"{self.skill_id}:converse_on.intent")
+        self.assertEqual(messages[9].msg_type, f"{self.skill_id}:converse_on.intent")
         # verify skill_id is now present in every message.context
         for m in messages[7:]:
             self.assertEqual(m.context["skill_id"], self.skill_id)
 
         # verify intent execution
-        self.assertEqual(messages[8].msg_type, "mycroft.skill.handler.start")
-        self.assertEqual(messages[8].data["name"], "TestAbortSkill.handle_converse_on")
+        self.assertEqual(messages[10].msg_type, "mycroft.skill.handler.start")
+        self.assertEqual(messages[10].data["name"], "TestAbortSkill.handle_converse_on")
 
-        # verify skill is activated by intent service (intent pipeline matched)
-        self.assertEqual(messages[9].msg_type, "intent.service.skills.activate")
-        self.assertEqual(messages[9].data["skill_id"], self.skill_id)
-        self.assertEqual(messages[10].msg_type, "intent.service.skills.activated")
-        self.assertEqual(messages[10].data["skill_id"], self.skill_id)
-        self.assertEqual(messages[11].msg_type, f"{self.skill_id}.activate")
-        self.assertEqual(messages[12].msg_type, "ovos.session.update_default")
-
-        self.assertEqual(messages[13].msg_type, "enclosure.active_skill")
-        self.assertEqual(messages[13].data["skill_id"], self.skill_id)
-        self.assertEqual(messages[14].msg_type, "speak")
-        self.assertEqual(messages[14].data["lang"], "en-us")
-        self.assertFalse(messages[14].data["expect_response"])
-        self.assertEqual(messages[14].data["meta"]["skill"], self.skill_id)
-        self.assertEqual(messages[15].msg_type, "mycroft.skill.handler.complete")
-        self.assertEqual(messages[15].data["name"], "TestAbortSkill.handle_converse_on")
+        self.assertEqual(messages[-3].msg_type, "mycroft.skill.handler.complete")
+        self.assertEqual(messages[-3].data["name"], "TestAbortSkill.handle_converse_on")
 
         # verify default session is now updated
-        self.assertEqual(messages[16].msg_type, "ovos.utterance.handled")
+        self.assertEqual(messages[-2].msg_type, "ovos.utterance.handled")
         self.assertEqual(messages[-1].msg_type, "ovos.session.update_default")
         self.assertEqual(messages[-1].data["session_data"]["session_id"], "default")
         # test deserialization of payload
@@ -507,13 +471,11 @@ class TestSessions(TestCase):
         # confirm all expected messages are sent
         expected_messages = [
             "recognizer_loop:utterance",  # no session
+            "intent.service.skills.activated",
+            f"{self.skill_id}.activate",
             "ovos-tskill-abort.openvoiceos:deactivate.intent",
             # skill selected
             "mycroft.skill.handler.start",
-            "intent.service.skills.activate",
-            "intent.service.skills.activated",
-            f"{self.skill_id}.activate",
-            "ovos.session.update_default",
             # intent code
             "intent.service.skills.deactivate",
             "intent.service.skills.deactivated",

--- a/test/end2end/session/test_ocp.py
+++ b/test/end2end/session/test_ocp.py
@@ -58,12 +58,11 @@ class TestOCPPipeline(TestCase):
         expected_messages = [
             "recognizer_loop:utterance",
             "ovos.common_play.status",
-            "intent.service.skills.activate",
             "intent.service.skills.activated",
             "ovos.common_play.activate",
+            "ocp:play",
             "enclosure.active_skill",
             "speak",
-            "ocp:play",
             "ovos.common_play.search.start",
             "enclosure.mouth.think",
             "ovos.common_play.search.stop",  # any ongoing previous search
@@ -128,12 +127,11 @@ class TestOCPPipeline(TestCase):
             "ovos.common_play.status",
             "ovos.common_play.SEI.get",  # request player info
             # no response
-            "intent.service.skills.activate",
             "intent.service.skills.activated",
             "ovos.common_play.activate",
+            "ocp:play",
             "enclosure.active_skill",
             "speak",
-            "ocp:play",
             "ovos.common_play.search.start",
             "enclosure.mouth.think",
             "ovos.common_play.search.stop",  # any ongoing previous search
@@ -182,12 +180,11 @@ class TestOCPPipeline(TestCase):
             "ovos.common_play.status",
             "ovos.common_play.SEI.get",  # request player info
             "ovos.common_play.SEI.get.response",  # OCP response
-            "intent.service.skills.activate",
             "intent.service.skills.activated",
             "ovos.common_play.activate",
+            "ocp:play",
             "enclosure.active_skill",
             "speak",
-            "ocp:play",
             "ovos.common_play.search.start",
             "enclosure.mouth.think",
             "ovos.common_play.search.stop",  # any ongoing previous search
@@ -269,12 +266,11 @@ class TestOCPPipeline(TestCase):
         expected_messages = [
             "recognizer_loop:utterance",
             "ovos.common_play.status",
-            "intent.service.skills.activate",
             "intent.service.skills.activated",
             "ovos.common_play.activate",
+            "ocp:play",
             "enclosure.active_skill",
             "speak",
-            "ocp:play",
             "ovos.common_play.search.start",
             "enclosure.mouth.think",
             "ovos.common_play.search.stop",  # any ongoing previous search
@@ -344,12 +340,11 @@ class TestOCPPipeline(TestCase):
         expected_messages = [
             "recognizer_loop:utterance",
             "ovos.common_play.status",
-            "intent.service.skills.activate",
             "intent.service.skills.activated",
             "ovos.common_play.activate",
+            "ocp:play",
             "enclosure.active_skill",
             "speak",
-            "ocp:play",
             "ovos.common_play.search.start",
             "enclosure.mouth.think",
             "ovos.common_play.search.stop",  # any ongoing previous search
@@ -418,12 +413,11 @@ class TestOCPPipeline(TestCase):
         expected_messages = [
             "recognizer_loop:utterance",
             "ovos.common_play.status",
-            "intent.service.skills.activate",
             "intent.service.skills.activated",
             "ovos.common_play.activate",
+            "ocp:play",
             "enclosure.active_skill",
             "speak",
-            "ocp:play",
             "ovos.common_play.search.start",
             "enclosure.mouth.think",
             "ovos.common_play.search.stop",  # any ongoing previous search
@@ -494,12 +488,11 @@ class TestOCPPipeline(TestCase):
         expected_messages = [
             "recognizer_loop:utterance",
             "ovos.common_play.status",
-            "intent.service.skills.activate",
             "intent.service.skills.activated",
             "ovos.common_play.activate",
+            "ocp:play",
             "enclosure.active_skill",
             "speak",
-            "ocp:play",
             "ovos.common_play.search.start",
             "enclosure.mouth.think",
             "ovos.common_play.search.stop",  # any ongoing previous search
@@ -572,7 +565,6 @@ class TestOCPPipeline(TestCase):
         expected_messages = [
             "recognizer_loop:utterance",
             "ovos.common_play.status",
-            "intent.service.skills.activate",
             "intent.service.skills.activated",
             "ovos.common_play.activate",
             "ocp:pause",
@@ -632,7 +624,6 @@ class TestOCPPipeline(TestCase):
         expected_messages = [
             "recognizer_loop:utterance",
             "ovos.common_play.status",
-            "intent.service.skills.activate",
             "intent.service.skills.activated",
             "ovos.common_play.activate",
             "ocp:resume",
@@ -692,7 +683,6 @@ class TestOCPPipeline(TestCase):
         expected_messages = [
             "recognizer_loop:utterance",
             "ovos.common_play.status",
-            "intent.service.skills.activate",
             "intent.service.skills.activated",
             "ovos.common_play.activate",
             "ocp:media_stop",
@@ -752,7 +742,6 @@ class TestOCPPipeline(TestCase):
         expected_messages = [
             "recognizer_loop:utterance",
             "ovos.common_play.status",
-            "intent.service.skills.activate",
             "intent.service.skills.activated",
             "ovos.common_play.activate",
             "ocp:next",
@@ -807,7 +796,6 @@ class TestOCPPipeline(TestCase):
         expected_messages = [
             "recognizer_loop:utterance",
             "ovos.common_play.status",
-            "intent.service.skills.activate",
             "intent.service.skills.activated",
             "ovos.common_play.activate",
             "ocp:prev",
@@ -861,7 +849,6 @@ class TestOCPPipeline(TestCase):
         expected_messages = [
             "recognizer_loop:utterance",
             "ovos.common_play.status",
-            "intent.service.skills.activate",
             "intent.service.skills.activated",
             "ovos.common_play.activate",
             "ocp:pause",
@@ -916,7 +903,6 @@ class TestOCPPipeline(TestCase):
         expected_messages = [
             "recognizer_loop:utterance",
             "ovos.common_play.status",
-            "intent.service.skills.activate",
             "intent.service.skills.activated",
             "ovos.common_play.activate",
             "ocp:resume",
@@ -970,7 +956,6 @@ class TestOCPPipeline(TestCase):
         expected_messages = [
             "recognizer_loop:utterance",
             "ovos.common_play.status",
-            "intent.service.skills.activate",
             "intent.service.skills.activated",
             "ovos.common_play.activate",
             "ocp:media_stop",
@@ -1025,7 +1010,6 @@ class TestOCPPipeline(TestCase):
         expected_messages = [
             "recognizer_loop:utterance",
             "ovos.common_play.status",
-            "intent.service.skills.activate",
             "intent.service.skills.activated",
             "ovos.common_play.activate",
             "ocp:next",
@@ -1079,7 +1063,6 @@ class TestOCPPipeline(TestCase):
         expected_messages = [
             "recognizer_loop:utterance",
             "ovos.common_play.status",
-            "intent.service.skills.activate",
             "intent.service.skills.activated",
             "ovos.common_play.activate",
             "ocp:prev",
@@ -1187,6 +1170,8 @@ class TestOCPPipeline(TestCase):
         # confirm all expected messages are sent
         expected_messages = [
             "recognizer_loop:utterance",
+            "intent.service.skills.activated",
+            "ovos.common_play.activate",
             "ocp:legacy_cps",
             # legacy cps api
             "play:query",
@@ -1247,6 +1232,8 @@ class TestLegacyCPSPipeline(TestCase):
         # confirm all expected messages are sent
         expected_messages = [
             "recognizer_loop:utterance",
+            "intent.service.skills.activated",
+            "ovos.common_play.activate",
             "ocp:legacy_cps",
             # legacy cps api
             "play:query",

--- a/test/end2end/session/test_sched.py
+++ b/test/end2end/session/test_sched.py
@@ -48,12 +48,10 @@ class TestSessions(TestCase):
         # confirm all expected messages are sent
         expected_messages = [
             "recognizer_loop:utterance",
-            f"{self.skill_id}:ScheduleIntent",
-            "mycroft.skill.handler.start",
-            "intent.service.skills.activate",
             "intent.service.skills.activated",
             f"{self.skill_id}.activate",
-            "ovos.session.update_default",
+            f"{self.skill_id}:ScheduleIntent",
+            "mycroft.skill.handler.start",
             "enclosure.active_skill",
             "speak",
             "mycroft.scheduler.schedule_event",
@@ -78,60 +76,57 @@ class TestSessions(TestCase):
             self.assertEqual(m.context["session"]["session_id"], "default")
             self.assertEqual(m.context["lang"], "en-us")
 
-        # verify intent triggers
-        self.assertEqual(messages[1].msg_type, f"{self.skill_id}:ScheduleIntent")
-        self.assertEqual(messages[1].data["intent_type"], f"{self.skill_id}:ScheduleIntent")
         # verify skill_id is now present in every message.context
+        self.assertEqual(messages[1].msg_type, "intent.service.skills.activated")
+        self.assertEqual(messages[1].data["skill_id"], self.skill_id)
+        self.assertEqual(messages[2].msg_type, f"{self.skill_id}.activate")
         for m in messages[1:]:
             self.assertEqual(m.context["skill_id"], self.skill_id)
 
+        # verify intent triggers
+        self.assertEqual(messages[3].msg_type, f"{self.skill_id}:ScheduleIntent")
+        self.assertEqual(messages[3].data["intent_type"], f"{self.skill_id}:ScheduleIntent")
+
         # verify intent execution
-        self.assertEqual(messages[2].msg_type, "mycroft.skill.handler.start")
-        self.assertEqual(messages[2].data["name"], "ScheduleSkill.handle_sched_intent")
+        self.assertEqual(messages[4].msg_type, "mycroft.skill.handler.start")
+        self.assertEqual(messages[4].data["name"], "ScheduleSkill.handle_sched_intent")
 
-        self.assertEqual(messages[3].msg_type, "intent.service.skills.activate")
-        self.assertEqual(messages[3].data["skill_id"], self.skill_id)
-        self.assertEqual(messages[4].msg_type, "intent.service.skills.activated")
-        self.assertEqual(messages[4].data["skill_id"], self.skill_id)
-        self.assertEqual(messages[5].msg_type, f"{self.skill_id}.activate")
-        self.assertEqual(messages[6].msg_type, "ovos.session.update_default")
-
-        self.assertEqual(messages[7].msg_type, "enclosure.active_skill")
-        self.assertEqual(messages[7].data["skill_id"], self.skill_id)
-        self.assertEqual(messages[8].msg_type, "speak")
-        self.assertEqual(messages[8].data["lang"], "en-us")
-        self.assertFalse(messages[8].data["expect_response"])
-        self.assertEqual(messages[8].data["meta"]["dialog"], "done")
-        self.assertEqual(messages[8].data["meta"]["skill"], self.skill_id)
-        self.assertEqual(messages[9].msg_type, "mycroft.scheduler.schedule_event")
-        self.assertEqual(messages[10].msg_type, "mycroft.skill.handler.complete")
-        self.assertEqual(messages[10].data["name"], "ScheduleSkill.handle_sched_intent")
+        self.assertEqual(messages[5].msg_type, "enclosure.active_skill")
+        self.assertEqual(messages[5].data["skill_id"], self.skill_id)
+        self.assertEqual(messages[6].msg_type, "speak")
+        self.assertEqual(messages[6].data["lang"], "en-us")
+        self.assertFalse(messages[6].data["expect_response"])
+        self.assertEqual(messages[6].data["meta"]["dialog"], "done")
+        self.assertEqual(messages[6].data["meta"]["skill"], self.skill_id)
+        self.assertEqual(messages[7].msg_type, "mycroft.scheduler.schedule_event")
+        self.assertEqual(messages[8].msg_type, "mycroft.skill.handler.complete")
+        self.assertEqual(messages[8].data["name"], "ScheduleSkill.handle_sched_intent")
 
         # verify default session is now updated
-        self.assertEqual(messages[12].msg_type, "ovos.session.update_default")
-        self.assertEqual(messages[12].data["session_data"]["session_id"], "default")
+        self.assertEqual(messages[10].msg_type, "ovos.session.update_default")
+        self.assertEqual(messages[10].data["session_data"]["session_id"], "default")
         # test deserialization of payload
-        sess = Session.deserialize(messages[12].data["session_data"])
+        sess = Session.deserialize(messages[10].data["session_data"])
         self.assertEqual(sess.session_id, "default")
 
         # test that active skills list has been updated
         self.assertEqual(sess.active_skills[0][0], self.skill_id)
-        self.assertEqual(messages[12].data["session_data"]["active_skills"][0][0], self.skill_id)
+        self.assertEqual(messages[10].data["session_data"]["active_skills"][0][0], self.skill_id)
 
         # ensure context in triggered event is the same from message that triggered the intent
-        self.assertEqual(messages[4].msg_type, "intent.service.skills.activated")
-        intent_context = messages[4].context  # when skill added to active list (last context change)
+        self.assertEqual(messages[1].msg_type, "intent.service.skills.activated")
+        intent_context = messages[1].context  # when skill added to active list (last context change)
 
-        self.assertEqual(messages[13].msg_type, "skill-ovos-schedule.openvoiceos:my_event")
+        self.assertEqual(messages[11].msg_type, "skill-ovos-schedule.openvoiceos:my_event")
+        self.assertEqual(messages[11].context, intent_context)
+        self.assertEqual(messages[12].msg_type, "enclosure.active_skill")
+        self.assertEqual(messages[12].context, intent_context)
+        self.assertEqual(messages[13].msg_type, "speak")
+        self.assertEqual(messages[13].data["lang"], "en-us")
+        self.assertFalse(messages[13].data["expect_response"])
+        self.assertEqual(messages[13].data["meta"]["dialog"], "trigger")
+        self.assertEqual(messages[13].data["meta"]["skill"], self.skill_id)
         self.assertEqual(messages[13].context, intent_context)
-        self.assertEqual(messages[14].msg_type, "enclosure.active_skill")
-        self.assertEqual(messages[14].context, intent_context)
-        self.assertEqual(messages[15].msg_type, "speak")
-        self.assertEqual(messages[15].data["lang"], "en-us")
-        self.assertFalse(messages[15].data["expect_response"])
-        self.assertEqual(messages[15].data["meta"]["dialog"], "trigger")
-        self.assertEqual(messages[15].data["meta"]["skill"], self.skill_id)
-        self.assertEqual(messages[15].context, intent_context)
 
     def test_explicit_session(self):
         SessionManager.sessions = {}
@@ -172,11 +167,10 @@ class TestSessions(TestCase):
         # confirm all expected messages are sent
         expected_messages = [
             "recognizer_loop:utterance",
-            f"{self.skill_id}:ScheduleIntent",
-            "mycroft.skill.handler.start",
-            "intent.service.skills.activate",
             "intent.service.skills.activated",
             f"{self.skill_id}.activate",
+            f"{self.skill_id}:ScheduleIntent",
+            "mycroft.skill.handler.start",
             "enclosure.active_skill",
             "speak",
             "mycroft.scheduler.schedule_event",
@@ -199,49 +193,47 @@ class TestSessions(TestCase):
         for m in messages:
             self.assertEqual(m.context["session"]["session_id"], sess.session_id)
 
-        # verify intent triggers
-        self.assertEqual(messages[1].msg_type, f"{self.skill_id}:ScheduleIntent")
-        self.assertEqual(messages[1].data["intent_type"], f"{self.skill_id}:ScheduleIntent")
+        # verify skill is activated
+        self.assertEqual(messages[1].msg_type, "intent.service.skills.activated")
+        self.assertEqual(messages[1].data["skill_id"], self.skill_id)
+        self.assertEqual(messages[2].msg_type, f"{self.skill_id}.activate")
+        self.assertEqual(messages[2].msg_type, f"{self.skill_id}.activate")
         # verify skill_id is now present in every message.context
         for m in messages[1:]:
             self.assertEqual(m.context["skill_id"], self.skill_id)
+        # verify intent triggers
+        self.assertEqual(messages[3].msg_type, f"{self.skill_id}:ScheduleIntent")
+        self.assertEqual(messages[3].data["intent_type"], f"{self.skill_id}:ScheduleIntent")
 
-        # verify skill is activated
-        self.assertEqual(messages[2].msg_type, "mycroft.skill.handler.start")
-        self.assertEqual(messages[2].data["name"], "ScheduleSkill.handle_sched_intent")
-        self.assertEqual(messages[3].msg_type, "intent.service.skills.activate")
-        self.assertEqual(messages[3].data["skill_id"], self.skill_id)
-        self.assertEqual(messages[4].msg_type, "intent.service.skills.activated")
-        self.assertEqual(messages[4].data["skill_id"], self.skill_id)
-        self.assertEqual(messages[5].msg_type, f"{self.skill_id}.activate")
-        self.assertEqual(messages[5].msg_type, f"{self.skill_id}.activate")
+        self.assertEqual(messages[4].msg_type, "mycroft.skill.handler.start")
+        self.assertEqual(messages[4].data["name"], "ScheduleSkill.handle_sched_intent")
 
         # verify intent execution
-        self.assertEqual(messages[6].msg_type, "enclosure.active_skill")
-        self.assertEqual(messages[6].data["skill_id"], self.skill_id)
-        self.assertEqual(messages[7].msg_type, "speak")
-        self.assertEqual(messages[7].data["lang"], "en-us")
-        self.assertFalse(messages[7].data["expect_response"])
-        self.assertEqual(messages[7].data["meta"]["dialog"], "done")
-        self.assertEqual(messages[7].data["meta"]["skill"], self.skill_id)
-        self.assertEqual(messages[8].msg_type, "mycroft.scheduler.schedule_event")
-        self.assertEqual(messages[9].msg_type, "mycroft.skill.handler.complete")
-        self.assertEqual(messages[9].data["name"], "ScheduleSkill.handle_sched_intent")
+        self.assertEqual(messages[5].msg_type, "enclosure.active_skill")
+        self.assertEqual(messages[5].data["skill_id"], self.skill_id)
+        self.assertEqual(messages[6].msg_type, "speak")
+        self.assertEqual(messages[6].data["lang"], "en-us")
+        self.assertFalse(messages[6].data["expect_response"])
+        self.assertEqual(messages[6].data["meta"]["dialog"], "done")
+        self.assertEqual(messages[6].data["meta"]["skill"], self.skill_id)
+        self.assertEqual(messages[7].msg_type, "mycroft.scheduler.schedule_event")
+        self.assertEqual(messages[8].msg_type, "mycroft.skill.handler.complete")
+        self.assertEqual(messages[8].data["name"], "ScheduleSkill.handle_sched_intent")
 
         # ensure context in triggered event is the same from message that triggered the intent
-        self.assertEqual(messages[4].msg_type, "intent.service.skills.activated")
-        intent_context = messages[4].context  # when skill added to active list (last context change)
+        self.assertEqual(messages[1].msg_type, "intent.service.skills.activated")
+        intent_context = messages[1].context  # when skill added to active list (last context change)
 
-        self.assertEqual(messages[11].msg_type, "skill-ovos-schedule.openvoiceos:my_event")
+        self.assertEqual(messages[10].msg_type, "skill-ovos-schedule.openvoiceos:my_event")
+        self.assertEqual(messages[10].context, intent_context)
+        self.assertEqual(messages[11].msg_type, "enclosure.active_skill")
         self.assertEqual(messages[11].context, intent_context)
-        self.assertEqual(messages[12].msg_type, "enclosure.active_skill")
+        self.assertEqual(messages[12].msg_type, "speak")
+        self.assertEqual(messages[12].data["lang"], "en-us")
+        self.assertFalse(messages[12].data["expect_response"])
+        self.assertEqual(messages[12].data["meta"]["dialog"], "trigger")
+        self.assertEqual(messages[12].data["meta"]["skill"], self.skill_id)
         self.assertEqual(messages[12].context, intent_context)
-        self.assertEqual(messages[13].msg_type, "speak")
-        self.assertEqual(messages[13].data["lang"], "en-us")
-        self.assertFalse(messages[13].data["expect_response"])
-        self.assertEqual(messages[13].data["meta"]["dialog"], "trigger")
-        self.assertEqual(messages[13].data["meta"]["skill"], self.skill_id)
-        self.assertEqual(messages[13].context, intent_context)
 
     def tearDown(self) -> None:
         self.core.stop()

--- a/test/end2end/session/test_session.py
+++ b/test/end2end/session/test_session.py
@@ -52,12 +52,10 @@ class TestSessions(TestCase):
         # confirm all expected messages are sent
         expected_messages = [
             "recognizer_loop:utterance",  # no session
-            f"{self.skill_id}:HelloWorldIntent",
-            "mycroft.skill.handler.start",
-            "intent.service.skills.activate",
             "intent.service.skills.activated",
             f"{self.skill_id}.activate",
-            "ovos.session.update_default",
+            f"{self.skill_id}:HelloWorldIntent",
+            "mycroft.skill.handler.start",
             "enclosure.active_skill",
             "speak",
             "mycroft.skill.handler.complete",
@@ -77,34 +75,21 @@ class TestSessions(TestCase):
             self.assertEqual(m.context["session"]["session_id"], "default")
             self.assertEqual(m.context["lang"], "en-us")
 
-        # verify intent triggers
-        self.assertEqual(messages[1].msg_type, f"{self.skill_id}:HelloWorldIntent")
-        self.assertEqual(messages[1].data["intent_type"], f"{self.skill_id}:HelloWorldIntent")
+        # verify skill is activated
+        self.assertEqual(messages[1].msg_type, "intent.service.skills.activated")
+        self.assertEqual(messages[1].data["skill_id"], self.skill_id)
+        self.assertEqual(messages[2].msg_type, f"{self.skill_id}.activate")
         # verify skill_id is now present in every message.context
         for m in messages[1:]:
             self.assertEqual(m.context["skill_id"], self.skill_id)
-
-        # verify intent
-        self.assertEqual(messages[2].msg_type, "mycroft.skill.handler.start")
-        self.assertEqual(messages[2].data["name"], "HelloWorldSkill.handle_hello_world_intent")
-        # verify skill is activated
-        self.assertEqual(messages[3].msg_type, "intent.service.skills.activate")
-        self.assertEqual(messages[3].data["skill_id"], self.skill_id)
-        self.assertEqual(messages[4].msg_type, "intent.service.skills.activated")
-        self.assertEqual(messages[4].data["skill_id"], self.skill_id)
-        self.assertEqual(messages[5].msg_type, f"{self.skill_id}.activate")
-        self.assertEqual(messages[6].msg_type, "ovos.session.update_default")
-        # verify intent code execution
-        self.assertEqual(messages[7].msg_type, "enclosure.active_skill")
-        self.assertEqual(messages[7].data["skill_id"], self.skill_id)
-        self.assertEqual(messages[8].msg_type, "speak")
-        self.assertEqual(messages[8].data["lang"], "en-us")
-        self.assertFalse(messages[8].data["expect_response"])
-        self.assertEqual(messages[8].data["meta"]["dialog"], "hello.world")
-        self.assertEqual(messages[8].data["meta"]["skill"], self.skill_id)
+        # verify intent triggers
+        self.assertEqual(messages[3].msg_type, f"{self.skill_id}:HelloWorldIntent")
+        self.assertEqual(messages[3].data["intent_type"], f"{self.skill_id}:HelloWorldIntent")
+        self.assertEqual(messages[4].msg_type, "mycroft.skill.handler.start")
+        self.assertEqual(messages[4].data["name"], "HelloWorldSkill.handle_hello_world_intent")
         # intent complete
-        self.assertEqual(messages[9].msg_type, "mycroft.skill.handler.complete")
-        self.assertEqual(messages[9].data["name"], "HelloWorldSkill.handle_hello_world_intent")
+        self.assertEqual(messages[-3].msg_type, "mycroft.skill.handler.complete")
+        self.assertEqual(messages[-3].data["name"], "HelloWorldSkill.handle_hello_world_intent")
 
         # verify default session is now updated
         self.assertEqual(messages[-1].msg_type, "ovos.session.update_default")
@@ -159,12 +144,10 @@ class TestSessions(TestCase):
             "recognizer_loop:utterance",
             f"{self.skill_id}.converse.ping",
             "skill.converse.pong",
-            f"{self.skill_id}:HelloWorldIntent",
-            "mycroft.skill.handler.start",
-            "intent.service.skills.activate",
             "intent.service.skills.activated",
             f"{self.skill_id}.activate",
-            "ovos.session.update_default",
+            f"{self.skill_id}:HelloWorldIntent",
+            "mycroft.skill.handler.start",
             "enclosure.active_skill",
             "speak",
             "mycroft.skill.handler.complete",
@@ -190,32 +173,22 @@ class TestSessions(TestCase):
         self.assertEqual(messages[2].context["skill_id"], self.skill_id)
         self.assertFalse(messages[2].data["can_handle"])
 
+        # verify skill is activated
+        self.assertEqual(messages[3].msg_type, "intent.service.skills.activated")
+        self.assertEqual(messages[3].data["skill_id"], self.skill_id)
+        self.assertEqual(messages[4].msg_type, f"{self.skill_id}.activate")
         # verify intent triggers
-        self.assertEqual(messages[3].msg_type, f"{self.skill_id}:HelloWorldIntent")
-        self.assertEqual(messages[3].data["intent_type"], f"{self.skill_id}:HelloWorldIntent")
+        self.assertEqual(messages[5].msg_type, f"{self.skill_id}:HelloWorldIntent")
+        self.assertEqual(messages[5].data["intent_type"], f"{self.skill_id}:HelloWorldIntent")
         # verify skill_id is now present in every message.context
         for m in messages[3:]:
             self.assertEqual(m.context["skill_id"], self.skill_id)
 
-        self.assertEqual(messages[4].msg_type, "mycroft.skill.handler.start")
-        # verify skill is activated
-        self.assertEqual(messages[5].msg_type, "intent.service.skills.activate")
-        self.assertEqual(messages[5].data["skill_id"], self.skill_id)
-        self.assertEqual(messages[6].msg_type, "intent.service.skills.activated")
-        self.assertEqual(messages[6].data["skill_id"], self.skill_id)
-        self.assertEqual(messages[7].msg_type, f"{self.skill_id}.activate")
-        self.assertEqual(messages[8].msg_type, "ovos.session.update_default")
-        # verify intent code execution
-        self.assertEqual(messages[9].msg_type, "enclosure.active_skill")
-        self.assertEqual(messages[9].data["skill_id"], self.skill_id)
-        self.assertEqual(messages[10].msg_type, "speak")
-        self.assertEqual(messages[10].data["lang"], "en-us")
-        self.assertFalse(messages[10].data["expect_response"])
-        self.assertEqual(messages[10].data["meta"]["dialog"], "hello.world")
-        self.assertEqual(messages[10].data["meta"]["skill"], self.skill_id)
+        self.assertEqual(messages[6].msg_type, "mycroft.skill.handler.start")
+
         # intent complete
-        self.assertEqual(messages[11].msg_type, "mycroft.skill.handler.complete")
-        self.assertEqual(messages[11].data["name"], "HelloWorldSkill.handle_hello_world_intent")
+        self.assertEqual(messages[-3].msg_type, "mycroft.skill.handler.complete")
+        self.assertEqual(messages[-3].data["name"], "HelloWorldSkill.handle_hello_world_intent")
 
         # verify default session is now updated
         self.assertEqual(messages[-1].msg_type, "ovos.session.update_default")
@@ -277,11 +250,10 @@ class TestSessions(TestCase):
             "recognizer_loop:utterance",
             f"{self.skill_id}.converse.ping",
             "skill.converse.pong",
-            f"{self.skill_id}:HelloWorldIntent",
-            "mycroft.skill.handler.start",
-            "intent.service.skills.activate",
             "intent.service.skills.activated",
             f"{self.skill_id}.activate",
+            f"{self.skill_id}:HelloWorldIntent",
+            "mycroft.skill.handler.start",
             "enclosure.active_skill",
             "speak",
             "mycroft.skill.handler.complete",
@@ -305,33 +277,31 @@ class TestSessions(TestCase):
         self.assertEqual(messages[2].data["skill_id"], self.skill_id)
         self.assertEqual(messages[2].context["skill_id"], self.skill_id)
         self.assertFalse(messages[2].data["can_handle"])
-
+        # verify skill is activated
+        self.assertEqual(messages[3].msg_type, "intent.service.skills.activated")
+        self.assertEqual(messages[3].data["skill_id"], self.skill_id)
+        self.assertEqual(messages[4].msg_type, f"{self.skill_id}.activate")
         # verify intent triggers
-        self.assertEqual(messages[3].msg_type, f"{self.skill_id}:HelloWorldIntent")
-        self.assertEqual(messages[3].data["intent_type"], f"{self.skill_id}:HelloWorldIntent")
+        self.assertEqual(messages[5].msg_type, f"{self.skill_id}:HelloWorldIntent")
+        self.assertEqual(messages[5].data["intent_type"], f"{self.skill_id}:HelloWorldIntent")
         # verify skill_id is now present in every message.context
         for m in messages[3:]:
             self.assertEqual(m.context["skill_id"], self.skill_id)
 
         # verify intent execution
-        self.assertEqual(messages[4].msg_type, "mycroft.skill.handler.start")
-        self.assertEqual(messages[4].data["name"], "HelloWorldSkill.handle_hello_world_intent")
-        # verify skill is activated
-        self.assertEqual(messages[5].msg_type, "intent.service.skills.activate")
-        self.assertEqual(messages[5].data["skill_id"], self.skill_id)
-        self.assertEqual(messages[6].msg_type, "intent.service.skills.activated")
-        self.assertEqual(messages[6].data["skill_id"], self.skill_id)
-        self.assertEqual(messages[7].msg_type, f"{self.skill_id}.activate")
+        self.assertEqual(messages[6].msg_type, "mycroft.skill.handler.start")
+        self.assertEqual(messages[6].data["name"], "HelloWorldSkill.handle_hello_world_intent")
 
-        self.assertEqual(messages[8].msg_type, "enclosure.active_skill")
-        self.assertEqual(messages[8].data["skill_id"], self.skill_id)
-        self.assertEqual(messages[9].msg_type, "speak")
-        self.assertEqual(messages[9].data["lang"], "en-us")
-        self.assertFalse(messages[9].data["expect_response"])
-        self.assertEqual(messages[9].data["meta"]["dialog"], "hello.world")
-        self.assertEqual(messages[9].data["meta"]["skill"], self.skill_id)
-        self.assertEqual(messages[10].msg_type, "mycroft.skill.handler.complete")
-        self.assertEqual(messages[10].data["name"], "HelloWorldSkill.handle_hello_world_intent")
+        self.assertEqual(messages[7].msg_type, "enclosure.active_skill")
+        self.assertEqual(messages[7].data["skill_id"], self.skill_id)
+        self.assertEqual(messages[8].msg_type, "speak")
+        self.assertEqual(messages[8].data["lang"], "en-us")
+        self.assertFalse(messages[8].data["expect_response"])
+        self.assertEqual(messages[8].data["meta"]["dialog"], "hello.world")
+        self.assertEqual(messages[8].data["meta"]["skill"], self.skill_id)
+
+        self.assertEqual(messages[-2].msg_type, "mycroft.skill.handler.complete")
+        self.assertEqual(messages[-2].data["name"], "HelloWorldSkill.handle_hello_world_intent")
 
         # test that active skills list has been updated
         sess = Session.from_message(messages[-1])

--- a/test/end2end/session/test_stop.py
+++ b/test/end2end/session/test_stop.py
@@ -107,11 +107,10 @@ class TestSessions(TestCase):
         expected_messages = [
             "recognizer_loop:utterance",
             # skill selected
-            f"{self.skill_id}:OldWorldIntent",
-            "mycroft.skill.handler.start",
-            "intent.service.skills.activate",
             "intent.service.skills.activated",
             f"{self.skill_id}.activate",
+            f"{self.skill_id}:OldWorldIntent",
+            "mycroft.skill.handler.start",
             # skill code executing
             "enclosure.active_skill",
             "speak",
@@ -125,7 +124,7 @@ class TestSessions(TestCase):
             self.assertEqual(m.msg_type, expected_messages[idx])
 
         # sanity check correct intent triggered
-        self.assertEqual(messages[7].data["utterance"], "hello world")
+        self.assertEqual(messages[-3].data["utterance"], "hello world")
 
         # test that active skills list has been updated
         sess = Session.deserialize(messages[-1].context["session"])
@@ -281,11 +280,10 @@ class TestSessions(TestCase):
         expected_messages = [
             "recognizer_loop:utterance",
             # skill selected
-            f"{self.new_skill_id}:NewWorldIntent",
-            "mycroft.skill.handler.start",
-            "intent.service.skills.activate",
             "intent.service.skills.activated",
             f"{self.new_skill_id}.activate",
+            f"{self.new_skill_id}:NewWorldIntent",
+            "mycroft.skill.handler.start",
             # skill code executing
             "enclosure.active_skill",
             "speak",


### PR DESCRIPTION
companion to https://github.com/OpenVoiceOS/OVOS-workshop/pull/212

update session data so the skill already sees the skill as active, otherwise since it was async the Session was outdated in the intent handler