### PR TITLE
feat: INTENT-4 §10 orchestrator manifest (IntentManifest)

### DIFF
--- a/ovos_core/intent_services/manifest.py
+++ b/ovos_core/intent_services/manifest.py
@@ -40,6 +40,16 @@ class IntentManifest:
         bus.on("ovos.intent.list", self._on_list)
         bus.on("ovos.intent.describe", self._on_describe)
 
+    def shutdown(self):
+        self.bus.remove("ovos.intent.register.keyword", self._on_register)
+        self.bus.remove("ovos.intent.register.template", self._on_register)
+        self.bus.remove("ovos.intent.deregister", self._on_deregister)
+        self.bus.remove("ovos.intent.enable", self._on_enable_disable)
+        self.bus.remove("ovos.intent.disable", self._on_enable_disable)
+        self.bus.remove("ovos.skill.deregister", self._on_skill_deregister)
+        self.bus.remove("ovos.intent.list", self._on_list)
+        self.bus.remove("ovos.intent.describe", self._on_describe)
+
     # ------------------------------------------------------------------
     # internal helpers
     # ------------------------------------------------------------------

--- a/ovos_core/intent_services/manifest.py
+++ b/ovos_core/intent_services/manifest.py
@@ -1,0 +1,175 @@
+# Copyright 2024 OpenVoiceOS
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ovos_bus_client.message import Message
+from ovos_spec_tools import standardize_lang
+from ovos_utils.log import LOG
+
+
+class IntentManifest:
+    """INTENT-4 §10 orchestrator-owned manifest.
+
+    Indexes every ``ovos.intent.register.*`` broadcast and serves
+    ``ovos.intent.list`` / ``ovos.intent.describe`` pull-queries.
+    The manifest is keyed by the quintuple
+    ``(session_id, skill_id, intent_name, lang, method)`` per §11.1.
+    """
+
+    def __init__(self, bus):
+        self.bus = bus
+        # (session_id, skill_id, intent_name, lang, method) → entry dict
+        self._index: dict = {}
+
+        bus.on("ovos.intent.register.keyword", self._on_register)
+        bus.on("ovos.intent.register.template", self._on_register)
+        bus.on("ovos.intent.deregister", self._on_deregister)
+        bus.on("ovos.intent.enable", self._on_enable_disable)
+        bus.on("ovos.intent.disable", self._on_enable_disable)
+        bus.on("ovos.skill.deregister", self._on_skill_deregister)
+        bus.on("ovos.intent.list", self._on_list)
+        bus.on("ovos.intent.describe", self._on_describe)
+
+    # ------------------------------------------------------------------
+    # internal helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _key(session_id: str, skill_id: str, intent_name: str,
+              lang: str, method: str) -> tuple:
+        return session_id, skill_id, intent_name, standardize_lang(lang), method
+
+    def _effective_pool(self, session_id: str) -> list:
+        """Return entries for *session_id* merged with 'default' (§11.2)."""
+        seen = {}
+        for key, entry in self._index.items():
+            s, skill, name, lang, method = key
+            if s not in ("default", session_id):
+                continue
+            dedup = (skill, name, lang, method)
+            if dedup not in seen or s == session_id:
+                seen[dedup] = entry
+        return list(seen.values())
+
+    # ------------------------------------------------------------------
+    # registration broadcasts  §§5–8
+    # ------------------------------------------------------------------
+
+    def _on_register(self, message: Message):
+        method = "keyword" if message.msg_type == "ovos.intent.register.keyword" else "template"
+        skill_id = message.data.get("skill_id") or message.context.get("skill_id")
+        intent_name = message.data.get("intent_name")
+        lang = message.data.get("lang")
+        if not (skill_id and intent_name and lang):
+            LOG.warning(f"malformed intent registration from {skill_id!r}: missing required fields")
+            return
+        session_id = (message.context.get("session") or {}).get("session_id", "default")
+        key = self._key(session_id, skill_id, intent_name, lang, method)
+        self._index[key] = {
+            "skill_id": skill_id,
+            "intent_name": intent_name,
+            "lang": standardize_lang(lang),
+            "method": method,
+            "enabled": True,
+            "session_id": session_id,
+            "definition": message.data,
+        }
+
+    def _on_deregister(self, message: Message):
+        skill_id = message.data.get("skill_id") or message.context.get("skill_id")
+        intent_name = message.data.get("intent_name")
+        lang = message.data.get("lang")
+        session_id = message.data.get("session_id", "default")
+        if not (skill_id and intent_name):
+            return
+        for method in ("keyword", "template"):
+            if lang:
+                self._index.pop(self._key(session_id, skill_id, intent_name, lang, method), None)
+            else:
+                for key in [k for k in self._index
+                            if k[0] == session_id and k[1] == skill_id
+                            and k[2] == intent_name and k[4] == method]:
+                    del self._index[key]
+
+    def _on_enable_disable(self, message: Message):
+        enabled = message.msg_type == "ovos.intent.enable"
+        skill_id = message.data.get("skill_id") or message.context.get("skill_id")
+        intent_name = message.data.get("intent_name")
+        lang = message.data.get("lang")
+        session_id = message.data.get("session_id", "default")
+        for key, entry in self._index.items():
+            if key[0] != session_id or key[1] != skill_id or key[2] != intent_name:
+                continue
+            if lang and key[3] != standardize_lang(lang):
+                continue
+            entry["enabled"] = enabled
+
+    def _on_skill_deregister(self, message: Message):
+        skill_id = message.data.get("skill_id") or message.context.get("skill_id")
+        session_id = message.data.get("session_id", "default")
+        if not skill_id:
+            return
+        for key in [k for k in self._index if k[0] == session_id and k[1] == skill_id]:
+            del self._index[key]
+
+    # ------------------------------------------------------------------
+    # introspection queries  §10
+    # ------------------------------------------------------------------
+
+    def _on_list(self, message: Message):
+        f_skill = message.data.get("skill_id")
+        f_lang = message.data.get("lang")
+        f_session = message.data.get("session_id")
+        if f_lang:
+            f_lang = standardize_lang(f_lang)
+
+        pool = self._effective_pool(f_session) if f_session else list(self._index.values())
+        results = []
+        for entry in pool:
+            if f_skill and entry["skill_id"] != f_skill:
+                continue
+            if f_lang and entry["lang"] != f_lang:
+                continue
+            results.append({k: entry[k] for k in
+                            ("skill_id", "intent_name", "lang", "method", "enabled", "session_id")})
+
+        self.bus.emit(message.reply("ovos.intent.list.response", {"ok": True, "intents": results}))
+
+    def _on_describe(self, message: Message):
+        skill_id = message.data.get("skill_id")
+        intent_name = message.data.get("intent_name")
+        lang = message.data.get("lang")
+        method_filter = message.data.get("method")
+        session_id = message.data.get("session_id", "default")
+        if not (skill_id and intent_name and lang):
+            self.bus.emit(message.reply("ovos.intent.describe.response",
+                                        {"ok": False,
+                                         "error": "skill_id, intent_name and lang are required"}))
+            return
+        lang = standardize_lang(lang)
+        pool = self._effective_pool(session_id)
+        definitions = []
+        for entry in pool:
+            if entry["skill_id"] != skill_id or entry["intent_name"] != intent_name or entry["lang"] != lang:
+                continue
+            if method_filter and entry["method"] != method_filter:
+                continue
+            definitions.append({"method": entry["method"], "definition": entry["definition"]})
+        definitions.sort(key=lambda d: 0 if d["method"] == "keyword" else 1)
+        if definitions:
+            self.bus.emit(message.reply("ovos.intent.describe.response",
+                                        {"ok": True, "definitions": definitions}))
+        else:
+            self.bus.emit(message.reply("ovos.intent.describe.response",
+                                        {"ok": False,
+                                         "error": f"unknown intent {skill_id}:{intent_name}:{lang}"}))

