### PR TITLE
fix: logs and pipeline query api

### DIFF
--- a/ovos_core/intent_services/__init__.py
+++ b/ovos_core/intent_services/__init__.py
@@ -17,7 +17,6 @@ from typing import Tuple, Callable, Union
 
 from ovos_adapt.opm import AdaptPipeline
 from ovos_commonqa.opm import CommonQAService
-from padacioso.opm import PadaciosoPipeline as PadaciosoService
 
 from ocp_pipeline.opm import OCPPipelineMatcher
 from ovos_bus_client.message import Message
@@ -33,6 +32,7 @@ from ovos_plugin_manager.templates.pipeline import PipelineMatch, IntentHandlerM
 from ovos_utils.lang import standardize_lang_tag
 from ovos_utils.log import LOG, log_deprecation, deprecated
 from ovos_utils.metrics import Stopwatch
+from padacioso.opm import PadaciosoPipeline as PadaciosoService
 
 
 class IntentService:
@@ -355,6 +355,7 @@ class IntentService:
         lang = self.disambiguate_lang(message)
 
         utterances = message.data.get('utterances', [])
+        LOG.info(f"Parsing utterance: {utterances}")
 
         stopwatch = Stopwatch()
 
@@ -465,6 +466,7 @@ class IntentService:
 
         # Loop through the matching functions until a match is found.
         for pipeline, match_func in self.get_pipeline(skips=["converse",
+                                                             "common_qa",
                                                              "fallback_high",
                                                              "fallback_medium",
                                                              "fallback_low"],

--- a/ovos_core/intent_services/converse_service.py
+++ b/ovos_core/intent_services/converse_service.py
@@ -335,6 +335,7 @@ class ConverseService(PipelinePlugin):
             if skill_id in session.blacklisted_skills:
                 LOG.debug(f"ignoring match, skill_id '{skill_id}' blacklisted by Session '{session.session_id}'")
                 continue
+            LOG.debug(f"Attempting to converse with skill: {skill_id}")
             if self.converse(utterances, skill_id, lang, message):
                 state = session.utterance_states.get(skill_id, UtteranceState.INTENT)
                 return PipelineMatch(handled=state != UtteranceState.RESPONSE,


### PR DESCRIPTION
skip common_qa when checking intent via bus api

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Integrated `PadaciosoService` for improved intent handling.
	- Enhanced logging for skill interactions during conversations.

- **Bug Fixes**
	- Adjusted intent matching logic to skip specific pipelines, refining intent retrieval process.

- **Documentation**
	- Updated logging statements to improve traceability of utterance parsing and skill engagement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->