### PR TITLE
feat:opendata upload

### DIFF
--- a/ovos_core/intent_services/__init__.py
+++ b/ovos_core/intent_services/__init__.py
@@ -376,9 +376,12 @@ class IntentService:
             "lang": lang,
             "match_data": match_data
         }
-        response = requests.post(api_url, data=data, headers=headers)
-        LOG.info(f"Uploaded metrics: {data} - Response: {response.status_code}")
-
+        try:
+            # Add a timeout to prevent hanging
+            response = requests.post(api_url, data=data, headers=headers, timeout=3)
+            LOG.info(f"Uploaded metrics - Response: {response.status_code}")
+        except Exception as e:
+            LOG.warning(f"Failed to upload metrics: {e}")
 
     def send_cancel_event(self, message):
         """

--- a/ovos_core/intent_services/__init__.py
+++ b/ovos_core/intent_services/__init__.py
@@ -362,7 +362,7 @@ class IntentService:
         There isn't a default server to upload things too, users needs to explicitly configure one
         eg. https://github.com/TigreGotico/metrics-server-docker
         """
-        config = self.config.get("open_data", {})
+        config = Configuration().get("open_data", {})
         endpoints: List[str] = config.get("intent_urls", []) #eg. "http://localhost:8000/intents"
         if not endpoints:
             return # user didn't configure any endpoints to upload metrics to


### PR DESCRIPTION
metrics integration for https://github.com/TigreGotico/metrics-server-docker or equivalent

```json
{
  "open_data": {
    "intent_urls": [
       "http://localhost:8000/intents",
       "https://metrics.tigregotico.pt/intents"
    ]
   }
}
```
![img](https://github.com/user-attachments/assets/a3b591fc-cc79-451e-a098-6e97fe8f2e68)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved tracking for language interpretation by automatically reporting intent matching data to a configured endpoint, enhancing performance monitoring and diagnostics. 
  - Introduced a method for uploading intent match data to specified servers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->