### PR TITLE
feat:fix website url

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,5 +68,5 @@ manpower resources available to us:
 * [ovos-technical-manual](https://openvoiceos.github.io/ovos-technical-manual)
 * [Release Notes](https://github.com/OpenVoiceOS/ovos-core/releases)
 * [OpenVoiceOS Chat](https://matrix.to/#/!XFpdtmgyCoPDxOMPpH:matrix.org?via=matrix.org)
-* [OpenVoiceOS Website](https://openvoiceos.com/)
+* [OpenVoiceOS Website](https://openvoiceos.org)
 * [Open Conversational AI Forums](https://community.openconversational.ai/)  (previously mycroft forums)


### PR DESCRIPTION
marked as feature just to trigger automations and skip to 0.1.0

reserving version **0.0.X** for bug fix **backports**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the OpenVoiceOS website URL in the README file from `https://openvoiceos.com/` to `https://openvoiceos.org`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->