### PR TITLE
fix/sklearn_import

### DIFF
--- a/ovos_core/intent_services/ocp_service.py
+++ b/ovos_core/intent_services/ocp_service.py
@@ -17,7 +17,6 @@ from ovos_utils.log import LOG
 from ovos_utils.messagebus import FakeBus
 from ovos_workshop.app import OVOSAbstractApplication
 from padacioso import IntentContainer
-from sklearn.pipeline import FeatureUnion
 
 from ovos_plugin_manager.ocp import available_extractors
 from ovos_plugin_manager.templates.pipeline import IntentMatch
@@ -1366,6 +1365,7 @@ class OCPFeaturizer:
 
     def transform(self, X):
         if self.clf_feats:
+            from sklearn.pipeline import FeatureUnion
             vec = FeatureUnion([
                 ("kw", self.ocp_keywords),
                 ("clf", self.clf_feats)


### PR DESCRIPTION
when ovos-classifiers was made optional this import was missed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Optimized import statements to enhance module performance by relocating a specific import to within a method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->