### PR TITLE
Scope fallback pong collection

### DIFF
--- a/ovos_core/intent_services/fallback_service.py
+++ b/ovos_core/intent_services/fallback_service.py
@@ -15,6 +15,7 @@
 import operator
 import threading
 import time
+import uuid
 from collections import namedtuple
 from typing import Callable, Dict, List, Optional, Tuple, Union
 
@@ -133,6 +134,14 @@ class FallbackService(ConfidenceMatcherPipeline):
             fb_range = FallbackRange(0, 100)
         skill_ids = []  # skill_ids that already answered to ping
         fallback_skills = []  # skill_ids that want to handle fallback
+        response_event = threading.Event()
+        request_id = (
+            message.data.get("fallback_request_id")
+            or message.context.get("fallback_request_id")
+            or uuid.uuid4().hex
+        )
+        message.data["fallback_request_id"] = request_id
+        message.context["fallback_request_id"] = request_id
 
         sess = SessionManager.get(message)
         if sess is None:
@@ -144,6 +153,12 @@ class FallbackService(ConfidenceMatcherPipeline):
         skill_ids += [s for s in self.registered_fallbacks if s not in in_range]
 
         def handle_ack(msg):
+            ack_request_id = (
+                msg.data.get("fallback_request_id")
+                or msg.context.get("fallback_request_id")
+            )
+            if ack_request_id and ack_request_id != request_id:
+                return
             skill_id = msg.data["skill_id"]
             if msg.data.get("can_handle", True):
                 if skill_id in in_range:
@@ -154,7 +169,7 @@ class FallbackService(ConfidenceMatcherPipeline):
             else:
                 LOG.debug(f"{skill_id} does NOT WANT to try to handle fallback")
             skill_ids.append(skill_id)
-            self._fallback_response_event.set()
+            response_event.set()
 
         if in_range:  # no need to search if no skills available
             self.bus.on("ovos.skills.fallback.pong", handle_ack)
@@ -167,8 +182,8 @@ class FallbackService(ConfidenceMatcherPipeline):
             start = time.time()
             while not all(s in skill_ids for s in self.registered_fallbacks) \
                     and time.time() - start <= 0.5:
-                self._fallback_response_event.clear()
-                self._fallback_response_event.wait(0.02)
+                response_event.clear()
+                response_event.wait(0.02)
 
             self.bus.remove("ovos.skills.fallback.pong", handle_ack)
         return fallback_skills

--- a/test/unittests/test_fallback_service.py
+++ b/test/unittests/test_fallback_service.py
@@ -275,6 +275,59 @@ class TestCollectFallbackSkills(unittest.TestCase):
 
         self.assertEqual(result_holder[0], [])
 
+    def test_pong_for_other_fallback_request_is_ignored(self):
+        """Concurrent fallback collectors must not consume each other's pongs."""
+        svc = _make_service()
+        svc.registered_fallbacks = {"skill_a": 50}
+
+        ack_handler = None
+
+        def capture_on(event, handler):
+            nonlocal ack_handler
+            if event == "ovos.skills.fallback.pong":
+                ack_handler = handler
+
+        svc.bus.on = capture_on
+        svc.bus.remove = MagicMock()
+        svc.bus.emit = MagicMock()
+
+        sess = Session("s")
+        result_holder = []
+
+        def run():
+            with patch("ovos_core.intent_services.fallback_service.SessionManager.get",
+                       return_value=sess):
+                result_holder.append(
+                    svc._collect_fallback_skills(
+                        Message("test"), fb_range=FallbackRange(5, 90)))
+
+        t = None
+        try:
+            t = threading.Thread(target=run)
+            t.start()
+            time.sleep(0.05)
+            self.assertIsNotNone(ack_handler)
+            ping = svc.bus.emit.call_args[0][0]
+            request_id = ping.data["fallback_request_id"]
+            ack_handler(Message("ovos.skills.fallback.pong", {
+                "skill_id": "skill_a",
+                "can_handle": True,
+                "fallback_request_id": "other-request",
+            }))
+            time.sleep(0.05)
+            self.assertEqual(result_holder, [])
+            ack_handler(Message("ovos.skills.fallback.pong", {
+                "skill_id": "skill_a",
+                "can_handle": True,
+                "fallback_request_id": request_id,
+            }))
+        finally:
+            if t is not None:
+                t.join(timeout=1)
+            svc.shutdown()
+
+        self.assertEqual(result_holder[0], ["skill_a"])
+
     def test_listener_removed_on_timeout(self):
         """bus.remove must be called even when no skill replies (timeout path)."""
         svc = _make_service()

--- a/test/unittests/test_fallback_service.py
+++ b/test/unittests/test_fallback_service.py
@@ -18,7 +18,7 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 from ovos_bus_client.message import Message
-from ovos_bus_client.session import Session, SessionManager
+from ovos_bus_client.session import Session
 from ovos_utils.fakebus import FakeBus
 from ovos_workshop.permissions import FallbackMode
 


### PR DESCRIPTION
## What
- stamp fallback pings with a `fallback_request_id`
- ignore pongs that belong to another in-flight fallback request
- use a local response event per collection instead of a shared collector event

## Why
Concurrent utterances can collect fallback candidates at the same time. The collector should not let one request consume or wake on another request's pong.

## Test
- `python -m pytest test/unittests/test_fallback_service.py -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fallback skill collection so each request uses its own unique identifier and only processes matching acknowledgements.
  * Prevented concurrent fallback lookups from interfering with one another.
  * Ensured fallback request identifiers are consistently tracked during response handling.

* **Tests**
  * Added coverage for ignoring acknowledgement messages that belong to a different fallback request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->