### PR TITLE
fix(deps): allow ovos-workshop 9.x (widen <9.0.0 -> <10.0.0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "ovos_bus_client>=2.2.0a1,<3.0.0",
     "ovos-plugin-manager>=2.5.0a1,<3.0.0",
     "ovos-config>=0.0.13,<3.0.0",
-    "ovos-workshop>=8.3.0a1,<9.0.0",
+    "ovos-workshop>=8.3.0a1,<10.0.0",
     "rapidfuzz>=3.6,<4.0",
     "ovos-spec-tools[langcodes]>=0.9.0a1,<1.0.0",
 ]


### PR DESCRIPTION
Lift the stale `ovos-workshop<9.0.0` cap so workshop 9.x consumers resolve.

workshop dev is now 9.0.0a1 (merged #427, intent-layer gating breaking change). Ordinary consumers are unaffected, so widen `<9.0.0` -> `<10.0.0` keeping the existing lower floor. This unblocks ovos-workshop PR #431 whose CI failed `ResolutionImpossible`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a dependency version range to allow a newer compatible release.
  * This should help keep the project up to date and maintain compatibility with future updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->