### PR TITLE
feat/reranker+optional_ovos_classifiers

### DIFF
--- a/ovos_core/intent_services/__init__.py
+++ b/ovos_core/intent_services/__init__.py
@@ -64,7 +64,7 @@ class IntentService:
         self.padacioso_service = PadaciosoService(bus, self.config["padatious"])
         self.fallback = FallbackService(bus)
         self.converse = ConverseService(bus)
-        self.common_qa = CommonQAService(bus)
+        self.common_qa = CommonQAService(bus, self.config.get("common_query"))
         self.stop = StopService(bus)
         self.ocp = OCPPipelineMatcher(self.bus, config=self.config.get("OCP", {}))
         self.utterance_plugins = UtteranceTransformersService(bus)

--- a/ovos_core/intent_services/commonqa_service.py
+++ b/ovos_core/intent_services/commonqa_service.py
@@ -45,13 +45,16 @@ class CommonQAService(OVOSAbstractApplication):
         self._max_time = config.get('max_response_wait') or 6  # regardless of extensions
         reranker_module = config.get("reranker", "ovos-choice-solver-bm25")  # default to BM25 from ovos-classifiers
         self.reranker = None
-        for name, plug in find_multiple_choice_solver_plugins().items():
-            if name == reranker_module:
-                self.reranker = plug()
-                LOG.info(f"CommonQuery ReRanker: {name}")
-                break
-        else:
-            LOG.info("No CommonQuery ReRanker loaded!")
+        try:
+            for name, plug in find_multiple_choice_solver_plugins().items():
+                if name == reranker_module:
+                    self.reranker = plug()
+                    LOG.info(f"CommonQuery ReRanker: {name}")
+                    break
+            else:
+                LOG.info("No CommonQuery ReRanker loaded!")
+        except Exception as e:
+            LOG.error(f"Failed to load ReRanker plugin: {e}")
         self.add_event('question:query.response', self.handle_query_response)
         self.add_event('common_query.question', self.handle_question)
         self.add_event('ovos.common_query.pong', self.handle_skill_pong)

--- a/ovos_core/intent_services/ocp_service.py
+++ b/ovos_core/intent_services/ocp_service.py
@@ -253,6 +253,8 @@ class OCPPipelineMatcher(OVOSAbstractApplication):
             except:
                 LOG.error(f"{skill_id} reported an invalid media_type: {m}")
 
+        if OCPFeaturizer.ocp_keywords is None:
+            return
         # TODO - review below and add missing
         # set bias in classifier
         # aliases -> {type}_streaming_service bias
@@ -281,6 +283,8 @@ class OCPPipelineMatcher(OVOSAbstractApplication):
 
     def handle_skill_keyword_register(self, message: Message):
         """ register skill provided keywords """
+        if OCPFeaturizer.ocp_keywords is None:
+            return
         skill_id = message.data["skill_id"]
         kw_label = message.data["label"]
         media = message.data["media_type"]
@@ -1263,6 +1267,8 @@ class OCPFeaturizer:
 
     @classmethod
     def load_csv(cls, entity_csvs: list):
+        if OCPFeaturizer.ocp_keywords is None:
+            return
         for csv in entity_csvs or []:
             if not os.path.isfile(csv):
                 # check for bundled files

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -13,8 +13,6 @@ ovos-config~=0.0,>=0.0.13a8
 ovos-lingua-franca>=0.4.7
 ovos-backend-client~=0.1.0
 ovos-workshop>=0.0.16a45
-# provides plugins and classic machine learning framework
-ovos-classifiers<0.1.0, >=0.0.0a53
 
 # ensure default plugin available for any solver plugins
 ovos-translate-server-plugin

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -19,6 +19,9 @@ ovos-listener~=0.0, >=0.0.3a2
 ovos-gui~=0.0, >=0.0.2
 ovos-messagebus~=0.0
 
+# provides plugins and classic machine learning framework
+ovos-classifiers<0.1.0, >=0.0.0a53
+
 # Support OCP tests
 ovos_bus_client>=0.0.9a15
 ovos-utils>=0.1.0a16

--- a/test/unittests/skills/test_ocp.py
+++ b/test/unittests/skills/test_ocp.py
@@ -18,7 +18,7 @@ class TestOCPFeaturizer(unittest.TestCase):
         self.featurizer = OCPFeaturizer()
 
     @patch('os.path.isfile', return_value=True)
