### PR TITLE
fix:standardize_lang

### DIFF
--- a/ovos_core/intent_services/__init__.py
+++ b/ovos_core/intent_services/__init__.py
@@ -210,7 +210,7 @@ class IntentService:
 
     @property
     def registered_intents(self):
-        lang = standardize_lang_tag(get_message_lang())
+        lang = get_message_lang()
         return [parser.__dict__
                 for parser in self._adapt_service.engines[lang].intent_parsers]
 
@@ -264,7 +264,7 @@ class IntentService:
         Pipe utterance through transformer plugins to get more metadata.
         Utterances may be modified by any parser and context overwritten
         """
-        lang = standardize_lang_tag(get_message_lang())  # per query lang or default Configuration lang
+        lang = get_message_lang()  # per query lang or default Configuration lang
         original = utterances = message.data.get('utterances', [])
         message.context["lang"] = lang
         utterances, message.context = self.utterance_plugins.transform(utterances, message.context)
@@ -282,7 +282,7 @@ class IntentService:
         3 - detected_lang -> tagged by transformers  (text classification, free form chat)
         4 - config lang (or from message.data)
         """
-        default_lang = standardize_lang_tag(get_message_lang())
+        default_lang = get_message_lang()
         valid_langs = get_valid_languages()
         lang_keys = ["stt_lang",
                      "request_lang",
@@ -527,7 +527,7 @@ class IntentService:
         entity_type = message.data.get('entity_type')
         regex_str = message.data.get('regex')
         alias_of = message.data.get('alias_of')
-        lang = standardize_lang_tag(get_message_lang())
+        lang = get_message_lang()
         self._adapt_service.register_vocabulary(entity_value, entity_type,
                                                alias_of, regex_str, lang)
         self.registered_vocab.append(message.data)
@@ -604,7 +604,7 @@ class IntentService:
             message (Message): message containing utterance
         """
         utterance = message.data["utterance"]
-        lang = standardize_lang_tag(get_message_lang())
+        lang = get_message_lang()
         sess = SessionManager.get(message)
 
         # Loop through the matching functions until a match is found.
@@ -655,7 +655,7 @@ class IntentService:
             message (Message): message containing utterance
         """
         utterance = message.data["utterance"]
-        lang = standardize_lang_tag(get_message_lang())
+        lang = get_message_lang()
         intent = self._adapt_service.match_intent((utterance,), lang, message.serialize())
         intent_data = intent.intent_data if intent else None
         self.bus.emit(message.reply("intent.service.adapt.reply",

--- a/ovos_core/intent_services/__init__.py
+++ b/ovos_core/intent_services/__init__.py
@@ -264,7 +264,7 @@ class IntentService:
         Pipe utterance through transformer plugins to get more metadata.
         Utterances may be modified by any parser and context overwritten
         """
-        lang = get_message_lang()  # per query lang or default Configuration lang
+        lang = get_message_lang(message)  # per query lang or default Configuration lang
         original = utterances = message.data.get('utterances', [])
         message.context["lang"] = lang
         utterances, message.context = self.utterance_plugins.transform(utterances, message.context)
@@ -282,7 +282,7 @@ class IntentService:
         3 - detected_lang -> tagged by transformers  (text classification, free form chat)
         4 - config lang (or from message.data)
         """
-        default_lang = get_message_lang()
+        default_lang = get_message_lang(message)
         valid_langs = get_valid_languages()
         lang_keys = ["stt_lang",
                      "request_lang",
@@ -527,7 +527,7 @@ class IntentService:
         entity_type = message.data.get('entity_type')
         regex_str = message.data.get('regex')
         alias_of = message.data.get('alias_of')
-        lang = get_message_lang()
+        lang = get_message_lang(message)
         self._adapt_service.register_vocabulary(entity_value, entity_type,
                                                alias_of, regex_str, lang)
         self.registered_vocab.append(message.data)
@@ -604,7 +604,7 @@ class IntentService:
             message (Message): message containing utterance
         """
         utterance = message.data["utterance"]
-        lang = get_message_lang()
+        lang = get_message_lang(message)
         sess = SessionManager.get(message)
 
         # Loop through the matching functions until a match is found.
@@ -655,7 +655,7 @@ class IntentService:
             message (Message): message containing utterance
         """
         utterance = message.data["utterance"]
-        lang = get_message_lang()
+        lang = get_message_lang(message)
         intent = self._adapt_service.match_intent((utterance,), lang, message.serialize())
         intent_data = intent.intent_data if intent else None
         self.bus.emit(message.reply("intent.service.adapt.reply",

--- a/ovos_core/intent_services/converse_service.py
+++ b/ovos_core/intent_services/converse_service.py
@@ -9,6 +9,7 @@ from ovos_config.config import Configuration
 from ovos_config.locale import setup_locale
 from ovos_plugin_manager.templates.pipeline import IntentMatch, PipelinePlugin
 from ovos_utils import flatten_list
+from ovos_utils.lang import standardize_lang_tag
 from ovos_utils.log import LOG
 from ovos_workshop.permissions import ConverseMode, ConverseActivationMode
 
@@ -279,7 +280,7 @@ class ConverseService(PipelinePlugin):
             handled (bool): True if handled otherwise False.
         """
         session = SessionManager.get(message)
-        session.lang = lang
+        session.lang = standardize_lang_tag(lang)
 
         state = session.utterance_states.get(skill_id, UtteranceState.INTENT)
         if state == UtteranceState.RESPONSE:
@@ -384,7 +385,7 @@ class ConverseService(PipelinePlugin):
 
     def reset_converse(self, message):
         """Let skills know there was a problem with speech recognition"""
-        lang = get_message_lang(message)
+        lang = standardize_lang_tag(get_message_lang())
         try:
             setup_locale(lang)  # restore default lang
         except Exception as e:

--- a/ovos_core/intent_services/converse_service.py
+++ b/ovos_core/intent_services/converse_service.py
@@ -24,6 +24,7 @@ class ConverseService(PipelinePlugin):
         self.bus.on('mycroft.speech.recognition.unknown', self.reset_converse)
         self.bus.on('intent.service.skills.deactivate', self.handle_deactivate_skill_request)
         self.bus.on('intent.service.skills.activate', self.handle_activate_skill_request)
+        self.bus.on('active_skill_request', self.handle_activate_skill_request)  # TODO backwards compat, deprecate
         self.bus.on('intent.service.active_skills.get', self.handle_get_active_skills)
         self.bus.on("skill.converse.get_response.enable", self.handle_get_response_enable)
         self.bus.on("skill.converse.get_response.disable", self.handle_get_response_disable)
@@ -408,6 +409,7 @@ class ConverseService(PipelinePlugin):
         self.bus.remove('mycroft.speech.recognition.unknown', self.reset_converse)
         self.bus.remove('intent.service.skills.deactivate', self.handle_deactivate_skill_request)
         self.bus.remove('intent.service.skills.activate', self.handle_activate_skill_request)
+        self.bus.remove('active_skill_request', self.handle_activate_skill_request)  # TODO backwards compat, deprecate
         self.bus.remove('intent.service.active_skills.get', self.handle_get_active_skills)
         self.bus.remove("skill.converse.get_response.enable", self.handle_get_response_enable)
         self.bus.remove("skill.converse.get_response.disable", self.handle_get_response_disable)

--- a/ovos_core/intent_services/converse_service.py
+++ b/ovos_core/intent_services/converse_service.py
@@ -388,7 +388,7 @@ class ConverseService(PipelinePlugin):
 
     def reset_converse(self, message: Message):
         """Let skills know there was a problem with speech recognition"""
-        lang = standardize_lang_tag(get_message_lang())
+        lang = get_message_lang()
         try:
             setup_locale(lang)  # restore default lang
         except Exception as e:

--- a/ovos_core/intent_services/fallback_service.py
+++ b/ovos_core/intent_services/fallback_service.py
@@ -22,6 +22,7 @@ from ovos_bus_client.session import SessionManager
 from ovos_config import Configuration
 from ovos_plugin_manager.templates.pipeline import IntentMatch, PipelinePlugin
 from ovos_utils import flatten_list
+from ovos_utils.lang import standardize_lang_tag
 from ovos_utils.log import LOG
 from ovos_workshop.permissions import FallbackMode
 
@@ -171,6 +172,7 @@ class FallbackService(PipelinePlugin):
         Returns:
             IntentMatch or None
         """
+        lang = standardize_lang_tag(lang)
         # we call flatten in case someone is sending the old style list of tuples
         utterances = flatten_list(utterances)
         message.data["utterances"] = utterances  # all transcripts

--- a/ovos_core/intent_services/stop_service.py
+++ b/ovos_core/intent_services/stop_service.py
@@ -24,7 +24,7 @@ class StopService(PipelinePlugin):
         self.bus = bus
         self._voc_cache = {}
         self.load_resource_files()
-        super().__init__()
+        super().__init__(config=Configuration().get("skills", {}).get("stop") or {})
 
     def load_resource_files(self):
         base = f"{dirname(__file__)}/locale"
@@ -37,14 +37,6 @@ class StopService(PipelinePlugin):
                              if l.strip() and not l.startswith("#")]
                     n = f.split(".", 1)[0]
                     self._voc_cache[lang2][n] = flatten_list(lines)
-
-    @property
-    def config(self):
-        """
-        Returns:
-            stop_config (dict): config for stop handling options
-        """
-        return Configuration().get("skills", {}).get("stop") or {}
 
     def get_active_skills(self, message: Optional[Message] = None):
         """Active skill ids ordered by converse priority
@@ -182,8 +174,8 @@ class StopService(PipelinePlugin):
         Returns:
             IntentMatch if handled otherwise None.
         """
-        lang = standardize_lang_tag(lang)
-        if lang not in self._voc_cache:
+        lang = self._get_closest_lang(lang)
+        if lang is None:  # no vocs registered for this lang
             return None
 
         # we call flatten in case someone is sending the old style list of tuples

--- a/ovos_core/intent_services/stop_service.py
+++ b/ovos_core/intent_services/stop_service.py
@@ -10,6 +10,7 @@ from ovos_config.config import Configuration
 from ovos_plugin_manager.templates.pipeline import IntentMatch, PipelinePlugin
 from ovos_utils import flatten_list
 from ovos_utils.bracket_expansion import expand_options
+from ovos_utils.lang import standardize_lang_tag
 from ovos_utils.log import LOG
 from ovos_utils.parse import match_one
 
@@ -25,7 +26,7 @@ class StopService(PipelinePlugin):
     def load_resource_files(self):
         base = f"{dirname(__file__)}/locale"
         for lang in os.listdir(base):
-            lang2 = lang.split("-")[0].lower()
+            lang2 = standardize_lang_tag(lang)
             self._voc_cache[lang2] = {}
             for f in os.listdir(f"{base}/{lang}"):
                 with open(f"{base}/{lang}/{f}", encoding="utf-8") as fi:
@@ -127,7 +128,7 @@ class StopService(PipelinePlugin):
         Returns:
             IntentMatch if handled otherwise None.
         """
-        lang = lang.split("-")[0]
+        lang = standardize_lang_tag(lang)
         if lang not in self._voc_cache:
             return None
 
@@ -178,7 +179,7 @@ class StopService(PipelinePlugin):
         Returns:
             IntentMatch if handled otherwise None.
         """
-        lang = lang.split("-")[0]
+        lang = standardize_lang_tag(lang)
         if lang not in self._voc_cache:
             return None
 
@@ -205,7 +206,7 @@ class StopService(PipelinePlugin):
         Returns:
             IntentMatch if handled otherwise None.
         """
-        lang = lang.split("-")[0]
+        lang = standardize_lang_tag(lang)
         if lang not in self._voc_cache:
             return None
         sess = SessionManager.get(message)
@@ -266,7 +267,7 @@ class StopService(PipelinePlugin):
         Returns:
             bool: True if the utterance has the given vocabulary it
         """
-        lang = lang.split("-")[0].lower()
+        lang = standardize_lang_tag(lang)
         if lang not in self._voc_cache:
             return False
 

--- a/ovos_core/intent_services/stop_service.py
+++ b/ovos_core/intent_services/stop_service.py
@@ -38,7 +38,8 @@ class StopService(PipelinePlugin):
                     n = f.split(".", 1)[0]
                     self._voc_cache[lang2][n] = flatten_list(lines)
 
-    def get_active_skills(self, message: Optional[Message] = None):
+    @staticmethod
+    def get_active_skills(message: Optional[Message] = None) -> List[str]:
         """Active skill ids ordered by converse priority
         this represents the order in which stop will be called
 
@@ -48,7 +49,7 @@ class StopService(PipelinePlugin):
         session = SessionManager.get(message)
         return [skill[0] for skill in session.active_skills]
 
-    def _collect_stop_skills(self, message: Message):
+    def _collect_stop_skills(self, message: Message) -> List[str]:
         """use the messagebus api to determine which skills can stop
         This includes all skills and external applications"""
 
@@ -92,7 +93,7 @@ class StopService(PipelinePlugin):
         self.bus.remove("skill.stop.pong", handle_ack)
         return want_stop or active_skills
 
-    def stop_skill(self, skill_id: str, message: Message):
+    def stop_skill(self, skill_id: str, message: Message) -> bool:
         """Tell a skill to stop anything it's doing,
         taking into account the message Session
 

--- a/requirements/lgpl.txt
+++ b/requirements/lgpl.txt
@@ -1,2 +1,2 @@
-ovos_padatious>=0.1.2,<1.0.0
+ovos_padatious>=0.1.3,<1.0.0
 fann2>=1.0.7, < 1.1.0

--- a/requirements/plugins.txt
+++ b/requirements/plugins.txt
@@ -1,5 +1,5 @@
 ovos-utterance-corrections-plugin>=0.0.2, <1.0.0
-ovos-utterance-plugin-cancel>=0.2.0, <1.0.0
+ovos-utterance-plugin-cancel>=0.2.2, <1.0.0
 ovos-bidirectional-translation-plugin>=0.1.0, <1.0.0
 ovos-translate-server-plugin>=0.0.2, <1.0.0
 ovos-utterance-normalizer>=0.2.1, <1.0.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -14,4 +14,4 @@ ovos-plugin-manager>=0.0.26,<1.0.0
 ovos-config>=0.0.13,<1.0.0
 ovos-lingua-franca>=0.4.7,<1.0.0
 ovos-backend-client>=0.1.0,<2.0.0
-ovos-workshop>=0.0.16,<2.0.0
+ovos-workshop>=1.0.1,<2.0.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -9,7 +9,7 @@ ovos_ocp_pipeline_plugin>=0.1.3, <1.0.0
 ovos-common-query-pipeline-plugin>=0.1.4, <1.0.0
 
 ovos-utils>=0.3.5,<1.0.0
-ovos_bus_client>=0.1.0,<1.0.0
+ovos_bus_client>=0.1.4,<1.0.0
 ovos-plugin-manager>=0.0.26,<1.0.0
 ovos-config>=0.0.13,<1.0.0
 ovos-lingua-franca>=0.4.7,<1.0.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -3,12 +3,12 @@ python-dateutil>=2.6, <3.0
 watchdog>=2.1, <3.0
 combo-lock>=0.2.2, <0.3
 
-padacioso>=0.2.2,<1.0.0
-ovos-adapt-parser>=0.1.2, <1.0.0
-ovos_ocp_pipeline_plugin>=0.1.2, <1.0.0
-ovos-common-query-pipeline-plugin>=0.1.2, <1.0.0
+padacioso>=0.2.4,<1.0.0
+ovos-adapt-parser>=0.1.3, <1.0.0
+ovos_ocp_pipeline_plugin>=0.1.3, <1.0.0
+ovos-common-query-pipeline-plugin>=0.1.4, <1.0.0
 
-ovos-utils>=0.1.0,<1.0.0
+ovos-utils>=0.3.5,<1.0.0
 ovos_bus_client>=0.1.0,<1.0.0
 ovos-plugin-manager>=0.0.26,<1.0.0
 ovos-config>=0.0.13,<1.0.0

--- a/test/backwards_compat/test_ocp.py
+++ b/test/backwards_compat/test_ocp.py
@@ -196,36 +196,36 @@ class TestCPS(unittest.TestCase):
 
         # assert that OCP intents registered
         locale_folder = join(dirname(ovos_plugin_common_play.__file__),
-                             "ocp", "res", "locale", "en-us")
+                             "ocp", "res", "locale", "en-US")
         ocp_msgs = [
             {'type': 'padatious:register_intent',
              'data': {
                  'file_name': f'{locale_folder}/play.intent',
-                 'name': 'ovos.common_play:play.intent', 'lang': 'en-us'}},
+                 'name': 'ovos.common_play:play.intent', 'lang': 'en-US'}},
             {'type': 'padatious:register_intent',
              'data': {
                  'file_name': f'{locale_folder}/read.intent',
-                 'name': 'ovos.common_play:read.intent', 'lang': 'en-us'}},
+                 'name': 'ovos.common_play:read.intent', 'lang': 'en-US'}},
             {'type': 'padatious:register_intent',
              'data': {
                  'file_name': f'{locale_folder}/open.intent',
-                 'name': 'ovos.common_play:open.intent', 'lang': 'en-us'}},
+                 'name': 'ovos.common_play:open.intent', 'lang': 'en-US'}},
             {'type': 'padatious:register_intent',
              'data': {
                  'file_name': f'{locale_folder}/next.intent',
-                 'name': 'ovos.common_play:next.intent', 'lang': 'en-us'}},
+                 'name': 'ovos.common_play:next.intent', 'lang': 'en-US'}},
             {'type': 'padatious:register_intent',
              'data': {
                  'file_name': f'{locale_folder}/prev.intent',
-                 'name': 'ovos.common_play:prev.intent', 'lang': 'en-us'}},
+                 'name': 'ovos.common_play:prev.intent', 'lang': 'en-US'}},
             {'type': 'padatious:register_intent',
              'data': {
                  'file_name': f'{locale_folder}/pause.intent',
-                 'name': 'ovos.common_play:pause.intent', 'lang': 'en-us'}},
+                 'name': 'ovos.common_play:pause.intent', 'lang': 'en-US'}},
             {'type': 'padatious:register_intent',
              'data': {
                  'file_name': f'{locale_folder}/resume.intent',
-                 'name': 'ovos.common_play:resume.intent', 'lang': 'en-us'}},
+                 'name': 'ovos.common_play:resume.intent', 'lang': 'en-US'}},
             {'type': 'ovos.common_play.skills.get',
              'data': {}}
         ]

