### PR TITLE
feat:multilang_match

### DIFF
--- a/ovos_core/intent_services/__init__.py
+++ b/ovos_core/intent_services/__init__.py
@@ -296,7 +296,11 @@ class IntentService:
             None
         """
         reply = None
-        sess = match.updated_session or SessionManager.get(message)
+        try:
+            sess = match.updated_session or SessionManager.get(message)
+        except AttributeError:  # old ovos-plugin-manager version
+            LOG.warning("outdated ovos-plugin-manager detected! please update to version 0.8.0")
+            sess = SessionManager.get(message)
         sess.lang = lang  # ensure it is updated
 
         # utterance fully handled by pipeline matcher


### PR DESCRIPTION
if enabled attempt to match intents across all configured langs

this allows OVOS to match even if lang was incorrectly tagged, as long as the transcription is correct

use cases aretext chatbots (eg, matrix hivemind both) or misclassifications of audio transformer plugins

example config
```json
{
  "lang": "en-US",
  "secondary_langs": [
    "pt-PT", "fr-FR"
  ],
  "intents": {
     "multilingual_matching": true
   }
 }
 ```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced multilingual intent matching support
	- Improved language processing for intent recognition

- **Bug Fixes**
	- Expanded language matching capabilities to support multiple language configurations

- **Chores**
	- Updated logging for language-specific intent matching process
	- Added language context to match messages
<!-- end of auto-generated comment: release notes by coderabbit.ai -->