### PR TITLE
ovos.common_play.search.populate event

### DIFF
--- a/.github/workflows/license_tests.yml
+++ b/.github/workflows/license_tests.yml
@@ -37,7 +37,7 @@ jobs:
           requirements: 'requirements-all.txt'
           fail: 'Copyleft,Other,Error'
           fails-only: true
-          exclude: '^(precise-runner|fann2|tqdm|bs4|sonopy|caldav|recurring-ical-events|x-wr-timezone).*'
+          exclude: '^(precise-runner|fann2|tqdm|bs4|sonopy|caldav|recurring-ical-events|x-wr-timezone|zeroconf|mutagen).*'
           exclude-license: '^(Mozilla).*$'
       - name: Print report
         if: ${{ always() }}

--- a/ovos_core/intent_services/ocp_service.py
+++ b/ovos_core/intent_services/ocp_service.py
@@ -604,7 +604,11 @@ class OCPPipelineMatcher(OVOSAbstractApplication):
             if not player.ocp_available:
                 self.legacy_play(results, query, message=message)
             else:
-                self.ocp_api.play(results, query, source_message=message)
+                self.ocp_api.play(tracks=[best], utterance=query, source_message=message)
+            self.ocp_api.populate_search_results(tracks=results,
+                                                 replace=True,
+                                                 sort_by_conf=False,  # already sorted
+                                                 source_message=message)
 
     def handle_open_intent(self, message: Message):
         LOG.info("Requesting OCP homescreen")

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -7,7 +7,7 @@ padacioso>=0.1.0,<1.0.0
 adapt-parser>=1.0.0, <2.0.0
 
 ovos-utils>=0.0.38,<1.0.0
-ovos_bus_client>=0.0.9,<1.0.0
+ovos_bus_client>=0.1.0,<1.0.0
 ovos-plugin-manager>=0.0.26,<1.0.0
 ovos-config>=0.0.13,<1.0.0
 ovos-lingua-franca>=0.4.7,<1.0.0

--- a/test/end2end/routing/test_session.py
+++ b/test/end2end/routing/test_session.py
@@ -156,6 +156,7 @@ class TestOCPRouting(TestCase):
             "ovos.common_play.reset",
             "add_context",  # NowPlaying context
             "ovos.common_play.play",  # OCP api,
+            "ovos.common_play.search.populate",
             "ovos.utterance.handled"  # handle_utterance returned (intent service)
         ]
         wait_for_n_messages(len(expected_messages))

--- a/test/end2end/session/test_blacklist.py
+++ b/test/end2end/session/test_blacklist.py
@@ -197,6 +197,7 @@ class TestOCP(TestCase):
             "ovos.common_play.reset",
             "add_context",  # NowPlaying context
             "ovos.common_play.play",  # OCP api
+            "ovos.common_play.search.populate",
             "ovos.utterance.handled"  # handle_utterance returned (intent service)
         ]
         wait_for_n_messages(len(expected_messages))

--- a/test/end2end/session/test_ocp.py
+++ b/test/end2end/session/test_ocp.py
@@ -288,6 +288,7 @@ class TestOCPPipeline(TestCase):
             "ovos.common_play.reset",
             "add_context",  # NowPlaying context
             "ovos.common_play.play",  # OCP api,
+            "ovos.common_play.search.populate",
             "ovos.utterance.handled"  # handle_utterance returned (intent service)
         ]
         wait_for_n_messages(len(expected_messages))
@@ -429,6 +430,7 @@ class TestOCPPipeline(TestCase):
             "ovos.common_play.reset",
             "add_context",  # NowPlaying context
             "ovos.common_play.play",  # OCP api
+            "ovos.common_play.search.populate",
             "ovos.utterance.handled"  # handle_utterance returned (intent service)
         ]
         wait_for_n_messages(len(expected_messages))
@@ -504,6 +506,7 @@ class TestOCPPipeline(TestCase):
             "ovos.common_play.reset",
             "add_context",  # NowPlaying context
             'mycroft.audio.service.play',  # LEGACY api
+            "ovos.common_play.search.populate",
             "ovos.utterance.handled",  # handle_utterance returned (intent service)
         ]
         wait_for_n_messages(len(expected_messages))

--- a/test/end2end/session/test_ocp.py
+++ b/test/end2end/session/test_ocp.py
@@ -298,7 +298,7 @@ class TestOCPPipeline(TestCase):
         for idx, m in enumerate(messages):
             self.assertEqual(m.msg_type, expected_messages[idx])
 
-        play = messages[-2]
+        play = messages[-3]
         self.assertEqual(play.data["media"]["uri"], "https://fake_4.mp3")
 
     def test_unk_media_match(self):


### PR DESCRIPTION
new bus event to allow replacing the search results explicitly

fixes handling of Playlist objects when populating playlist/search result

companion to https://github.com/OpenVoiceOS/ovos-ocp-audio-plugin/pull/139 and https://github.com/OpenVoiceOS/ovos-bus-client/pull/118

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced track playing functionality for more focused playback.
	- Improved search results population after a play intent is handled.
	- Added support for a new message type related to search result population in the messaging system.

- **Bug Fixes**
	- Updated dependency version for `ovos_bus_client`, potentially fixing issues and introducing new features.

- **Tests**
	- Expanded test coverage to include the new message type for search result population.
	- Adjusted message indexing in tests to reflect changes in expected message order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->