--- a/test/backwards_compat/test_ocp.py
+++ b/test/backwards_compat/test_ocp.py
@@ -196,7 +196,7 @@ class TestCPS(unittest.TestCase):
 
         # assert that OCP intents registered
         locale_folder = join(dirname(ovos_plugin_common_play.__file__),
-                             "ocp", "res", "locale", "en-US")
+                             "ocp", "res", "locale", "en-us")
         ocp_msgs = [
             {'type': 'padatious:register_intent',
              'data': {

--- a/test/end2end/routing/test_sched.py
+++ b/test/end2end/routing/test_sched.py
@@ -16,7 +16,7 @@ class TestSched(TestCase):
     def test_no_session(self):
         SessionManager.sessions = {}
         SessionManager.default_session = SessionManager.sessions["default"] = Session("default")
-        SessionManager.default_session.lang = "en-us"
+        SessionManager.default_session.lang = "en-US"
         SessionManager.pipeline = ["adapt_high"]
 
         messages = []

--- a/test/end2end/routing/test_session.py
+++ b/test/end2end/routing/test_session.py
@@ -21,7 +21,7 @@ class TestRouting(TestCase):
     def test_no_session(self):
         SessionManager.sessions = {}
         SessionManager.default_session = SessionManager.sessions["default"] = Session("default")
-        SessionManager.default_session.lang = "en-us"
+        SessionManager.default_session.lang = "en-US"
         SessionManager.pipeline = ["adapt_high"]
 
         messages = []

--- a/test/end2end/session/test_blacklist.py
+++ b/test/end2end/session/test_blacklist.py
@@ -21,7 +21,7 @@ class TestSessions(TestCase):
     def test_blacklist(self):
         SessionManager.sessions = {}
         SessionManager.default_session = SessionManager.sessions["default"] = Session("default")
-        SessionManager.default_session.lang = "en-us"
+        SessionManager.default_session.lang = "en-US"
         SessionManager.default_session.pipeline = ["adapt_high"]
         SessionManager.default_session.blacklisted_skills = []
         SessionManager.default_session.blacklisted_intents = []
@@ -309,7 +309,7 @@ class TestFallback(TestCase):
     def test_fallback(self):
         SessionManager.sessions = {}
         SessionManager.default_session = SessionManager.sessions["default"] = Session("default")
-        SessionManager.default_session.lang = "en-us"
+        SessionManager.default_session.lang = "en-US"
         SessionManager.default_session.pipeline = [
             "fallback_high"
         ]
@@ -400,7 +400,7 @@ class TestCommonQuery(TestCase):
     def test_common_qa(self):
         SessionManager.sessions = {}
         SessionManager.default_session = SessionManager.sessions["default"] = Session("default")
-        SessionManager.default_session.lang = "en-us"
+        SessionManager.default_session.lang = "en-US"
         SessionManager.default_session.pipeline = ["common_qa"]
         messages = []
 

--- a/test/end2end/session/test_complete_failure.py
+++ b/test/end2end/session/test_complete_failure.py
@@ -19,7 +19,7 @@ class TestSessions(TestCase):
     def test_complete_failure(self):
         SessionManager.sessions = {}
         SessionManager.default_session = SessionManager.sessions["default"] = Session("default")
-        SessionManager.default_session.lang = "en-us"
+        SessionManager.default_session.lang = "en-US"
         SessionManager.default_session.active_skills = [(self.skill_id, time.time())]
         SessionManager.default_session.pipeline = [
                            "stop_high",
@@ -105,7 +105,7 @@ class TestSessions(TestCase):
     def test_complete_failure_lang_detect(self):
         SessionManager.sessions = {}
         SessionManager.default_session = SessionManager.sessions["default"] = Session("default")
-        SessionManager.default_session.lang = "en-us"
+        SessionManager.default_session.lang = "en-US"
         SessionManager.default_session.active_skills = [(self.skill_id, time.time())]
         SessionManager.default_session.pipeline = [
                            "stop_high",
@@ -144,7 +144,7 @@ class TestSessions(TestCase):
 
         self.core.bus.on("message", new_msg)
 
-        SessionManager.default_session.valid_languages = ["en-us", stt_lang_detect, "fr-fr"]
+        SessionManager.default_session.valid_languages = ["en-US", stt_lang_detect, "fr-fr"]
         utt = Message("recognizer_loop:utterance",
                       {"utterances": ["hello world"]},
                       {"session": SessionManager.default_session.serialize(),
@@ -247,4 +247,4 @@ class TestSessions(TestCase):
         self.assertEqual(messages[18].data["session_data"]["lang"], "pt-pt")
         self.assertEqual(SessionManager.default_session.lang, "pt-pt")
 
-        SessionManager.default_session.lang = "en-us"
+        SessionManager.default_session.lang = "en-US"

--- a/test/end2end/session/test_converse.py
+++ b/test/end2end/session/test_converse.py
@@ -21,7 +21,7 @@ class TestSessions(TestCase):
     def test_no_session(self):
         SessionManager.sessions = {}
         SessionManager.default_session = SessionManager.sessions["default"] = Session("default")
-        SessionManager.default_session.lang = "en-us"
+        SessionManager.default_session.lang = "en-US"
         SessionManager.default_session.pipeline = [
             "converse",
             "padatious_high",
@@ -85,7 +85,7 @@ class TestSessions(TestCase):
         # (missing in utterance message) and kept in all messages
         for m in messages[1:]:
             self.assertEqual(m.context["session"]["session_id"], "default")
-            self.assertEqual(m.context["lang"], "en-us")
+            self.assertEqual(m.context["lang"], "en-US")
 
         # verify skill is activated
         self.assertEqual(messages[1].msg_type, "intent.service.skills.activated")
@@ -157,7 +157,7 @@ class TestSessions(TestCase):
         # (missing in utterance message) and kept in all messages
         for m in messages[1:]:
             self.assertEqual(m.context["session"]["session_id"], "default")
-            self.assertEqual(m.context["lang"], "en-us")
+            self.assertEqual(m.context["lang"], "en-US")
 
         # verify that "lang" is injected by converse.ping
         # (missing in utterance message) and kept in all messages
@@ -250,7 +250,7 @@ class TestSessions(TestCase):
         # (missing in utterance message) and kept in all messages
         for m in messages[1:]:
             self.assertEqual(m.context["session"]["session_id"], "default")
-            self.assertEqual(m.context["lang"], "en-us")
+            self.assertEqual(m.context["lang"], "en-US")
 
         # converse
         self.assertEqual(messages[1].msg_type, f"{self.other_skill_id}.converse.ping")
@@ -339,7 +339,7 @@ class TestSessions(TestCase):
         # (missing in utterance message) and kept in all messages
         for m in messages[1:]:
             self.assertEqual(m.context["session"]["session_id"], "default")
-            self.assertEqual(m.context["lang"], "en-us")
+            self.assertEqual(m.context["lang"], "en-US")
 
         # converse
         self.assertEqual(messages[1].msg_type, f"{self.skill_id}.converse.ping")

--- a/test/end2end/session/test_fallback.py
+++ b/test/end2end/session/test_fallback.py
@@ -19,7 +19,7 @@ class TestFallback(TestCase):
     def test_fallback(self):
         SessionManager.sessions = {}
         SessionManager.default_session = SessionManager.sessions["default"] = Session("default")
-        SessionManager.default_session.lang = "en-us"
+        SessionManager.default_session.lang = "en-US"
         SessionManager.default_session.pipeline = [
             "converse",
             "fallback_high",
@@ -142,7 +142,7 @@ class TestFallback(TestCase):
     def test_fallback_with_session(self):
         SessionManager.sessions = {}
         SessionManager.default_session = SessionManager.sessions["default"] = Session("default")
-        SessionManager.default_session.lang = "en-us"
+        SessionManager.default_session.lang = "en-US"
         SessionManager.default_session.pipeline = [
             "fallback_high",
             "fallback_medium",
@@ -316,7 +316,7 @@ class TestFallbackTimeout(TestCase):
     def test_fallback(self):
         SessionManager.sessions = {}
         SessionManager.default_session = SessionManager.sessions["default"] = Session("default")
-        SessionManager.default_session.lang = "en-us"
+        SessionManager.default_session.lang = "en-US"
         SessionManager.default_session.pipeline = [
             "fallback_medium",
             "fallback_low"

--- a/test/end2end/session/test_get_response.py
+++ b/test/end2end/session/test_get_response.py
@@ -20,7 +20,7 @@ class TestSessions(TestCase):
     def test_no_response(self):
         SessionManager.sessions = {}
         SessionManager.default_session = SessionManager.sessions["default"] = Session("default")
-        SessionManager.default_session.lang = "en-us"
+        SessionManager.default_session.lang = "en-US"
         SessionManager.default_session.pipeline = [
                            "converse",
                            "padatious_high",
@@ -100,7 +100,7 @@ class TestSessions(TestCase):
         # (missing in utterance message) and kept in all messages
         for m in messages[1:]:
             self.assertEqual(m.context["session"]["session_id"], "default")
-            self.assertEqual(m.context["lang"], "en-us")
+            self.assertEqual(m.context["lang"], "en-US")
 
         # verify intent triggers
         self.assertEqual(messages[3].msg_type, f"{self.skill_id}:test_get_response.intent")
@@ -125,7 +125,7 @@ class TestSessions(TestCase):
         self.assertEqual(messages[7].msg_type, "enclosure.active_skill")
         self.assertEqual(messages[7].data["skill_id"], self.skill_id)
         self.assertEqual(messages[8].msg_type, "speak")
-        self.assertEqual(messages[8].data["lang"], "en-us")
+        self.assertEqual(messages[8].data["lang"], "en-US")
         self.assertTrue(messages[8].data["expect_response"])  # listen after dialog
         self.assertEqual(messages[8].data["meta"]["skill"], self.skill_id)
         self.assertEqual(messages[9].msg_type, "recognizer_loop:audio_output_start")
@@ -142,7 +142,7 @@ class TestSessions(TestCase):
         self.assertEqual(messages[14].msg_type, "enclosure.active_skill")
         self.assertEqual(messages[14].data["skill_id"], self.skill_id)
         self.assertEqual(messages[15].msg_type, "speak")
-        self.assertEqual(messages[15].data["lang"], "en-us")
+        self.assertEqual(messages[15].data["lang"], "en-US")
         self.assertFalse(messages[15].data["expect_response"])
         self.assertEqual(messages[15].data["utterance"], "ERROR")
         self.assertEqual(messages[15].data["meta"]["skill"], self.skill_id)
@@ -163,7 +163,7 @@ class TestSessions(TestCase):
     def test_with_response(self):
         SessionManager.sessions = {}
         SessionManager.default_session = SessionManager.sessions["default"] = Session("default")
-        SessionManager.default_session.lang = "en-us"
+        SessionManager.default_session.lang = "en-US"
         SessionManager.default_session.pipeline = [
                            "converse",
                            "padatious_high",
@@ -279,7 +279,7 @@ class TestSessions(TestCase):
         self.assertEqual(messages[7].data["skill_id"], self.skill_id)
         self.assertEqual(messages[8].msg_type, "speak")
         self.assertEqual(messages[8].data["utterance"], "give me an answer", )
-        self.assertEqual(messages[8].data["lang"], "en-us")
+        self.assertEqual(messages[8].data["lang"], "en-US")
         self.assertTrue(messages[8].data["expect_response"])  # listen after dialog
         self.assertEqual(messages[8].data["meta"]["skill"], self.skill_id)
         # ovos-audio speak execution (simulated)
@@ -308,7 +308,7 @@ class TestSessions(TestCase):
         self.assertEqual(messages[19].msg_type, "enclosure.active_skill")
         self.assertEqual(messages[19].data["skill_id"], self.skill_id)
         self.assertEqual(messages[20].msg_type, "speak")
-        self.assertEqual(messages[20].data["lang"], "en-us")
+        self.assertEqual(messages[20].data["lang"], "en-US")
         self.assertFalse(messages[20].data["expect_response"])
         self.assertEqual(messages[20].data["utterance"], "ok")
         self.assertEqual(messages[20].data["meta"]["skill"], self.skill_id)
@@ -329,7 +329,7 @@ class TestSessions(TestCase):
     def test_cancel_response(self):
         SessionManager.sessions = {}
         SessionManager.default_session = SessionManager.sessions["default"] = Session("default")
-        SessionManager.default_session.lang = "en-us"
+        SessionManager.default_session.lang = "en-US"
         SessionManager.default_session.pipeline = [
                            "converse",
                            "padatious_high",
@@ -445,7 +445,7 @@ class TestSessions(TestCase):
         self.assertEqual(messages[7].data["skill_id"], self.skill_id)
         self.assertEqual(messages[8].msg_type, "speak")
         self.assertEqual(messages[8].data["utterance"], "give me an answer", )
-        self.assertEqual(messages[8].data["lang"], "en-us")
+        self.assertEqual(messages[8].data["lang"], "en-US")
         self.assertTrue(messages[8].data["expect_response"])  # listen after dialog
         self.assertEqual(messages[8].data["meta"]["skill"], self.skill_id)
         # ovos-audio speak execution (simulated)
@@ -473,7 +473,7 @@ class TestSessions(TestCase):
         self.assertEqual(messages[19].msg_type, "enclosure.active_skill")
         self.assertEqual(messages[19].data["skill_id"], self.skill_id)
         self.assertEqual(messages[20].msg_type, "speak")
-        self.assertEqual(messages[20].data["lang"], "en-us")
+        self.assertEqual(messages[20].data["lang"], "en-US")
         self.assertFalse(messages[20].data["expect_response"])
         self.assertEqual(messages[20].data["utterance"], "ERROR")
         self.assertEqual(messages[20].data["meta"]["skill"], self.skill_id)
@@ -494,7 +494,7 @@ class TestSessions(TestCase):
     def test_with_reprompt(self):
         SessionManager.sessions = {}
         SessionManager.default_session = SessionManager.sessions["default"] = Session("default")
-        SessionManager.default_session.lang = "en-us"
+        SessionManager.default_session.lang = "en-US"
         SessionManager.default_session.pipeline = [
                            "converse",
                            "padatious_high",
@@ -629,7 +629,7 @@ class TestSessions(TestCase):
         self.assertEqual(messages[18].msg_type, "enclosure.active_skill")
         self.assertEqual(messages[18].data["skill_id"], self.skill_id)
         self.assertEqual(messages[19].msg_type, "speak")
-        self.assertEqual(messages[19].data["lang"], "en-us")
+        self.assertEqual(messages[19].data["lang"], "en-US")
         self.assertFalse(messages[19].data["expect_response"])
         self.assertEqual(messages[19].data["utterance"], "ok")
         self.assertEqual(messages[19].data["meta"]["skill"], self.skill_id)
@@ -647,7 +647,7 @@ class TestSessions(TestCase):
     def test_nested(self):
         SessionManager.sessions = {}
         SessionManager.default_session = SessionManager.sessions["default"] = Session("default")
-        SessionManager.default_session.lang = "en-us"
+        SessionManager.default_session.lang = "en-US"
         SessionManager.default_session.pipeline = [
                            "converse",
                            "padatious_high",
@@ -801,7 +801,7 @@ class TestSessions(TestCase):
         self.assertEqual(messages[5].msg_type, "enclosure.active_skill")
         self.assertEqual(messages[5].data["skill_id"], self.skill_id)
         self.assertEqual(messages[6].msg_type, "speak")
-        self.assertEqual(messages[6].data["lang"], "en-us")
+        self.assertEqual(messages[6].data["lang"], "en-US")
         self.assertFalse(messages[6].data["expect_response"])
         self.assertEqual(messages[6].data["utterance"], "give me items")
         self.assertEqual(messages[6].data["meta"]["skill"], self.skill_id)
@@ -847,7 +847,7 @@ class TestSessions(TestCase):
     def test_kill_response(self):
         SessionManager.sessions = {}
         SessionManager.default_session = SessionManager.sessions["default"] = Session("default")
-        SessionManager.default_session.lang = "en-us"
+        SessionManager.default_session.lang = "en-US"
         SessionManager.default_session.pipeline = [
             "converse",
             "padatious_high",

--- a/test/end2end/session/test_sched.py
+++ b/test/end2end/session/test_sched.py
@@ -16,7 +16,7 @@ class TestSessions(TestCase):
     def test_no_session(self):
         SessionManager.sessions = {}
         SessionManager.default_session = SessionManager.sessions["default"] = Session("default")
-        SessionManager.default_session.lang = "en-us"
+        SessionManager.default_session.lang = "en-US"
         SessionManager.default_session.pipeline = [
                            "adapt_high"
                        ]
@@ -74,7 +74,7 @@ class TestSessions(TestCase):
         # (missing in utterance message) and kept in all messages
         for m in messages[1:]:
             self.assertEqual(m.context["session"]["session_id"], "default")
-            self.assertEqual(m.context["lang"], "en-us")
+            self.assertEqual(m.context["lang"], "en-US")
 
         # verify skill_id is now present in every message.context
         self.assertEqual(messages[1].msg_type, "intent.service.skills.activated")
@@ -94,7 +94,7 @@ class TestSessions(TestCase):
         self.assertEqual(messages[5].msg_type, "enclosure.active_skill")
         self.assertEqual(messages[5].data["skill_id"], self.skill_id)
         self.assertEqual(messages[6].msg_type, "speak")
-        self.assertEqual(messages[6].data["lang"], "en-us")
+        self.assertEqual(messages[6].data["lang"], "en-US")
         self.assertFalse(messages[6].data["expect_response"])
         self.assertEqual(messages[6].data["meta"]["dialog"], "done")
         self.assertEqual(messages[6].data["meta"]["skill"], self.skill_id)
@@ -122,7 +122,7 @@ class TestSessions(TestCase):
         self.assertEqual(messages[12].msg_type, "enclosure.active_skill")
         self.assertEqual(messages[12].context, intent_context)
         self.assertEqual(messages[13].msg_type, "speak")
-        self.assertEqual(messages[13].data["lang"], "en-us")
+        self.assertEqual(messages[13].data["lang"], "en-US")
         self.assertFalse(messages[13].data["expect_response"])
         self.assertEqual(messages[13].data["meta"]["dialog"], "trigger")
         self.assertEqual(messages[13].data["meta"]["skill"], self.skill_id)
@@ -131,7 +131,7 @@ class TestSessions(TestCase):
     def test_explicit_session(self):
         SessionManager.sessions = {}
         SessionManager.default_session = SessionManager.sessions["default"] = Session("default")
-        SessionManager.default_session.lang = "en-us"
+        SessionManager.default_session.lang = "en-US"
         SessionManager.default_session.pipeline = [
                            "adapt_high"
                        ]
@@ -212,7 +212,7 @@ class TestSessions(TestCase):
         self.assertEqual(messages[5].msg_type, "enclosure.active_skill")
         self.assertEqual(messages[5].data["skill_id"], self.skill_id)
         self.assertEqual(messages[6].msg_type, "speak")
-        self.assertEqual(messages[6].data["lang"], "en-us")
+        self.assertEqual(messages[6].data["lang"], "en-US")
         self.assertFalse(messages[6].data["expect_response"])
         self.assertEqual(messages[6].data["meta"]["dialog"], "done")
         self.assertEqual(messages[6].data["meta"]["skill"], self.skill_id)
@@ -229,7 +229,7 @@ class TestSessions(TestCase):
         self.assertEqual(messages[11].msg_type, "enclosure.active_skill")
         self.assertEqual(messages[11].context, intent_context)
         self.assertEqual(messages[12].msg_type, "speak")
-        self.assertEqual(messages[12].data["lang"], "en-us")
+        self.assertEqual(messages[12].data["lang"], "en-US")
         self.assertFalse(messages[12].data["expect_response"])
         self.assertEqual(messages[12].data["meta"]["dialog"], "trigger")
         self.assertEqual(messages[12].data["meta"]["skill"], self.skill_id)

--- a/test/end2end/session/test_session.py
+++ b/test/end2end/session/test_session.py
@@ -20,7 +20,7 @@ class TestSessions(TestCase):
     def test_no_session(self):
         SessionManager.sessions = {}
         SessionManager.default_session = SessionManager.sessions["default"] = Session("default")
-        SessionManager.default_session.lang = "en-us"
+        SessionManager.default_session.lang = "en-US"
         SessionManager.default_session.pipeline = [
             "adapt_high"
         ]
@@ -73,7 +73,7 @@ class TestSessions(TestCase):
         # (missing in utterance message) and kept in all messages
         for m in messages[1:]:
             self.assertEqual(m.context["session"]["session_id"], "default")
-            self.assertEqual(m.context["lang"], "en-us")
+            self.assertEqual(m.context["lang"], "en-US")
 
         # verify skill is activated
         self.assertEqual(messages[1].msg_type, "intent.service.skills.activated")
@@ -105,7 +105,7 @@ class TestSessions(TestCase):
     def test_explicit_default_session(self):
         SessionManager.sessions = {}
         SessionManager.default_session = SessionManager.sessions["default"] = Session("default")
-        SessionManager.default_session.lang = "en-us"
+        SessionManager.default_session.lang = "en-US"
         now = time.time()
         SessionManager.default_session.active_skills = [(self.skill_id, now)]
         SessionManager.default_session.pipeline = [
@@ -206,7 +206,7 @@ class TestSessions(TestCase):
     def test_explicit_session(self):
         SessionManager.sessions = {}
         SessionManager.default_session = SessionManager.sessions["default"] = Session("default")
-        SessionManager.default_session.lang = "en-us"
+        SessionManager.default_session.lang = "en-US"
         SessionManager.default_session.pipeline = [
             "converse",
             "adapt_high"
@@ -295,7 +295,7 @@ class TestSessions(TestCase):
         self.assertEqual(messages[7].msg_type, "enclosure.active_skill")
         self.assertEqual(messages[7].data["skill_id"], self.skill_id)
         self.assertEqual(messages[8].msg_type, "speak")
-        self.assertEqual(messages[8].data["lang"], "en-us")
+        self.assertEqual(messages[8].data["lang"], "en-US")
         self.assertFalse(messages[8].data["expect_response"])
         self.assertEqual(messages[8].data["meta"]["dialog"], "hello.world")
         self.assertEqual(messages[8].data["meta"]["skill"], self.skill_id)

--- a/test/end2end/session/test_stop.py
+++ b/test/end2end/session/test_stop.py
@@ -20,7 +20,7 @@ class TestSessions(TestCase):
     def test_old_stop(self):
         SessionManager.sessions = {}
         SessionManager.default_session = SessionManager.sessions["default"] = Session("default")
-        SessionManager.default_session.lang = "en-us"
+        SessionManager.default_session.lang = "en-US"
         SessionManager.default_session.pipeline = [
             "stop_high",
             "adapt_high"
@@ -196,7 +196,7 @@ class TestSessions(TestCase):
     def test_new_stop(self):
         SessionManager.sessions = {}
         SessionManager.default_session = SessionManager.sessions["default"] = Session("default")
-        SessionManager.default_session.lang = "en-us"
+        SessionManager.default_session.lang = "en-US"
         SessionManager.default_session.pipeline = [
             "stop_high",
             "adapt_high",

--- a/test/end2end/session/test_transformers.py
+++ b/test/end2end/session/test_transformers.py
@@ -32,7 +32,7 @@ class TestTransformerPlugins(TestCase):
 
         SessionManager.sessions = {}
         SessionManager.default_session = SessionManager.sessions["default"] = Session("default")
-        SessionManager.default_session.lang = "en-us"
+        SessionManager.default_session.lang = "en-US"
         SessionManager.default_session.active_skills = [(self.skill_id, time.time())]
         SessionManager.default_session.pipeline = [
             "stop_high",
@@ -105,7 +105,7 @@ class TestTransformerPlugins(TestCase):
 
         SessionManager.sessions = {}
         SessionManager.default_session = SessionManager.sessions["default"] = Session("default")
-        SessionManager.default_session.lang = "en-us"
+        SessionManager.default_session.lang = "en-US"
         SessionManager.default_session.active_skills = [(self.skill_id, time.time())]
         SessionManager.default_session.pipeline = [
             "stop_high",

--- a/test/integrationtests/common_query/test_continuous_dialog.py
+++ b/test/integrationtests/common_query/test_continuous_dialog.py
@@ -49,7 +49,7 @@ class TestDialog(unittest.TestCase):
         self.assertEqual(self.bus.emitted_msgs[-1],
                          {'context': {'skill_id': 'wiki.test'},
                           'data': {'expect_response': False,
-                                   'lang': 'en-us',
+                                   'lang': 'en-US',
                                    'meta': {'skill': 'wiki.test'},
                                    'utterance': 'answer 1'},
                           'type': 'speak'})
@@ -61,7 +61,7 @@ class TestDialog(unittest.TestCase):
         self.assertEqual(self.bus.emitted_msgs[-1],
                          {'context': {'skill_id': 'wiki.test'},
                           'data': {'expect_response': False,
-                                   'lang': 'en-us',
+                                   'lang': 'en-US',
                                    'meta': {'skill': 'wiki.test'},
                                    'utterance': 'answer 2'},
                           'type': 'speak'})

--- a/test/integrationtests/test_workshop.py
+++ b/test/integrationtests/test_workshop.py
@@ -106,7 +106,7 @@ class TestKillableIntents(unittest.TestCase):
         speak_msg = {'type': 'speak',
                      'data': {'utterance': 'still here', 'expect_response': False,
                               'meta': {'skill': 'abort.test'},
-                              'lang': 'en-us'}}
+                              'lang': 'en-US'}}
         self.assertIn(start_msg, self.bus.emitted_msgs)
         self.assertIn(speak_msg, self.bus.emitted_msgs)
         self.assertTrue(self.skill.instance.my_special_var == "changed")
@@ -129,7 +129,7 @@ class TestKillableIntents(unittest.TestCase):
         speak_msg = {'type': 'speak',
                      'data': {'utterance': 'I am dead', 'expect_response': False,
                               'meta': {'skill': 'abort.test'},
-                              'lang': 'en-us'}}
+                              'lang': 'en-US'}}
         self.assertIn(speak_msg, self.bus.emitted_msgs)
         self.assertTrue(self.skill.instance.my_special_var == "default")
 
@@ -149,7 +149,7 @@ class TestKillableIntents(unittest.TestCase):
                      'data': {'name': 'TestAbortSkill.handle_test_abort_intent'}}
         speak_msg = {'type': 'speak',
                      'data': {'utterance': 'still here', 'expect_response': False,
-                              'meta': {'skill': 'abort.test'}, 'lang': 'en-us'}}
+                              'meta': {'skill': 'abort.test'}, 'lang': 'en-US'}}
         self.assertIn(start_msg, self.bus.emitted_msgs)
         self.assertIn(speak_msg, self.bus.emitted_msgs)
         self.assertTrue(self.skill.instance.my_special_var == "changed")
@@ -171,7 +171,7 @@ class TestKillableIntents(unittest.TestCase):
         speak_msg = {'type': 'speak',
                      'data': {'utterance': 'I am dead', 'expect_response': False,
                               'meta': {'skill': 'abort.test'},
-                              'lang': 'en-us'}}
+                              'lang': 'en-US'}}
 
         self.assertIn(speak_msg, self.bus.emitted_msgs)
         self.assertTrue(self.skill.instance.my_special_var == "default")
@@ -198,7 +198,7 @@ class TestKillableIntents(unittest.TestCase):
                      'data': {'utterance': 'this is a question',
                               'expect_response': True,
                               'meta': {'dialog': 'question', 'data': {}, 'skill': 'abort.test'},
-                              'lang': 'en-us'}}
+                              'lang': 'en-US'}}
         activate_msg = {'type': 'intent.service.skills.activate', 'data': {'skill_id': 'abort.test'}}
 
         self.assertIn(start_msg, self.bus.emitted_msgs)
@@ -219,7 +219,7 @@ class TestKillableIntents(unittest.TestCase):
                      'data': {'utterance': 'question aborted',
                               'expect_response': False,
                               'meta': {'skill': 'abort.test'},
-                              'lang': 'en-us'}}
+                              'lang': 'en-US'}}
         self.assertIn(speak_msg, self.bus.emitted_msgs)
 
     def test_developer_stop_msg(self):
@@ -236,7 +236,7 @@ class TestKillableIntents(unittest.TestCase):
                      'data': {'utterance': "you can't abort me",
                               'expect_response': False,
                               'meta': {'skill': 'abort.test'},
-                              'lang': 'en-us'}}
+                              'lang': 'en-US'}}
         self.assertIn(start_msg, self.bus.emitted_msgs)
         self.assertIn(speak_msg, self.bus.emitted_msgs)
 
@@ -265,7 +265,7 @@ class TestKillableIntents(unittest.TestCase):
         speak_msg = {'type': 'speak',
                      'data': {'utterance': 'I am dead', 'expect_response': False,
                               'meta': {'skill': 'abort.test'},
-                              'lang': 'en-us'}}
+                              'lang': 'en-US'}}
         self.assertIn(speak_msg, self.bus.emitted_msgs)
         self.assertTrue(self.skill.instance.my_special_var == "default")
 

--- a/test/unittests/test_intent_service.py
+++ b/test/unittests/test_intent_service.py
@@ -31,7 +31,7 @@ BASE_CONF['lang'] = 'it-it'
 NO_LANG_CONF = deepcopy(LocalConf(DEFAULT_CONFIG))
 NO_LANG_CONF.pop('lang')
 
-setup_locale("en-us")
+setup_locale("en-US")
 
 
 class MockEmitter(object):
@@ -104,7 +104,7 @@ class TestLanguageExtraction(TestCase):
         setup_locale("it-it")
         msg = Message('test msg', data={})
         self.assertEqual(get_message_lang(msg), 'it-IT')
-        setup_locale("en-us")
+        setup_locale("en-US")
         self.assertEqual(get_message_lang(msg), 'en-US')
 
     @mock.patch.dict(Configuration._Configuration__patch, BASE_CONF)

--- a/test/unittests/test_intent_service.py
+++ b/test/unittests/test_intent_service.py
@@ -103,17 +103,17 @@ class TestLanguageExtraction(TestCase):
         """No lang in message should result in lang from active locale."""
         setup_locale("it-it")
         msg = Message('test msg', data={})
-        self.assertEqual(get_message_lang(msg), 'it-it')
+        self.assertEqual(get_message_lang(msg), 'it-IT')
         setup_locale("en-us")
-        self.assertEqual(get_message_lang(msg), 'en-us')
+        self.assertEqual(get_message_lang(msg), 'en-US')
 
     @mock.patch.dict(Configuration._Configuration__patch, BASE_CONF)
     def test_lang_exists(self):
         """Message has a lang code in data, it should be used."""
         msg = Message('test msg', data={'lang': 'de-de'})
-        self.assertEqual(get_message_lang(msg), 'de-de')
+        self.assertEqual(get_message_lang(msg), 'de-DE')
         msg = Message('test msg', data={'lang': 'sv-se'})
-        self.assertEqual(get_message_lang(msg), 'sv-se')
+        self.assertEqual(get_message_lang(msg), 'sv-SE')
 
 
 def create_old_style_vocab_msg(keyword, value):

--- a/test/unittests/xformers.py
+++ b/test/unittests/xformers.py
@@ -67,7 +67,7 @@ class TextTransformersTests(unittest.TestCase):
     def test_utterance_transformer_service_priority(self):
 
         utterances = ["test 1", "test one"]
-        lang = "en-us"
+        lang = "en-US"
 
         def mod_1_parse(utterances, lang):
             utterances.append("mod 1 parsed")


### PR DESCRIPTION
makes intents match regardless of upper or lowercase being used in lang code, and brings initial support for dynamic dialects in the pipeline plugins

companion PRs:
- https://github.com/OpenVoiceOS/ovos-adapt-pipeline-plugin/pull/10
- https://github.com/OpenVoiceOS/ovos-padatious-pipeline-plugin/pull/13
- https://github.com/OpenVoiceOS/ovos-ocp-pipeline-plugin/pull/12
- https://github.com/OpenVoiceOS/ovos-common-query-pipeline-plugin/pull/9
- https://github.com/OpenVoiceOS/padacioso/pull/27
- https://github.com/OpenVoiceOS/ovos-utterance-plugin-cancel/pull/12
- https://github.com/OpenVoiceOS/OVOS-workshop/pull/254
- https://github.com/OpenVoiceOS/ovos-utils/pull/281 + https://github.com/OpenVoiceOS/ovos-utils/pull/283
- https://github.com/OpenVoiceOS/ovos-bus-client/pull/128

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced language handling across various services for improved consistency.
  
- **Bug Fixes**
	- Corrected language code formatting in multiple test cases to ensure uniformity.

- **Chores**
	- Updated dependency versions for improved stability and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->