### PR TITLE
fix: allow latest padacioso (widen cap to <3.0.0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ plugins = [
     "ovos-adapt-parser>=1.3.1a1, <2.0.0",
     "ovos_ocp_pipeline_plugin>=1.1.21a5, <2.0.0",
     "ovos-persona>=0.9.0a7,<1.0.0",
-    "padacioso>=1.0.0, <2.0.0",
+    "padacioso>=1.0.0,<3.0.0",
     "keyword-template-matcher>=0.1.1,<1.0.0",
     "ahocorasick-ner>=0.1.1,<1.0.0",
 ]


### PR DESCRIPTION
Widens `padacioso>=1.0.0,<2.0.0` → `<3.0.0` to adopt padacioso 2.0 (OVOS-INTENT-1 grammar). Validated end-to-end against the workshop-9 stack in OpenVoiceOS/ovos-test-harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded compatibility for an optional package dependency, allowing a wider range of newer versions to be installed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->