### PR TITLE
Prevent duplicate skill loads during overlapping rescans

### DIFF
--- a/ovos_core/skill_manager.py
+++ b/ovos_core/skill_manager.py
@@ -109,6 +109,8 @@ class SkillManager(Thread):
         self.config = Configuration()
 
         self.plugin_skills = {}
+        self._plugin_skills_lock = threading.RLock()
+        self._loading_plugin_skills = set()
         self.enclosure = EnclosureAPI(bus)
         self.num_install_retries = 0
         self.empty_skill_dirs = set()  # Save a record of empty skill dirs.
@@ -209,6 +211,25 @@ class SkillManager(Thread):
         """
         return self.config['skills']
 
+    def _is_plugin_skill_tracked(self, skill_id):
+        """Check whether a skill is loaded or currently being loaded."""
+        with self._plugin_skills_lock:
+            return (skill_id in self.plugin_skills or
+                    skill_id in self._loading_plugin_skills)
+
+    def _reserve_plugin_skill_load(self, skill_id):
+        """Mark a skill as loading so overlapping scans skip it."""
+        with self._plugin_skills_lock:
+            if skill_id in self.plugin_skills or skill_id in self._loading_plugin_skills:
+                return False
+            self._loading_plugin_skills.add(skill_id)
+            return True
+
+    def _release_plugin_skill_load(self, skill_id):
+        """Clear the in-progress marker for a skill load attempt."""
+        with self._plugin_skills_lock:
+            self._loading_plugin_skills.discard(skill_id)
+
     def handle_gui_connected(self, message):
         """Handle GUI connection event.
 
@@ -295,16 +316,19 @@ class SkillManager(Thread):
                     LOG.warning(f"{skill_id} is blacklisted, it will NOT be loaded")
                     LOG.info(f"Consider uninstalling {skill_id} instead of blacklisting it")
                 continue
-            if skill_id not in self.plugin_skills:
-                skill_loader = self._get_plugin_skill_loader(skill_id, init_bus=False,
-                                                             skill_class=plug)
-                requirements = skill_loader.runtime_requirements
-                if not network and requirements.network_before_load:
-                    continue
-                if not internet and requirements.internet_before_load:
-                    continue
-                self._load_plugin_skill(skill_id, plug)
-                loaded_new = True
+            if self._is_plugin_skill_tracked(skill_id):
+                continue
+            skill_loader = self._get_plugin_skill_loader(skill_id, init_bus=False,
+                                                         skill_class=plug)
+            requirements = skill_loader.runtime_requirements
+            if not network and requirements.network_before_load:
+                continue
+            if not internet and requirements.internet_before_load:
+                continue
+            if not self._reserve_plugin_skill_load(skill_id):
+                continue
+            self._load_plugin_skill(skill_id, plug, reserved=True)
+            loaded_new = True
         return loaded_new
 
     def _get_internal_skill_bus(self):
@@ -342,18 +366,24 @@ class SkillManager(Thread):
             loader.skill_class = skill_class
         return loader
 
-    def _load_plugin_skill(self, skill_id, skill_plugin):
+    def _load_plugin_skill(self, skill_id, skill_plugin, reserved=False):
         """Load a plugin skill.
 
         Args:
             skill_id (str): ID of the skill.
             skill_plugin: Plugin skill instance.
+            reserved (bool): True if the caller already marked the skill as loading.
 
         Returns:
             PluginSkillLoader: Loaded plugin skill loader instance if successful, None otherwise.
         """
-        skill_loader = self._get_plugin_skill_loader(skill_id, skill_class=skill_plugin)
+        if not reserved and not self._reserve_plugin_skill_load(skill_id):
+            LOG.debug(f"Skipping duplicate load attempt for {skill_id}; load already in progress")
+            return None
+
+        skill_loader = None
         try:
+            skill_loader = self._get_plugin_skill_loader(skill_id, skill_class=skill_plugin)
             load_status = skill_loader.load(skill_plugin)
             if load_status:
                 self.bus.emit(Message("mycroft.skill.loaded", {"skill_id": skill_id}))
@@ -361,7 +391,10 @@ class SkillManager(Thread):
             LOG.exception(f'Load of skill {skill_id} failed!')
             load_status = False
         finally:
-            self.plugin_skills[skill_id] = skill_loader
+            if skill_loader is not None:
+                with self._plugin_skills_lock:
+                    self.plugin_skills[skill_id] = skill_loader
+            self._release_plugin_skill_load(skill_id)
 
         return skill_loader if load_status else None
 

--- a/test/unittests/test_skill_manager.py
+++ b/test/unittests/test_skill_manager.py
@@ -16,6 +16,7 @@ import tempfile
 from copy import deepcopy
 from pathlib import Path
 from shutil import rmtree
+from threading import Event, Thread
 from unittest import TestCase
 from unittest.mock import Mock, patch
 
@@ -215,6 +216,84 @@ class TestSkillManager(TestCase):
         # Verify return value
         self.assertEqual(result, mock_loader)
 
