### PR TITLE
fix:better_stop

### DIFF
--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       max-parallel: 2
       matrix:
-        python-version: [3.8, 3.9, "3.10", "3.11"]
+        python-version: ["3.10", "3.11"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@master
       with:
-        python-version: 3.9
+        python-version: "3.10"
     - name: Install System Dependencies
       run: |
         sudo apt-get update

--- a/.github/workflows/license_tests.yml
+++ b/.github/workflows/license_tests.yml
@@ -37,7 +37,7 @@ jobs:
           requirements: 'requirements-all.txt'
           fail: 'Copyleft,Other,Error'
           fails-only: true
-          exclude: '^(precise-runner|fann2|ovos-adapt-parser|ovos-padatious|tqdm|bs4|sonopy|caldav|recurring-ical-events|x-wr-timezone|zeroconf|mutagen).*'
+          exclude: '^(precise-runner|fann2|ovos-adapt-parser|ovos-padatious|tqdm|bs4|sonopy|caldav|recurring-ical-events|x-wr-timezone|zeroconf|mutagen|attrs).*'
           exclude-license: '^(Mozilla).*$'
       - name: Print report
         if: ${{ always() }}

--- a/.github/workflows/pipaudit.yml
+++ b/.github/workflows/pipaudit.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       max-parallel: 2
       matrix:
-        python-version: [ 3.7, 3.8, 3.9, "3.10", "3.11" ]
+        python-version: [3.9, "3.10", "3.11"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/sync_tx.yml
+++ b/.github/workflows/sync_tx.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.9
+          python-version: "3.10"
           
       - name: Run script if merged by gitlocalize-app[bot]
         if: github.event_name == 'push' && github.event.head_commit.author.username == 'gitlocalize-app[bot]'

--- a/ovos_core/intent_services/converse_service.py
+++ b/ovos_core/intent_services/converse_service.py
@@ -313,15 +313,29 @@ class ConverseService(PipelinePlugin):
         return False
 
     def converse_with_skills(self, utterances: List[str], lang: str, message: Message) -> Optional[PipelineMatch]:
-        """Give active skills a chance at the utterance
-
+        """
+        Attempt to converse with active skills for a given set of utterances.
+        
+        Iterates through active skills to find one that can handle the utterance. Filters skills based on timeout and blacklist status.
+        
         Args:
-            utterances (list):  list of utterances
-            lang (string):      4 letter ISO language code
-            message (Message):  message to use to generate reply
-
+            utterances (List[str]): List of utterance strings to process
+            lang (str): 4-letter ISO language code for the utterances
+            message (Message): Message context for generating a reply
+        
         Returns:
-            IntentMatch if handled otherwise None.
+            PipelineMatch: Match details if a skill successfully handles the utterance, otherwise None
+            - handled (bool): Whether the utterance was fully handled
+            - match_data (dict): Additional match metadata
+            - skill_id (str): ID of the skill that handled the utterance
+            - updated_session (Session): Current session state after skill interaction
+            - utterance (str): The original utterance processed
+        
+        Notes:
+            - Standardizes language tag
+            - Filters out blacklisted skills
+            - Checks for skill conversation timeouts
+            - Attempts conversation with each eligible skill
         """
         lang = standardize_lang_tag(lang)
         session = SessionManager.get(message)

--- a/ovos_core/intent_services/converse_service.py
+++ b/ovos_core/intent_services/converse_service.py
@@ -342,6 +342,7 @@ class ConverseService(PipelinePlugin):
                                      # handled == True -> emit "ovos.utterance.handled"
                                      match_data={},
                                      skill_id=skill_id,
+                                     updated_session=session,
                                      utterance=utterances[0])
         return None
 

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -12,4 +12,4 @@ ovos-utils[extras]>=0.6.0,<1.0.0
 ovos_bus_client>=0.1.4,<2.0.0
 ovos-plugin-manager>=0.8.0,<1.0.0
 ovos-config>=0.0.13,<2.0.0
-ovos-workshop>=3.3.3a1,<4.0.0
+ovos-workshop>=3.3.4a1,<4.0.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -12,4 +12,4 @@ ovos-utils[extras]>=0.6.0,<1.0.0
 ovos_bus_client>=0.1.4,<2.0.0
 ovos-plugin-manager>=0.8.0,<1.0.0
 ovos-config>=0.0.13,<2.0.0
-ovos-workshop>=3.3.4a1,<4.0.0
+ovos-workshop>=3.3.4,<4.0.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -12,4 +12,4 @@ ovos-utils[extras]>=0.6.0,<1.0.0
 ovos_bus_client>=0.1.4,<2.0.0
 ovos-plugin-manager>=0.8.0,<1.0.0
 ovos-config>=0.0.13,<2.0.0
-ovos-workshop>=3.1.2,<4.0.0
+ovos-workshop>=3.3.3a1,<4.0.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -10,6 +10,6 @@ ovos-common-query-pipeline-plugin>=1.0.5, <2.0.0
 
 ovos-utils[extras]>=0.6.0,<1.0.0
 ovos_bus_client>=0.1.4,<2.0.0
-ovos-plugin-manager>=0.5.6,<1.0.0
+ovos-plugin-manager>=0.8.0,<1.0.0
 ovos-config>=0.0.13,<2.0.0
 ovos-workshop>=3.1.2,<4.0.0

--- a/test/end2end/session/test_ocp.py
+++ b/test/end2end/session/test_ocp.py
@@ -78,11 +78,6 @@ class TestOCPPipeline(TestCase):
             "ovos.common_play.search.end",
             # no good results
             "ovos.common_play.reset",
-
-            # TODO - this is now matching ??
-            #  "add_context",
-            #  "ovos.common_play.play",
-            #  "ovos.common_play.search.populate",
             "speak",  # error,
             "ovos.utterance.handled"  # handle_utterance returned (intent service)
         ]
@@ -150,8 +145,6 @@ class TestOCPPipeline(TestCase):
             "ovos.common_play.SEI.get",  # request info again, cause player didnt answer before
             "ovos.common_play.search.end",
             "ovos.common_play.reset",
-
-            # TODO - it is matching here now?
 
             "speak",  # nothing to play
             "ovos.utterance.handled"  # handle_utterance returned (intent service)
@@ -365,8 +358,6 @@ class TestOCPPipeline(TestCase):
             "ovos.common_play.search.end",
             # no good results
             "ovos.common_play.reset",
-
-            # TODO - it is matching here now?
 
             "speak",  # error
             "ovos.utterance.handled"  # handle_utterance returned (intent service)

--- a/test/end2end/session/test_ocp.py
+++ b/test/end2end/session/test_ocp.py
@@ -78,7 +78,11 @@ class TestOCPPipeline(TestCase):
             "ovos.common_play.search.end",
             # no good results
             "ovos.common_play.reset",
-            
+
+            # TODO - this is now matching ??
+            #  "add_context",
+            #  "ovos.common_play.play",
+            #  "ovos.common_play.search.populate",
             "speak",  # error,
             "ovos.utterance.handled"  # handle_utterance returned (intent service)
         ]
@@ -146,7 +150,9 @@ class TestOCPPipeline(TestCase):
             "ovos.common_play.SEI.get",  # request info again, cause player didnt answer before
             "ovos.common_play.search.end",
             "ovos.common_play.reset",
-            
+
+            # TODO - it is matching here now?
+
             "speak",  # nothing to play
             "ovos.utterance.handled"  # handle_utterance returned (intent service)
         ]
@@ -351,11 +357,17 @@ class TestOCPPipeline(TestCase):
             # skill searching (generic)
             "ovos.common_play.skill.search_start",
             "ovos.common_play.query.response",
+            "ovos.common_play.query.response",
+            "ovos.common_play.query.response",
+            "ovos.common_play.query.response",
+            "ovos.common_play.query.response",
             "ovos.common_play.skill.search_end",
             "ovos.common_play.search.end",
             # no good results
             "ovos.common_play.reset",
-            
+
+            # TODO - it is matching here now?
+
             "speak",  # error
             "ovos.utterance.handled"  # handle_utterance returned (intent service)
         ]

--- a/test/end2end/session/test_sched.py
+++ b/test/end2end/session/test_sched.py
@@ -110,7 +110,8 @@ class TestSessions(TestCase):
         self.assertEqual(messages[8].data["session_data"]["active_skills"][0][0], self.skill_id)
 
         # ensure context in triggered event is the same from message that triggered the intent
-        intent_context = messages[1].context  # when skill added to active list (last context change)
+        intent_context = messages[-3].context  # when skill added to active list (last context change)
+        intent_context["skill_id"] = 'skill-ovos-schedule.openvoiceos'  # for tests below, skill_id is injected
 
         self.assertEqual(messages[-2].msg_type, "skill-ovos-schedule.openvoiceos:my_event")
         self.assertEqual(messages[-2].context, intent_context)

--- a/test/end2end/skill-fake-fm/__init__.py
+++ b/test/end2end/skill-fake-fm/__init__.py
@@ -15,7 +15,7 @@ class FakeFMSkill(OVOSCommonPlaybackSkill):
 
     @ocp_search()
     def search_fakefm(self, phrase, media_type):
-        score = 50
+        score = 30
         if "fake" in phrase:
             score += 35
         if media_type == MediaType.RADIO:


### PR DESCRIPTION
related https://github.com/OpenVoiceOS/OVOS-workshop/pull/323

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflows to use Python 3.10 across multiple configuration files.
	- Updated `ovos-plugin-manager` dependency to version 0.8.0.
	- Updated `ovos-workshop` dependency to version 3.3.4.

- **Improvements**
	- Enhanced intent and conversation services with improved session management.
	- Refined skill stopping mechanisms with more robust error handling.
	- Updated tests to align with new stopping logic and improve clarity.
	- Adjusted scoring logic in the `FakeFMSkill` to enhance match confidence evaluation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->