### PR TITLE
feat: intent.service.intent.get accepts exclude_pipeline filter

### DIFF
--- a/ovos_core/intent_services/service.py
+++ b/ovos_core/intent_services/service.py
@@ -575,7 +575,11 @@ class IntentService:
         lang = get_message_lang(message)
         sess = SessionManager.get(message)
         # optional: drop stages from the session pipeline for this probe
-        excluded = message.data.get("exclude_pipeline")
+        excluded = message.data.get("exclude_pipeline") or []
+        if isinstance(excluded, str):
+            excluded = [excluded]
+        else:
+            excluded = [x for x in excluded if isinstance(x, str) and x]
         match = None
         # Loop through the matching functions until a match is found.
         for pipeline, match_func in self.get_pipeline(session=sess):

--- a/ovos_core/intent_services/service.py
+++ b/ovos_core/intent_services/service.py
@@ -562,13 +562,25 @@ class IntentService:
 
         Args:
             message (Message): message containing utterance
+
+        Optional message.data keys:
+            exclude_pipeline (list[str]): drop these stages from the session
+                pipeline before matching (substring match, e.g. ["converse"]).
+                `intent.service.intent.get` is a read-only probe (it never runs
+                a handler), so callers can use this to ask "what would match,
+                ignoring these stages?" - e.g. a conversing skill probing the
+                pipeline without re-entering the converse stage.
         """
         utterance = message.data["utterance"]
         lang = get_message_lang(message)
         sess = SessionManager.get(message)
+        # optional: drop stages from the session pipeline for this probe
+        excluded = message.data.get("exclude_pipeline")
         match = None
         # Loop through the matching functions until a match is found.
         for pipeline, match_func in self.get_pipeline(session=sess):
+            if excluded and any(x in pipeline for x in excluded):
+                continue
             s = time.monotonic()
             match = match_func([utterance], lang, message)
             LOG.debug(f"matching '{pipeline}' took: {time.monotonic() - s} seconds")


### PR DESCRIPTION
## What

Adds an optional `exclude_pipeline` key to the `intent.service.intent.get` bus probe.

`handle_get_intent` is a **read-only** probe — it runs the pipeline matchers to find what *would* match an utterance and emits `intent.service.intent.reply`, but it never executes the matched handler and has no side effects. This makes it safe for a skill to ask "would one of my intents match this utterance (under the current session context)?".

`exclude_pipeline` (list of substrings) drops matching stages from the session pipeline for that probe. The motivating case: a skill that is currently **conversing** wants to probe the pipeline but must skip the `converse` stage, otherwise the probe re-enters the skill's own `can_converse`/converse logic (infinite recursion). It also lets a caller ignore non-intent-parser stages (fallback/persona/ocp/…) — though those are usually filtered by checking the returned `skill_id`.

```python
self.bus.wait_for_response(
    Message("intent.service.intent.get",
            {"utterance": utt, "lang": lang,
             "exclude_pipeline": ["ovos-converse-pipeline-plugin"]}),
    "intent.service.intent.reply")
```

## Why

Consumed by ovos-workshop's new `OVOSSkill.skill_will_match()` and by `ConversationalGameSkill`, where context-gated intent **layers** require games to let adapt match layer intents instead of converse swallowing every utterance while the game is active. (OpenVoiceOS/ovos-workshop intent-layers-context branch.)

Backwards compatible: when `exclude_pipeline` is absent the behaviour is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional `exclude_pipeline` setting to skip selected pipeline stages during read-only intent lookups.
  * Intent probe behavior is unchanged: it returns matched intent details when successful, or `intent: None` when nothing matches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->