--- a/ovos_core/intent_services/service.py
+++ b/ovos_core/intent_services/service.py
@@ -660,6 +660,7 @@ class IntentService:
 
     def shutdown(self) -> None:
         self.intent_dispatcher.shutdown()
+        self.intent_manifest.shutdown()
         self.utterance_plugins.shutdown()
         self.metadata_plugins.shutdown()
         for pipeline in self.pipeline_plugins.values():

--- a/ovos_core/intent_services/service.py
+++ b/ovos_core/intent_services/service.py
@@ -33,6 +33,7 @@ from ovos_utils.thread_utils import create_daemon
 
 from ovos_core.transformers import MetadataTransformersService, UtteranceTransformersService, IntentTransformersService
 from ovos_core.intent_services.dispatcher import IntentDispatcher, DEFAULT_HANDLER_TIMEOUT
+from ovos_core.intent_services.manifest import IntentManifest
 from ovos_plugin_manager.pipeline import OVOSPipelineFactory
 from ovos_plugin_manager.templates.pipeline import IntentHandlerMatch, ConfidenceMatcherPipeline
 
@@ -125,6 +126,10 @@ class IntentService:
         handler_timeout = self.config.get("handler_timeout", DEFAULT_HANDLER_TIMEOUT)
         self.intent_dispatcher: IntentDispatcher = IntentDispatcher(
             bus, timeout=handler_timeout, on_terminal=self._emit_utterance_handled)