+    @patch('ovos_core.skill_manager.find_skill_plugins')
+    def test_load_plugin_skills_skips_skill_already_loading(self, mock_find_skill_plugins):
+        """Test plugin discovery skips a skill that is already being loaded."""
+        skill_id = 'test.loading.skill'
+        mock_find_skill_plugins.return_value = {skill_id: Mock()}
+        self.skill_manager.plugin_skills = {}
+        self.skill_manager._loading_plugin_skills.add(skill_id)
+        self.skill_manager._get_plugin_skill_loader = Mock()
+        self.skill_manager._load_plugin_skill = Mock()
+
+        loaded_new = self.skill_manager.load_plugin_skills(network=True, internet=True)
+
+        self.assertFalse(loaded_new)
+        self.skill_manager._get_plugin_skill_loader.assert_not_called()
+        self.skill_manager._load_plugin_skill.assert_not_called()
+
+    def test_load_plugin_skill_tracks_loading_state(self):
+        """Test a skill is marked loading before PluginSkillLoader.load runs."""
+        skill_id = 'test.tracked.skill'
+        mock_plugin = Mock()
+        mock_loader = Mock(spec=SkillLoader)
+        mock_loader.skill_id = skill_id
+
+        def load_side_effect(plugin):
+            self.assertEqual(plugin, mock_plugin)
+            self.assertIn(skill_id, self.skill_manager._loading_plugin_skills)
+            return True
+
+        mock_loader.load.side_effect = load_side_effect
+        self.skill_manager._get_plugin_skill_loader = Mock(return_value=mock_loader)
+        self.skill_manager.plugin_skills = {}
+
+        result = self.skill_manager._load_plugin_skill(skill_id, mock_plugin)
+
+        self.assertEqual(result, mock_loader)
+        self.assertNotIn(skill_id, self.skill_manager._loading_plugin_skills)
+        self.assertEqual(mock_loader, self.skill_manager.plugin_skills[skill_id])
+
+    def test_load_plugin_skill_skips_concurrent_duplicate_attempt(self):
+        """Test concurrent loads for the same skill only execute once."""
+        skill_id = 'test.concurrent.skill'
+        mock_plugin = Mock()
+        mock_loader = Mock(spec=SkillLoader)
+        mock_loader.skill_id = skill_id
+        load_started = Event()
+        allow_finish = Event()
+        results = {}
+
+        def load_side_effect(plugin):
+            self.assertEqual(plugin, mock_plugin)
+            load_started.set()
+            self.assertTrue(allow_finish.wait(2))
+            return True
+
+        mock_loader.load.side_effect = load_side_effect
+        self.skill_manager._get_plugin_skill_loader = Mock(return_value=mock_loader)
+        self.skill_manager.plugin_skills = {}
+
+        def first_load():
+            results['first'] = self.skill_manager._load_plugin_skill(skill_id, mock_plugin)
+
+        thread = Thread(target=first_load)
+        thread.start()
+        self.assertTrue(load_started.wait(1))
+
+        results['second'] = self.skill_manager._load_plugin_skill(skill_id, mock_plugin)
+
+        allow_finish.set()
+        thread.join(timeout=2)
+
+        self.assertFalse(thread.is_alive())
+        self.assertEqual(results['first'], mock_loader)
+        self.assertIsNone(results['second'])
+        self.assertEqual(1, self.skill_manager._get_plugin_skill_loader.call_count)
+        mock_loader.load.assert_called_once_with(mock_plugin)
+        self.assertNotIn(skill_id, self.skill_manager._loading_plugin_skills)
+        self.assertEqual(mock_loader, self.skill_manager.plugin_skills[skill_id])
+
     def test_load_plugin_skill_failure(self):
         """Test failed plugin skill loading is handled gracefully."""
         skill_id = 'test.failing.skill'
@@ -245,6 +324,7 @@ class TestSkillManager(TestCase):
         # Verify skill was still added to plugin_skills (even on failure)
         self.assertIn(skill_id, self.skill_manager.plugin_skills)
         self.assertEqual(mock_loader, self.skill_manager.plugin_skills[skill_id])
+        self.assertNotIn(skill_id, self.skill_manager._loading_plugin_skills)
 
         # Verify return value is None on failure
         self.assertIsNone(result)
@@ -274,6 +354,7 @@ class TestSkillManager(TestCase):
 
         # Verify skill was added to plugin_skills
         self.assertIn(skill_id, self.skill_manager.plugin_skills)
+        self.assertNotIn(skill_id, self.skill_manager._loading_plugin_skills)
 
         # Verify return value is None when load returns False
         self.assertIsNone(result)


### PR DESCRIPTION
## Summary
Prevent the skill manager from starting a second load for the same plugin while an earlier load is still in progress.

## Changes
- track plugin skill IDs that are currently loading
- reserve a skill ID before calling `PluginSkillLoader.load()`
- skip duplicate load attempts from overlapping scans or event-triggered reloads
- clear the loading reservation in `finally` so failed loads do not leave stale state
- add regressions for already-loading and concurrent duplicate load attempts

## Testing
- `python -m py_compile ovos_core/skill_manager.py test/unittests/test_skill_manager.py`
- `/tmp/ovos-core-test/bin/python -m pytest -q test/unittests/test_skill_manager.py`
- `/tmp/ovos-core-test/bin/python -m pytest -q test/unittests/test_manager.py`