### PR TITLE
fix:ocp-pipeline>=1.0.8

### DIFF
--- a/requirements/plugins.txt
+++ b/requirements/plugins.txt
@@ -1,5 +1,5 @@
 ovos-utterance-corrections-plugin>=0.0.2, <1.0.0
-ovos-utterance-plugin-cancel>=0.2.2, <1.0.0
+ovos-utterance-plugin-cancel>=0.2.3, <1.0.0
 ovos-bidirectional-translation-plugin>=0.1.0, <1.0.0
 ovos-translate-server-plugin>=0.0.2, <1.0.0
 ovos-utterance-normalizer>=0.2.1, <1.0.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -5,11 +5,11 @@ combo-lock>=0.2.2, <0.4
 
 padacioso>=1.0.0, <2.0.0
 ovos-adapt-parser>=1.0.5, <2.0.0
-ovos_ocp_pipeline_plugin>=1.0.7, <2.0.0
+ovos_ocp_pipeline_plugin>=1.0.10, <2.0.0
 ovos-common-query-pipeline-plugin>=1.0.5, <2.0.0
 
 ovos-utils[extras]>=0.6.0,<1.0.0
 ovos_bus_client>=0.1.4,<2.0.0
 ovos-plugin-manager>=0.5.6,<1.0.0
 ovos-config>=0.0.13,<2.0.0
-ovos-workshop>=3.0.1,<4.0.0
+ovos-workshop>=3.1.2,<4.0.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -5,7 +5,7 @@ combo-lock>=0.2.2, <0.4
 
 padacioso>=1.0.0, <2.0.0
 ovos-adapt-parser>=1.0.5, <2.0.0
-ovos_ocp_pipeline_plugin==1.0.7
+ovos_ocp_pipeline_plugin>=1.0.7, <2.0.0
 ovos-common-query-pipeline-plugin>=1.0.5, <2.0.0
 
 ovos-utils[extras]>=0.6.0,<1.0.0

--- a/test/end2end/session/test_ocp.py
+++ b/test/end2end/session/test_ocp.py
@@ -126,6 +126,7 @@ class TestOCPPipeline(TestCase):
             "recognizer_loop:utterance",
             "ovos.common_play.status",
             "ovos.common_play.SEI.get",  # request player info
+            "ovos.common_play.SEI.get",  # (we didnt get player answer, so we try again)
             # no response
             "ovos.common_play.activate",
             "ocp:play",
@@ -142,6 +143,7 @@ class TestOCPPipeline(TestCase):
             "ovos.common_play.query.response",
             "ovos.common_play.query.response",
             "ovos.common_play.skill.search_end",
+            "ovos.common_play.SEI.get",  # request info again, cause player didnt answer before
             "ovos.common_play.search.end",
             "ovos.common_play.reset",
             
@@ -500,6 +502,10 @@ class TestOCPPipeline(TestCase):
             "ovos.common_play.reset",
             "add_context",  # NowPlaying context
             'mycroft.audio.service.play',  # LEGACY api
+            "mycroft.audio.service.queue",
+            "mycroft.audio.service.queue",
+            "mycroft.audio.service.queue",
+            "mycroft.audio.service.queue",
             "ovos.common_play.search.populate",
             "ovos.utterance.handled",  # handle_utterance returned (intent service)
         ]


### PR DESCRIPTION
since https://github.com/OpenVoiceOS/ovos-ocp-pipeline-plugin/pull/34 end2end tests started to fail

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved test coverage for player information retrieval and legacy audio service interactions.
	- Enhanced robustness of tests to ensure system retries fetching player information when necessary.

- **Tests**
	- Updated expected message sequences in various test methods for better alignment with system interactions.
	- Added new message checks for legacy audio service in test cases. 

- **Chores**
	- Updated dependency version specifications for improved flexibility in version selection:
		- `ovos_ocp_pipeline_plugin` updated to `>=1.0.10, <2.0.0`
		- `ovos-workshop` updated to `>=3.1.2,<4.0.0`
		- `ovos-utterance-plugin-cancel` updated to `>=0.2.3, <1.0.0`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->