+
+        # INTENT-4 §10 manifest — indexes registration broadcasts and serves
+        # ovos.intent.list / ovos.intent.describe pull-queries.
+        self.intent_manifest: IntentManifest = IntentManifest(bus)
 
         # connection SessionManager to the bus,
         # this will sync default session across all components

--- a/test/unittests/test_intent_manifest.py
+++ b/test/unittests/test_intent_manifest.py
@@ -1,0 +1,205 @@
+# Copyright 2024 OpenVoiceOS
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from ovos_bus_client.message import Message
+from ovos_utils.fakebus import FakeBus
+
+from ovos_core.intent_services.manifest import IntentManifest
+
+
+def _manifest() -> IntentManifest:
+    return IntentManifest(FakeBus())
+
+
+def _reg(skill_id, intent_name, lang="en-US", method="keyword", session_id="default"):
+    topic = f"ovos.intent.register.{method}"
+    return Message(topic,
+                   data={"skill_id": skill_id, "intent_name": intent_name, "lang": lang},
+                   context={"session": {"session_id": session_id}, "skill_id": skill_id})
+
+
+class TestManifestRegister(unittest.TestCase):
+    def setUp(self):
+        self.m = _manifest()
+
+    def test_register_keyword_adds_entry(self):
+        self.m._on_register(_reg("skill.test", "hello", method="keyword"))
+        self.assertEqual(len(self.m._index), 1)
+        entry = list(self.m._index.values())[0]
+        self.assertEqual(entry["intent_name"], "hello")
+        self.assertEqual(entry["method"], "keyword")
+        self.assertTrue(entry["enabled"])
+
+    def test_register_template_adds_entry(self):
+        self.m._on_register(_reg("skill.test", "hello", method="template"))
+        entry = list(self.m._index.values())[0]
+        self.assertEqual(entry["method"], "template")
+
+    def test_re_registration_replaces_entry(self):
+        self.m._on_register(_reg("skill.test", "hello"))
+        self.m._on_register(_reg("skill.test", "hello"))
+        self.assertEqual(len(self.m._index), 1)
+
+    def test_malformed_registration_ignored(self):
+        msg = Message("ovos.intent.register.keyword",
+                      data={"skill_id": "s", "intent_name": "x"},  # missing lang
+                      context={})
+        self.m._on_register(msg)
+        self.assertEqual(len(self.m._index), 0)
+
+    def test_session_scoped_registration(self):
+        self.m._on_register(_reg("skill.test", "hello", session_id="sat-1"))
+        key = list(self.m._index.keys())[0]
+        self.assertEqual(key[0], "sat-1")
+
+
+class TestManifestDeregister(unittest.TestCase):
+    def setUp(self):
+        self.m = _manifest()
+        self.m._on_register(_reg("skill.test", "hello", lang="en-US"))
+        self.m._on_register(_reg("skill.test", "hello", lang="de-DE"))
+
+    def test_deregister_specific_lang(self):
+        msg = Message("ovos.intent.deregister",
+                      data={"skill_id": "skill.test", "intent_name": "hello", "lang": "en-US"})
+        self.m._on_deregister(msg)
+        langs = [e["lang"] for e in self.m._index.values()]
+        self.assertNotIn("en-US", langs)
+        self.assertIn("de-DE", langs)
+
+    def test_deregister_all_langs(self):
+        msg = Message("ovos.intent.deregister",
+                      data={"skill_id": "skill.test", "intent_name": "hello"})
+        self.m._on_deregister(msg)
+        self.assertEqual(len(self.m._index), 0)
+
+
+class TestManifestEnableDisable(unittest.TestCase):
+    def setUp(self):
+        self.m = _manifest()
+        self.m._on_register(_reg("skill.test", "hello", lang="en-US"))
+
+    def test_disable_intent(self):
+        msg = Message("ovos.intent.disable",
+                      data={"skill_id": "skill.test", "intent_name": "hello", "lang": "en-US"})
+        self.m._on_enable_disable(msg)
+        entry = list(self.m._index.values())[0]
+        self.assertFalse(entry["enabled"])
+
+    def test_enable_intent(self):
+        msg = Message("ovos.intent.disable",
+                      data={"skill_id": "skill.test", "intent_name": "hello", "lang": "en-US"})
+        self.m._on_enable_disable(msg)
+        msg2 = Message("ovos.intent.enable",
+                       data={"skill_id": "skill.test", "intent_name": "hello", "lang": "en-US"})
+        self.m._on_enable_disable(msg2)
+        entry = list(self.m._index.values())[0]
+        self.assertTrue(entry["enabled"])
+
+
+class TestSkillDeregister(unittest.TestCase):
+    def setUp(self):
+        self.m = _manifest()
+        self.m._on_register(_reg("skill.a", "x"))
+        self.m._on_register(_reg("skill.a", "y"))
+        self.m._on_register(_reg("skill.b", "z"))
+
+    def test_removes_only_target_skill(self):
+        msg = Message("ovos.skill.deregister", data={"skill_id": "skill.a"})
+        self.m._on_skill_deregister(msg)
+        skills = {e["skill_id"] for e in self.m._index.values()}
+        self.assertNotIn("skill.a", skills)
+        self.assertIn("skill.b", skills)
+
+
+class TestEffectivePool(unittest.TestCase):
+    def setUp(self):
+        self.m = _manifest()
+        self.m._on_register(_reg("skill.test", "hello", session_id="default"))
+        self.m._on_register(_reg("skill.sat", "sat_intent", session_id="sat-1"))
+
+    def test_default_session_excludes_satellite(self):
+        pool = self.m._effective_pool("default")
+        names = {e["intent_name"] for e in pool}
+        self.assertIn("hello", names)
+        self.assertNotIn("sat_intent", names)
+
+    def test_satellite_session_inherits_default(self):
+        pool = self.m._effective_pool("sat-1")
+        names = {e["intent_name"] for e in pool}
+        self.assertIn("hello", names)
+        self.assertIn("sat_intent", names)
+
+
+class TestIntentListQuery(unittest.TestCase):
+    def setUp(self):
+        self.m = _manifest()
+        self.m._on_register(_reg("skill.a", "play", lang="en-US"))
+        self.m._on_register(_reg("skill.a", "stop", lang="en-US"))
+        self.m._on_register(_reg("skill.b", "play", lang="de-DE"))
+
+    def _query(self, **kwargs):
+        replies = []
+        self.m.bus.on("ovos.intent.list.response", lambda msg: replies.append(msg))
+        self.m._on_list(Message("ovos.intent.list", data=kwargs))
+        return replies[-1].data if replies else None
+
+    def test_no_filters_returns_all(self):
+        resp = self._query()
+        self.assertTrue(resp["ok"])
+        self.assertEqual(len(resp["intents"]), 3)
+
+    def test_filter_by_skill(self):
+        resp = self._query(skill_id="skill.a")
+        names = {e["intent_name"] for e in resp["intents"]}
+        self.assertEqual(names, {"play", "stop"})
+
+    def test_filter_by_lang(self):
+        resp = self._query(lang="de-DE")
+        self.assertEqual(len(resp["intents"]), 1)
+        self.assertEqual(resp["intents"][0]["skill_id"], "skill.b")
+
+
+class TestIntentDescribeQuery(unittest.TestCase):
+    def setUp(self):
+        self.m = _manifest()
+        self.m._on_register(_reg("skill.a", "play", lang="en-US", method="keyword"))
+        self.m._on_register(_reg("skill.a", "play", lang="en-US", method="template"))
+
+    def _query(self, **kwargs):
+        replies = []
+        self.m.bus.on("ovos.intent.describe.response", lambda msg: replies.append(msg))
+        self.m._on_describe(Message("ovos.intent.describe", data=kwargs))
+        return replies[-1].data if replies else None
+
+    def test_describe_both_methods_ordered(self):
+        resp = self._query(skill_id="skill.a", intent_name="play", lang="en-US")
+        self.assertTrue(resp["ok"])
+        methods = [d["method"] for d in resp["definitions"]]
+        self.assertEqual(methods, ["keyword", "template"])
+
+    def test_describe_filter_by_method(self):
+        resp = self._query(skill_id="skill.a", intent_name="play", lang="en-US", method="template")
+        self.assertEqual(len(resp["definitions"]), 1)
+        self.assertEqual(resp["definitions"][0]["method"], "template")
+
+    def test_describe_unknown_returns_error(self):
+        resp = self._query(skill_id="skill.a", intent_name="nonexistent", lang="en-US")
+        self.assertFalse(resp["ok"])
+
+    def test_describe_missing_fields_returns_error(self):
+        resp = self._query(skill_id="skill.a")
+        self.assertFalse(resp["ok"])

