### PR TITLE
ci: wire shared opm-check workflow (opm.pipeline entry-points)

### DIFF
--- a/.github/workflows/opm_check.yml
+++ b/.github/workflows/opm_check.yml
@@ -1,0 +1,17 @@
+name: OPM Plugin Check
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [dev]
+  workflow_dispatch:
+
+jobs:
+  opm_check:
+    uses: OpenVoiceOS/gh-automations/.github/workflows/opm-check.yml@dev
+    secrets: inherit
+    with:
+      system_deps: 'swig libssl-dev portaudio19-dev libpulse-dev libfann-dev'
+      install_extras: 'mycroft,plugins,skills-essential,lgpl,test'
+      python_version: '3.11'
+      plugin_type: 'pipeline'


### PR DESCRIPTION
ovos-core declares three `opm.pipeline` entry-points (converse/fallback/stop pipeline plugins) in pyproject.toml but had no `opm_check` workflow, so entry-point registration was never validated in CI.

This adds the shared `gh-automations/.github/workflows/opm-check.yml@dev` caller, mirroring the install extras / system deps used by `build_tests.yml`. Auto-detection enumerates the declared `opm.*` entry points and verifies they are discoverable by OPM after install.

Small, self-contained, backward-compatible: workflow-only, no code or dependency changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated checks for plugin validation on pushes, pull requests, and manual runs.
  * Included required setup for the validation environment to help keep changes more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->