### PR TITLE
fix: update deprecated imports from ovos-utils

### DIFF
--- a/test/backwards_compat/test_ocp.py
+++ b/test/backwards_compat/test_ocp.py
@@ -17,7 +17,7 @@ from mycroft.audio.audioservice import AudioService
 # from mycroft.configuration import Configuration
 from mycroft.skills.intent_service import IntentService
 from mycroft.skills.skill_loader import SkillLoader
-from ovos_utils.messagebus import FakeBus
+from ovos_utils.fakebus import FakeBus
 
 # Patch Configuration in the audioservice module to ensure its patched
 from ovos_config.config import Configuration

--- a/test/end2end/minicroft.py
+++ b/test/end2end/minicroft.py
@@ -6,7 +6,7 @@ from ovos_core.intent_services import IntentService
 from ovos_core.skill_manager import SkillManager
 from ovos_plugin_manager.skills import find_skill_plugins
 from ovos_utils.log import LOG
-from ovos_utils.messagebus import FakeBus
+from ovos_utils.fakebus import FakeBus
 from ovos_utils.process_utils import ProcessState
 from ovos_workshop.skills.fallback import FallbackSkill
 

--- a/test/integrationtests/common_query/test_continuous_dialog.py
+++ b/test/integrationtests/common_query/test_continuous_dialog.py
@@ -2,7 +2,7 @@ import json
 import unittest
 
 from ovos_tskill_fakewiki import FakeWikiSkill
-from ovos_utils.messagebus import FakeBus, Message
+from ovos_utils.fakebus import FakeBus, FakeMessage as Message
 
 
 class TestDialog(unittest.TestCase):

--- a/test/integrationtests/common_query/test_skill.py
+++ b/test/integrationtests/common_query/test_skill.py
@@ -1,7 +1,7 @@
 import json
 import unittest
 
-from ovos_utils.messagebus import FakeBus
+from ovos_utils.fakebus import FakeBus
 from ovos_tskill_fakewiki import FakeWikiSkill
 from ovos_workshop.skills.common_query_skill import CommonQuerySkill
 

--- a/test/integrationtests/test_workshop.py
+++ b/test/integrationtests/test_workshop.py
@@ -4,7 +4,7 @@ from os.path import dirname
 from time import sleep
 from ovos_workshop.skill_launcher import SkillLoader
 from ovos_workshop.skills.ovos import OVOSSkill
-from ovos_utils.messagebus import FakeBus, Message
+from ovos_utils.fakebus import FakeBus, FakeMessage as Message
 
 # tests taken from ovos_workshop
 

--- a/test/unittests/test_skill_manager.py
+++ b/test/unittests/test_skill_manager.py
@@ -57,7 +57,6 @@ def mock_config():
     config = deepcopy(LocalConf(DEFAULT_CONFIG))
     config['skills']['priority_skills'] = ['foobar']
     config['data_dir'] = str(tempfile.mkdtemp())
-    config['server']['metrics'] = False
     config['enclosure'] = {}
     return config
 
@@ -71,8 +70,6 @@ class TestSkillManager(TestCase):
         self.temp_dir = Path(temp_dir)
         self.message_bus_mock = MessageBusMock()
         self._mock_log()
-        self._mock_skill_updater()
-        self._mock_skill_settings_downloader()
         self.skill_manager = SkillManager(self.message_bus_mock)
         self._mock_skill_loader_instance()
 
@@ -83,22 +80,6 @@ class TestSkillManager(TestCase):
 
     def tearDown(self):
         rmtree(str(self.temp_dir))
-
-    def _mock_skill_settings_downloader(self):
-        settings_download_patch = patch(
-            self.mock_package + 'SkillSettingsDownloader',
-            spec=True
-        )
-        self.addCleanup(settings_download_patch.stop)
-        self.settings_download_mock = settings_download_patch.start()
-
-    def _mock_skill_updater(self):
-        skill_updater_patch = patch(
-            self.mock_package + 'SkillUpdater',
-            spec=True
-        )
-        self.addCleanup(skill_updater_patch.stop)
-        self.skill_updater_mock = skill_updater_patch.start()
 
     def _mock_skill_loader_instance(self):
         self.skill_dir = self.temp_dir.joinpath('test_skill')

--- a/test/unittests/xformers.py
+++ b/test/unittests/xformers.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock
 from ovos_core.transformers import UtteranceTransformersService
 from ovos_plugin_manager.templates.transformers import UtteranceTransformer
 
-from ovos_utils.messagebus import FakeBus
+from ovos_utils.fakebus import FakeBus
 
 
 class MockTransformer(UtteranceTransformer):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated import statements for `FakeBus` and `Message` across various test files to reflect new module organization.
  
- **Refactor**
	- Enhanced test structure by consistently applying configuration mocking across test classes.
	- Removed unnecessary mocking methods in `TestSkillManager` to simplify test setup. 

These changes improve the reliability and maintainability of the testing framework while ensuring consistent behavior across tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->