--- a/test/unittests/test_intent_service_extended.py
+++ b/test/unittests/test_intent_service_extended.py
@@ -27,6 +27,7 @@ from ovos_spec_tools import SpecMessage
 
 from ovos_core.intent_services.service import IntentService
 from ovos_core.intent_services.dispatcher import IntentDispatcher
+from ovos_core.intent_services.manifest import IntentManifest
 
 
 def _make_service(config=None) -> IntentService:
@@ -52,6 +53,9 @@ def _make_service(config=None) -> IntentService:
     it = MagicMock()
     it.transform.side_effect = lambda intent: intent
     svc.intent_plugins = it
+
+    # INTENT-4 §10 manifest — indexes registration broadcasts
+    svc.intent_manifest = IntentManifest(bus)
 
     svc.status = MagicMock()
     return svc


### PR DESCRIPTION
## Summary

- Adds `ovos_core/intent_services/manifest.py` — `IntentManifest` class that wires all INTENT-4 §§5–8 registration broadcasts (`ovos.intent.register.keyword`, `.template`, `ovos.intent.deregister`, `.enable`, `.disable`, `ovos.skill.deregister`) and maintains a `(session_id, skill_id, intent_name, lang, method)` keyed index
- Serves `ovos.intent.list` (§10.1) and `ovos.intent.describe` (§10.2) pull-queries; session-scoped pool inheritance per §11.2
- `IntentService.__init__` now holds `self.intent_manifest = IntentManifest(bus)` — one line; all logic lives in the helper
- 19 unit tests covering register, deregister, enable/disable, skill teardown, session pool inheritance, list/describe filtering

## Spec refs

OVOS-INTENT-4 §§5–8 (registration broadcasts), §10 (orchestrator-owned manifest), §11.2 (session inheritance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an intent manifest that tracks registered intents in-memory and exposes them via listing and description queries.
  * Supports session-aware overrides, language scoping, and method-specific intent organization.
  * Integrated the manifest into the intent service lifecycle, including proper shutdown cleanup.
  * Includes enable/disable and deregistration controls for intents and entire skills.
* **Bug Fixes**
  * Improved handling of incomplete registrations and unknown/missing query details with clear error responses.
* **Tests**
  * Added comprehensive unit coverage for registration, replacement, pooling, enable/disable, deregistration, list filtering, and describe ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->