-    @patch('ovos_core.intent_services.ocp_service.KeywordFeaturesVectorizer.load_entities')
+    @patch('ovos_classifiers.skovos.features.KeywordFeaturesVectorizer.load_entities')
     @patch.object(LOG, 'info')
     def test_load_csv_with_existing_file(self, mock_log_info, mock_load_entities, mock_isfile):
         csv_path = "existing_file.csv"


### PR DESCRIPTION
ovos-classifiers is still in pre-alpha and wont have a stable release anytime soon, make it an optional dependency of ovos-core 0.0.8

related https://github.com/OpenVoiceOS/ovos-core/issues/488

solves TODO to allow reranker to come from config instead of being hardcoded, closes https://github.com/OpenVoiceOS/ovos-core/issues/436

improves logs about reranking process for clarity

a new config option (default False) allows using the reranker while ignoring the skill self reported confidences

in example below wolfram alpha would normally be selected, but the reranker preferred the duck duck go answer
```
2024-08-04 01:46:56.692 - skills - ovos_core.intent_services.commonqa_service:_query_timeout:269 - DEBUG - Tied skills: ['skill-ovos-ddg.openvoiceos', 'skill-ovos-wikipedia.openvoiceos', 'skill-ovos-wolfie.openvoiceos']
2024-08-04 01:46:56.693 - skills - ovos_core.intent_services.commonqa_service:_query_timeout:275 - DEBUG - ReRanking answers from skills
2024-08-04 01:46:56.974 - skills - ovos_core.intent_services.commonqa_service:_query_timeout:280 - INFO - ReRanked score: 0.9994009733200073 - {'phrase': 'what is the speed of light', 'skill_id': 'skill-ovos-ddg.openvoiceos', 'answer': 'The speed of light in vacuum, commonly denoted c, is a universal physical constant that is exactly equal to 299,792,458 metres per second.', 'handles_speech': True, 'callback_data': {'query': 'what is the speed of light', 'answer': 'The speed of light in vacuum, commonly denoted c, is a universal physical constant that is exactly equal to 299,792,458 metres per second.'}, 'conf': 2.229565217391304}
2024-08-04 01:46:56.975 - skills - ovos_core.intent_services.commonqa_service:_query_timeout:280 - INFO - ReRanked score: 0.9994009733200073 - {'phrase': 'what is the speed of light', 'skill_id': 'skill-ovos-wikipedia.openvoiceos', 'answer': 'The speed of light in vacuum, commonly denoted c, is a universal physical constant that is exactly equal to 299,792,458 metres per second .', 'handles_speech': True, 'callback_data': {'query': 'what is the speed of light', 'image': 'https://upload.wikimedia.org/wikipedia/commons/2/2e/Earth_to_Sun_-_en.png', 'title': 'Speed Of Light', 'answer': 'The speed of light in vacuum, commonly denoted c, is a universal physical constant that is exactly equal to 299,792,458 metres per second .'}, 'conf': 2.1133333333333333}
2024-08-04 01:46:56.975 - skills - ovos_core.intent_services.commonqa_service:_query_timeout:280 - INFO - ReRanked score: 0.9967312812805176 - {'phrase': 'what is the speed of light', 'skill_id': 'skill-ovos-wolfie.openvoiceos', 'answer': 'The speed of light has a value of about 300 million meters per second', 'handles_speech': True, 'callback_data': {'query': 'what is the speed of light', 'answer': 'The speed of light has a value of about 300 million meters per second'}, 'conf': 2.8085714285714287}
2024-08-04 01:46:56.975 - skills - ovos_core.intent_services.commonqa_service:_query_timeout:287 - INFO - Handling with: skill-ovos-ddg.openvoiceos
```

recommend plugin: https://github.com/TigreGotico/ovos-flashrank-reranker-plugin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved error handling for the answer selection process, ensuring service functionality even if the re-ranking component is unavailable.
	- Conditional loading of classifiers based on configuration settings to enhance performance and efficiency.
	- Enhanced entity extraction logic to prevent errors when necessary keywords are unavailable.
	- Introduced a flexible configuration mechanism for dynamic retrieval of settings related to common query functionality.

- **Bug Fixes**
	- Adjusted logic to default to a random answer when the re-ranker is not available, avoiding potential failures.

- **Chores**
	- Removed unnecessary dependency on `ovos-classifiers`, simplifying project requirements.
	- Added `ovos-classifiers` dependency to the testing requirements for enhanced testing capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->