### PR TITLE
fix: drop unused alpha package with optional (unused) plugins

### DIFF
--- a/requirements/plugins.txt
+++ b/requirements/plugins.txt
@@ -5,5 +5,3 @@ ovos-translate-server-plugin>=0.0.2, <1.0.0
 ovos-utterance-normalizer>=0.2.1, <1.0.0
 ovos-number-parser>=0.0.1,<1.0.0
 ovos-date-parser>=0.0.3,<1.0.0
-# still in alpha
-ovos-classifiers


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated plugin requirements by removing an alpha-stage comment and the "ovos-classifiers" package from the dependencies list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->