### PR TITLE
fix: guard optional None blacklisted_skills/intents (SESSION-1 §3)

### DIFF
--- a/ovos_core/intent_services/converse_service.py
+++ b/ovos_core/intent_services/converse_service.py
@@ -305,7 +305,7 @@ class ConverseService(PipelinePlugin):
 
         # check if any skill wants to capture utterance for self.get_response method
         for skill_id in gr_skills:
-            if skill_id in session.blacklisted_skills:
+            if skill_id in (session.blacklisted_skills or []):
                 LOG.debug(f"ignoring match, skill_id '{skill_id}' blacklisted by Session '{session.session_id}'")
                 continue
             LOG.debug(f"utterance captured by skill.get_response method: {skill_id}")
@@ -322,7 +322,7 @@ class ConverseService(PipelinePlugin):
 
         # check if any skill wants to converse
         for skill_id in self._collect_converse_skills(message):
-            if skill_id in session.blacklisted_skills:
+            if skill_id in (session.blacklisted_skills or []):
                 LOG.debug(f"ignoring match, skill_id '{skill_id}' blacklisted by Session '{session.session_id}'")
                 continue
             LOG.debug(f"Attempting to converse with skill: {skill_id}")

--- a/ovos_core/intent_services/fallback_service.py
+++ b/ovos_core/intent_services/fallback_service.py
@@ -98,7 +98,7 @@ class FallbackService(ConfidenceMatcherPipeline):
         # filter skills outside the fallback_range
         in_range = [s for s, p in self.registered_fallbacks.items()
                     if fb_range.start < p <= fb_range.stop
-                    and s not in sess.blacklisted_skills]
+                    and s not in (sess.blacklisted_skills or [])]
         skill_ids += [s for s in self.registered_fallbacks if s not in in_range]
 
         def handle_ack(msg):
@@ -159,7 +159,7 @@ class FallbackService(ConfidenceMatcherPipeline):
         sorted_handlers = sorted(fallbacks, key=operator.itemgetter(1))
 
         for skill_id, prio in sorted_handlers:
-            if skill_id in sess.blacklisted_skills:
+            if skill_id in (sess.blacklisted_skills or []):
                 LOG.debug(f"ignoring match, skill_id '{skill_id}' blacklisted by Session '{sess.session_id}'")
                 continue
 

--- a/ovos_core/intent_services/service.py
+++ b/ovos_core/intent_services/service.py
@@ -472,11 +472,11 @@ class IntentService:
                     match = match_func(utterances, intent_lang, message)
                     if match:
                         LOG.info(f"{pipeline} match ({intent_lang}): {match}")
-                        if match.skill_id and match.skill_id in sess.blacklisted_skills:
+                        if match.skill_id and match.skill_id in (sess.blacklisted_skills or []):
                             LOG.debug(
                                 f"ignoring match, skill_id '{match.skill_id}' blacklisted by Session '{sess.session_id}'")
                             continue
-                        if isinstance(match, IntentHandlerMatch) and match.match_type in sess.blacklisted_intents:
+                        if isinstance(match, IntentHandlerMatch) and match.match_type in (sess.blacklisted_intents or []):
                             LOG.debug(
                                 f"ignoring match, intent '{match.match_type}' blacklisted by Session '{sess.session_id}'")
                             continue

--- a/ovos_core/intent_services/stop_service.py
+++ b/ovos_core/intent_services/stop_service.py
@@ -82,7 +82,7 @@ class StopService(ConfidenceMatcherPipeline, OVOSAbstractApplication):
         skill_ids = []
 
         active_skills = [s for s in self.get_active_skills(message)
-                         if s not in sess.blacklisted_skills]
+                         if s not in (sess.blacklisted_skills or [])]
 
         if not active_skills:
             return want_stop


### PR DESCRIPTION
`blacklisted_skills` / `blacklisted_intents` are **optional** SESSION-1 §3 fields and are legally `None` when a Session doesn't carry an empty list. The stop / fallback / converse / intent services tested membership directly (`x in sess.blacklisted_skills`) → `TypeError: 'NoneType' object is not iterable`, aborting the stop ping/pong cascade, the fallback query cycle, and the converse round-trip **before any bus traffic**.

Guards every use with `(... or [])` (7 call sites across stop_service / fallback_service / converse_service / service.py).

**How it was found:** live integration testing in the OVOS spec-compliance harness (ovos-bus-client 2.x leaves these fields `None`); the harness conformance suite went green once both this and the padacioso lru_cache fix (OpenVoiceOS/padacioso#60) landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved blacklist handling across intent, fallback, converse, and stop flows.
  * The app now safely treats missing blacklist values as empty lists, preventing errors when filtering skills or intents.
  * Blacklisted skills and intents are now excluded more consistently during matching and command handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->