### PR TITLE
test(e2e): fix transient test_fallback_match meta mismatch on dev

### DIFF
--- a/test/end2end/test_fallback.py
+++ b/test/end2end/test_fallback.py
@@ -80,6 +80,8 @@ class TestFallback(TestCase):
                         data={"lang": session.lang,
                               "expect_response": False,
                               "meta": {
+                                  "dialog": "unknown",
+                                  "data": {},
                                   "skill": self.skill_id
                               }},
                         context={"skill_id": self.skill_id}),


### PR DESCRIPTION
## Problem

`test/end2end/test_fallback.py::test_fallback_match` fails on **dev** (and every PR
branched off it, e.g. #787) with:

```
❌ message data mismatch for key 'meta' -
   expected '{'skill': 'ovos-skill-fallback-unknown.openvoiceos'}'
   got '{'dialog': 'unknown', 'data': {}, 'skill': 'ovos-skill-fallback-unknown.openvoiceos'}'
```

`ovos-skill-fallback-unknown` speaks its `unknown` dialog with a `meta` of
`{dialog, data, skill}`, but the expected speak message only listed `{skill}`. This
is a stale test expectation (surfaced once the skill was republished), not a code
regression — hence the "transient" failures across PRs.

## Fix

Expect the real speak `meta` (`dialog: "unknown"`, `data: {}`, `skill: ...`). One
test file; no production change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end fallback expectations to match the latest message metadata format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->