### PR TITLE
fix: OVOS-PIPELINE-1 §9.5 end-marker backstop for unexpected terminals

### DIFF
--- a/ovos_core/intent_services/service.py
+++ b/ovos_core/intent_services/service.py
@@ -550,91 +550,119 @@ class IntentService:
         Args:
             message (Message): The messagebus data
         """
-        # Get utterance utterance_plugins additional context
-        message = self._handle_transformers(message)
+        # OVOS-PIPELINE-1 §9.5: exactly one ``ovos.utterance.handled`` end-marker
+        # must terminate EVERY utterance, on every terminal path (§6.4). The three
+        # expected terminals each commit the end-marker themselves and set
+        # ``terminated``: the cancel path (``send_cancel_event`` — §6.4), the
+        # no-match path (``send_complete_intent_failure`` — §9.3), and the matched
+        # path (the dispatcher owns it, emitting from its §8 handler terminal via
+        # ``on_terminal``/``_emit_utterance_handled``, incl. the §8.3 timeout).
+        # The ``finally`` clause below is the backstop for an UNEXPECTED terminal —
+        # a transformer, language-disambiguation, session, or orchestration error
+        # that would otherwise leave the utterance with no end-marker, hanging
+        # every consumer that waits on it. ``terminated`` guards against a
+        # double-emit: a path that already committed the end-marker never re-emits.
+        terminated = False
+        try:
+            # Get utterance utterance_plugins additional context
+            message = self._handle_transformers(message)
 
-        if message.context.get("canceled"):
-            self.send_cancel_event(message)
-            return
+            if message.context.get("canceled"):
+                self.send_cancel_event(message)
+                terminated = True
+                return
 
-        # tag language of this utterance
-        lang = self.disambiguate_lang(message)
+            # tag language of this utterance
+            lang = self.disambiguate_lang(message)
 
-        utterances = message.data.get('utterances', [])
-        LOG.info(f"Parsing utterance: {utterances}")
+            utterances = message.data.get('utterances', [])
+            LOG.info(f"Parsing utterance: {utterances}")
 
-        stopwatch = Stopwatch()
+            stopwatch = Stopwatch()
 
-        # get session
-        sess = self._validate_session(message, lang)
-        message.context["session"] = sess.serialize()
+            # get session
+            sess = self._validate_session(message, lang)
+            message.context["session"] = sess.serialize()
 
-        # match
-        match = None
-        with stopwatch:
-            self._deactivations[sess.session_id] = []
-            # Loop through the matching functions until a match is found.
-            for pipeline, match_func in self.get_pipeline(session=sess):
-                langs = [lang]
-                if self.config.get("multilingual_matching"):
-                    # if multilingual matching is enabled, attempt to match all user languages if main fails
-                    langs += [l for l in get_valid_languages() if l != lang]
-                for intent_lang in langs:
-                    try:
-                        match = match_func(utterances, intent_lang, message)
-                    except Exception:
-                        # a misbehaving pipeline matcher (e.g. a malformed .voc
-                        # resource) must not abort the whole utterance — log and
-                        # treat it as a no-match so iteration continues.
-                        LOG.exception(f"{match_func} raised while matching "
-                                      f"'{intent_lang}'; treating as no-match")
-                        match = None
-                    if match:
-                        LOG.info(f"{pipeline} match ({intent_lang}): {match}")
-                        if match and not match.match_type:
-                            LOG.warning(f"Matcher {type(match_func).__name__} returned a match with empty match_type; skipping")
-                            continue
-                        if match.skill_id and match.skill_id in (sess.blacklisted_skills or []):
-                            LOG.debug(
-                                f"ignoring match, skill_id '{match.skill_id}' blacklisted by Session '{sess.session_id}'")
-                            continue
-                        if isinstance(match, IntentHandlerMatch) and match.match_type in (sess.blacklisted_intents or []):
-                            LOG.debug(
-                                f"ignoring match, intent '{match.match_type}' blacklisted by Session '{sess.session_id}'")
-                            continue
-                        # OVOS-PIPELINE-1 §6.2: if the matched intent is missing
-                        # any required slot, treat it as if the plugin had
-                        # declined and continue iteration; no bus event is emitted.
-                        missing = self._missing_required_slots(
-                            match, sess.session_id, intent_lang)
-                        if missing:
-                            LOG.debug(f"ignoring match '{match.match_type}': "
-                                      f"missing required slots {missing} (§6.2)")
-                            continue
+            # match
+            match = None
+            with stopwatch:
+                self._deactivations[sess.session_id] = []
+                # Loop through the matching functions until a match is found.
+                for pipeline, match_func in self.get_pipeline(session=sess):
+                    langs = [lang]
+                    if self.config.get("multilingual_matching"):
+                        # if multilingual matching is enabled, attempt to match all user languages if main fails
+                        langs += [l for l in get_valid_languages() if l != lang]
+                    for intent_lang in langs:
                         try:
-                            self._dispatch_match(match, message, intent_lang,
-                                                     pipeline_id=pipeline)
-                            break
+                            match = match_func(utterances, intent_lang, message)
                         except Exception:
-                            LOG.exception(f"{match_func} returned an invalid match")
+                            # a misbehaving pipeline matcher (e.g. a malformed .voc
+                            # resource) must not abort the whole utterance — log and
+                            # treat it as a no-match so iteration continues.
+                            LOG.exception(f"{match_func} raised while matching "
+                                          f"'{intent_lang}'; treating as no-match")
+                            match = None
+                        if match:
+                            LOG.info(f"{pipeline} match ({intent_lang}): {match}")
+                            if match and not match.match_type:
+                                LOG.warning(f"Matcher {type(match_func).__name__} returned a match with empty match_type; skipping")
+                                continue
+                            if match.skill_id and match.skill_id in (sess.blacklisted_skills or []):
+                                LOG.debug(
+                                    f"ignoring match, skill_id '{match.skill_id}' blacklisted by Session '{sess.session_id}'")
+                                continue
+                            if isinstance(match, IntentHandlerMatch) and match.match_type in (sess.blacklisted_intents or []):
+                                LOG.debug(
+                                    f"ignoring match, intent '{match.match_type}' blacklisted by Session '{sess.session_id}'")
+                                continue
+                            # OVOS-PIPELINE-1 §6.2: if the matched intent is missing
+                            # any required slot, treat it as if the plugin had
+                            # declined and continue iteration; no bus event is emitted.
+                            missing = self._missing_required_slots(
+                                match, sess.session_id, intent_lang)
+                            if missing:
+                                LOG.debug(f"ignoring match '{match.match_type}': "
+                                          f"missing required slots {missing} (§6.2)")
+                                continue
+                            try:
+                                self._dispatch_match(match, message, intent_lang,
+                                                         pipeline_id=pipeline)
+                                # the dispatcher now owns the §9.5 end-marker for
+                                # this utterance, emitting it from its §8 handler
+                                # terminal via on_terminal (_emit_utterance_handled)
+                                terminated = True
+                                break
+                            except Exception:
+                                LOG.exception(f"{match_func} returned an invalid match")
+                    else:
+                        LOG.debug(f"no match from {match_func}")
+                        continue
+                    break
                 else:
-                    LOG.debug(f"no match from {match_func}")
-                    continue
-                break
-            else:
-                # Nothing was able to handle the intent
-                # Ask politely for forgiveness for failing in this vital task
-                message.data["lang"] = lang
-                self.send_complete_intent_failure(message)
+                    # Nothing was able to handle the intent
+                    # Ask politely for forgiveness for failing in this vital task
+                    message.data["lang"] = lang
+                    self.send_complete_intent_failure(message)
+                    terminated = True
 
-        LOG.debug(f"intent matching took: {stopwatch.time}")
+            LOG.debug(f"intent matching took: {stopwatch.time}")
 
-        # sync any changes made to the default session, eg by ConverseService
-        if sess.session_id == "default":
-            SessionManager.sync(message)
-        elif sess.session_id in self._deactivations:
-            self._deactivations.pop(sess.session_id)
-        return match, message.context, stopwatch
+            # sync any changes made to the default session, eg by ConverseService
+            if sess.session_id == "default":
+                SessionManager.sync(message)
+            elif sess.session_id in self._deactivations:
+                self._deactivations.pop(sess.session_id)
+            return match, message.context, stopwatch
+        finally:
+            if not terminated:
+                # §9.5 backstop: no terminal path committed (unexpected error) —
+                # emit the end-marker so the utterance still terminates exactly
+                # once and no consumer waiting on it hangs.
+                LOG.exception("utterance processing did not reach a terminal; "
+                              "emitting ovos.utterance.handled backstop (§9.5)")
+                self.bus.emit(message.reply(SpecMessage.UTTERANCE_HANDLED))
 
     def send_complete_intent_failure(self, message):
         """Emit the OVOS-PIPELINE-1 §9.3 no-match terminal.

