### PR TITLE
StopService: wrap handlers in HandlerLifecycle instead of ad-hoc emission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [2.2.4a3](https://github.com/OpenVoiceOS/ovos-core/tree/2.2.4a3) (2026-06-28)
+
+[Full Changelog](https://github.com/OpenVoiceOS/ovos-core/compare/2.2.4a1...2.2.4a3)
+
+**Merged pull requests:**
+
+- test\(e2e\): fix transient test\_fallback\_match meta mismatch on dev [\#792](https://github.com/OpenVoiceOS/ovos-core/pull/792) ([JarbasAl](https://github.com/JarbasAl))
+- ci: wire shared opm-check workflow \(opm.pipeline entry-points\) [\#787](https://github.com/OpenVoiceOS/ovos-core/pull/787) ([JarbasAl](https://github.com/JarbasAl))
+
 ## [2.2.4a1](https://github.com/OpenVoiceOS/ovos-core/tree/2.2.4a1) (2026-06-28)
 
 [Full Changelog](https://github.com/OpenVoiceOS/ovos-core/compare/2.2.3a1...2.2.4a1)

--- a/ovos_core/intent_services/converse_service.py
+++ b/ovos_core/intent_services/converse_service.py
@@ -3,6 +3,7 @@ from threading import Event
 from typing import Optional, Dict, List, Union
 
 from ovos_bus_client.client import MessageBusClient
+from ovos_bus_client.handler import HandlerLifecycle
 from ovos_bus_client.message import Message
 from ovos_bus_client.session import SessionManager, UtteranceState, Session
 from ovos_config.config import Configuration
@@ -32,7 +33,10 @@ class ConverseService(PipelinePlugin):
 
     def handle_converse(self, message: Message):
         skill_id = message.data["skill_id"]
-        self.bus.emit(message.reply(f"{skill_id}.converse.request", message.data))
+        with HandlerLifecycle(self.bus, message,
+                              skill_id="converse.openvoiceos",
+                              data={"name": "ConverseService.handle_converse"}):
+            self.bus.emit(message.reply(f"{skill_id}.converse.request", message.data))
 
     @property
     def active_skills(self):

--- a/ovos_core/intent_services/stop_service.py
+++ b/ovos_core/intent_services/stop_service.py
@@ -4,6 +4,7 @@ from threading import Event
 from typing import Optional, Dict, List, Union
 
 from ovos_bus_client.client import MessageBusClient
+from ovos_bus_client.handler import HandlerLifecycle
 from ovos_bus_client.message import Message
 from ovos_bus_client.session import SessionManager, UtteranceState
 
@@ -32,15 +33,20 @@ class StopService(ConfidenceMatcherPipeline, OVOSAbstractApplication):
         self.bus.on("stop:skill", self.handle_skill_stop)
 
     def handle_global_stop(self, message: Message) -> None:
-        """Emit a global mycroft.stop and mark the utterance handled."""
-        self.bus.emit(message.forward("mycroft.stop"))
-        # TODO - this needs a confirmation dialog if nothing was stopped
-        self.bus.emit(message.forward("ovos.utterance.handled"))
+        """Emit a global mycroft.stop; the §9.5 end-marker is the orchestrator's
+        responsibility (``IntentDispatcher._notify_terminal``)."""
+        with HandlerLifecycle(self.bus, message,
+                              skill_id="stop.openvoiceos",
+                              data={"name": "StopService.handle_global_stop"}):
+            self.bus.emit(message.forward("mycroft.stop"))
 
     def handle_skill_stop(self, message: Message) -> None:
         """Forward a stop request to the specific skill."""
         skill_id = message.data["skill_id"]
-        self.bus.emit(message.reply(f"{skill_id}.stop"))
+        with HandlerLifecycle(self.bus, message,
+                              skill_id="stop.openvoiceos",
+                              data={"name": "StopService.handle_skill_stop"}):
+            self.bus.emit(message.reply(f"{skill_id}.stop"))
 
     @staticmethod
     def get_active_skills(message: Optional[Message] = None) -> List[str]:

--- a/test/unittests/test_stop_service.py
+++ b/test/unittests/test_stop_service.py
@@ -528,9 +528,10 @@ class TestBusHandlers(unittest.TestCase):
         msg = Message("stop:global", {})
         svc.handle_global_stop(msg)
         types = [m.msg_type for m in emitted]
-        self.assertIn("mycroft.stop", types)
         self.assertIn("mycroft.skill.handler.start", types)
+        self.assertIn("mycroft.stop", types)
         self.assertIn("mycroft.skill.handler.complete", types)
+        self.assertIn("ovos.utterance.handled", types)
 
     def test_handle_skill_stop_forwards_to_skill(self):
         svc = _make_service()
@@ -539,8 +540,8 @@ class TestBusHandlers(unittest.TestCase):
         msg = Message("stop:skill", {"skill_id": "my_skill"})
         svc.handle_skill_stop(msg)
         types = [m.msg_type for m in emitted]
-        self.assertIn("my_skill.stop", types)
         self.assertIn("mycroft.skill.handler.start", types)
+        self.assertIn("my_skill.stop", types)
         self.assertIn("mycroft.skill.handler.complete", types)
 
 

--- a/test/unittests/test_stop_service.py
+++ b/test/unittests/test_stop_service.py
@@ -529,7 +529,8 @@ class TestBusHandlers(unittest.TestCase):
         svc.handle_global_stop(msg)
         types = [m.msg_type for m in emitted]
         self.assertIn("mycroft.stop", types)
-        self.assertIn("ovos.utterance.handled", types)
+        self.assertIn("mycroft.skill.handler.start", types)
+        self.assertIn("mycroft.skill.handler.complete", types)
 
     def test_handle_skill_stop_forwards_to_skill(self):
         svc = _make_service()
@@ -537,8 +538,10 @@ class TestBusHandlers(unittest.TestCase):
         svc.bus.emit = lambda m: emitted.append(m)
         msg = Message("stop:skill", {"skill_id": "my_skill"})
         svc.handle_skill_stop(msg)
-        self.assertEqual(len(emitted), 1)
-        self.assertEqual(emitted[0].msg_type, "my_skill.stop")
+        types = [m.msg_type for m in emitted]
+        self.assertIn("my_skill.stop", types)
+        self.assertIn("mycroft.skill.handler.start", types)
+        self.assertIn("mycroft.skill.handler.complete", types)
 
 
 class TestShutdown(unittest.TestCase):


### PR DESCRIPTION
## Summary

Replace rudimentary manual emission of lifecycle events (both the `UTTERANCE_HANDLED` that the orchestrator now owns and the missing `mycroft.skill.handler.*` trio) with the canonical `HandlerLifecycle` context manager from `ovos-bus-client`.

The `HandlerLifecycle` context manager consistently emits the full handler-lifecycle trio (`start`/`complete`/`error`) so that the dispatcher can properly track in-flight entries and fire §9.5 `UTTERANCE_HANDLED` at the right moment — instead of waiting for the handler timeout.

## Changes

### StopService (`stop_service.py`)
- Remove manual `message.forward(\"ovos.utterance.handled\")` from `handle_global_stop` — the orchestrator's dispatcher emits the §9.5 end-marker
- Wrap both `handle_global_stop` and `handle_skill_stop` in `HandlerLifecycle`

### ConverseService (`converse_service.py`)
- Wrap `handle_converse` in `HandlerLifecycle` — same self-handling pattern as StopService (pipeline match → bus event dispatch → self-handled), but was missing lifecycle signalling entirely, causing converse dispatches to only resolve on timeout

### Other pipeline plugins
`FallbackService` does not need this — it does not self-handle its `match_type` (skills listen for `ovos.skills.fallback.{skill_id}.request` directly via workshop's automatic lifecycle wrapping).