### PR TITLE
fix:usage without skills installed

### DIFF
--- a/test/unittests/skills/test_skill_manager.py
+++ b/test/unittests/skills/test_skill_manager.py
@@ -103,7 +103,6 @@ class TestSkillManager(MycroftUnitTestBase):
             'skillmanager.keep',
             'skillmanager.activate',
             'mycroft.skills.initialized',
-            'mycroft.skills.trained',
             'mycroft.network.connected',
             'mycroft.internet.connected',
             'mycroft.gui.available',


### PR DESCRIPTION
in setups without skills installed the trained event was never emitted, causing OVOS to hang forever and never reporting ready, but we have no need to wait here, it was only there to delay padatious training to after all skills loaded, but this no longer happens at once on boot in OVOS like it did in mycroft

noticed in docker when running skills in standalone mode (individual container per skill)

adds a check to see if any skills are installed, to make logs more informative

relates to https://github.com/OpenVoiceOS/ovos-core/pull/554

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced skill loading logic to efficiently detect and load installed skills.
- **Bug Fixes**
	- Removed unnecessary loading attempts when no skills are available.
- **Refactor**
	- Streamlined the startup process by eliminating the waiting for initial training completion.
	- Removed the `handle_initial_training` method for improved clarity.
- **Style**
	- Minor formatting adjustments for improved code clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->