--- a/test/unittests/test_intent_service_extended.py
+++ b/test/unittests/test_intent_service_extended.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import contextlib
 import unittest
 from collections import defaultdict
 from unittest.mock import MagicMock, patch
@@ -514,6 +515,118 @@ class TestHandleUtterance(unittest.TestCase):
                    return_value=["en-US"]):
             svc.handle_utterance(msg)
         svc.send_complete_intent_failure.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# handle_utterance — OVOS-PIPELINE-1 §9.5 exactly-one end-marker invariant
+# ---------------------------------------------------------------------------
+
+class TestUtteranceHandledInvariant(unittest.TestCase):
+    """OVOS-PIPELINE-1 §9.5: every utterance MUST terminate with exactly one
+    ``ovos.utterance.handled`` end-marker, on every terminal path (§6.4)."""
+
+    @staticmethod
+    def _count_handled(svc):
+        """Attach a counter for ``ovos.utterance.handled`` on the real bus so
+        dispatcher done-signals still route to their handlers."""
+        handled = []
+        svc.bus.on(SpecMessage.UTTERANCE_HANDLED, lambda m: handled.append(m))
+        return handled
+
+    @staticmethod
+    def _patched_session(sess):
+        return [
+            patch("ovos_core.intent_services.service.SessionManager.get",
+                  return_value=sess),
+            patch("ovos_core.intent_services.service.SessionManager.reset_default_session",
+                  return_value=sess),
+            patch("ovos_core.intent_services.service.SessionManager.update"),
+            patch("ovos_core.intent_services.service.SessionManager.sync"),
+            patch("ovos_core.intent_services.service.get_message_lang",
+                  return_value="en-US"),
+            patch("ovos_core.intent_services.service.get_valid_languages",
+                  return_value=["en-US"]),
+        ]
+
+    def test_no_match_emits_exactly_one_handled(self):
+        """No-match terminal (§9.3 -> §9.5) emits exactly one end-marker."""
+        svc = _make_service()
+        handled = self._count_handled(svc)
+        sess = Session("s")
+        sess.pipeline = []  # empty pipeline -> no matchers
+        msg = Message("recognizer_loop:utterance",
+                      data={"utterances": ["xyz"]}, context={})
+        with contextlib.ExitStack() as stack:
+            for p in self._patched_session(sess):
+                stack.enter_context(p)
+            svc.handle_utterance(msg)
+        self.assertEqual(len(handled), 1)
+
+    def test_cancel_emits_exactly_one_handled(self):
+        """Cancel terminal (§6.4 -> §9.5) emits exactly one end-marker."""
+        svc = _make_service()
+        handled = self._count_handled(svc)
+        msg = Message("recognizer_loop:utterance",
+                      data={"utterances": ["stop"]},
+                      context={"canceled": True, "cancel_word": "stop"})
+        svc.handle_utterance(msg)
+        self.assertEqual(len(handled), 1)
+
+    def test_matched_handler_complete_emits_exactly_one_handled(self):
+        """Matched terminal: no end-marker before the §8 handler terminal, then
+        exactly one once the framework done-signal arrives (via the dispatcher's
+        on_terminal). Wire the real on_terminal so the dispatcher owns §9.5."""
+        svc = _make_service()
+        # re-wire the dispatcher's on_terminal to the real orchestrator callback
+        svc.intent_dispatcher.on_terminal = svc._emit_utterance_handled
+        handled = self._count_handled(svc)
+
+        sess = Session("s")
+        match = _make_match(session=sess)
+        mock_matcher = MagicMock(return_value=match)
+        mock_matcher.__name__ = "test_matcher"
+        svc.get_pipeline = MagicMock(return_value=[("ovos-test-plugin", mock_matcher)])
+
+        msg = Message("recognizer_loop:utterance",
+                      data={"utterances": ["hello"]},
+                      context={"session": sess.serialize()})
+        with contextlib.ExitStack() as stack:
+            for p in self._patched_session(sess):
+                stack.enter_context(p)
+            svc.handle_utterance(msg)
+            # dispatched, but the handler has not reported yet -> no end-marker
+            self.assertEqual(len(handled), 0)
+            # framework done-signal -> §8 complete -> §9.5 end-marker (exactly one)
+            svc.bus.emit(Message("mycroft.skill.handler.complete",
+                                 context={"session": sess.serialize(),
+                                          "skill_id": "test.skill"}))
+        self.assertEqual(len(handled), 1)
+
+    def test_transformer_exception_emits_backstop_handled(self):
+        """Unexpected error before iteration still terminates (§9.5 backstop)."""
+        svc = _make_service()
+        handled = self._count_handled(svc)
+        svc._handle_transformers = MagicMock(side_effect=RuntimeError("boom"))
+        msg = Message("recognizer_loop:utterance",
+                      data={"utterances": ["hello"]}, context={})
+        with self.assertRaises(RuntimeError):
+            svc.handle_utterance(msg)
+        self.assertEqual(len(handled), 1)
+
+    def test_session_error_emits_backstop_handled(self):
+        """Unexpected error during session validation still terminates (§9.5)."""
+        svc = _make_service()
+        handled = self._count_handled(svc)
+        svc._validate_session = MagicMock(side_effect=RuntimeError("boom"))
+        msg = Message("recognizer_loop:utterance",
+                      data={"utterances": ["hello"]}, context={})
+        with patch("ovos_core.intent_services.service.get_message_lang",
+                   return_value="en-US"), \
+             patch("ovos_core.intent_services.service.get_valid_languages",
+                   return_value=["en-US"]):
+            with self.assertRaises(RuntimeError):
+                svc.handle_utterance(msg)
+        self.assertEqual(len(handled), 1)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## OVOS-PIPELINE-1 §9.5 — guarantee exactly one `ovos.utterance.handled`

### The gap on `dev`
`IntentService.handle_utterance` already emits the §9.5 end-marker on all three *expected* terminals:

| Path | End-marker source |
|------|-------------------|
| Cancel (§6.4) | `send_cancel_event` → `ovos.utterance.cancelled` + `ovos.utterance.handled` |
| No-match (§9.3) | `send_complete_intent_failure` → `ovos.intent.unmatched` + `ovos.utterance.handled` |
| Matched (§8 terminal, incl. §8.3 timeout) | dispatcher `on_terminal` → `_emit_utterance_handled` |

But `handle_utterance` had **no top-level terminal guard**. An unexpected exception in the utterance/metadata transformer chain, `disambiguate_lang`, `_validate_session`, or the pipeline orchestration propagated out of the bus handler with **no end-marker** — leaving the utterance unterminated and hanging every consumer that waits on §9.5 (there is no dispatcher timeout on these pre-dispatch paths, so the consumer waits forever).

### The fix
Wrap the body in `try/finally` with a `terminated` flag that each expected terminal path sets after committing its own end-marker. The `finally` clause is a **backstop**: it emits `ovos.utterance.handled` only when no terminal path committed. This guarantees **exactly one** end-marker per utterance (§9.5), and the flag prevents any double-emit against the paths that already own it — including the asynchronous matched path, where the dispatcher emits the end-marker later from its §8 handler terminal.

Reuses the existing dispatcher correlation/lifecycle plumbing (the matched path stays owned by the dispatcher's `on_terminal`); the backstop only covers the previously-gapless exception terminals.

### Tests (TDD)
New `TestUtteranceHandledInvariant` asserts exactly-one `ovos.utterance.handled` for: matched+handler-complete, no-match/`complete_intent_failure`, cancel, and the two backstop paths (transformer-raise, session-raise). The two backstop tests are **red before / green after**; the three already-covered paths are green throughout. Full `test/unittests` suite: 302 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved utterance processing reliability by guaranteeing a single completion signal is emitted across all termination paths.
  * Prevented voice interactions from hanging during cancellations, no-match outcomes, or unexpected failures.
  * Preserved correct completion timing for successfully matched intents.
* **Tests**
  * Added coverage to enforce the “utterance handled” invariant, including cancel, no-match, matched-handler sequencing, and exception backstop scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->