### PR TITLE
fix: repair malformed intent-service locale templates

### DIFF
--- a/ovos_core/intent_services/locale/ca-es/global_stop.intent
+++ b/ovos_core/intent_services/locale/ca-es/global_stop.intent
@@ -1,4 +1,4 @@
-(acaba|finalitza)(-ho) tot
+(acaba|finalitza)-ho tot
 (atura|para)(-ho|) tot
 (atura|para)(|-ho) tot
 Acaba totes les tasques obertes
@@ -22,7 +22,7 @@ atura(-ho|) tot (ara mateix|)
 atura-ho tot
 avorta(-ho|) tot
 avorta(|-ho) tot
-cancel·la(-ho) tot
+cancel·la-ho tot
 cancel·la(-ho|) tot
 cessa tot
 cessa tot

--- a/ovos_core/intent_services/locale/ca-es/stop.intent
+++ b/ovos_core/intent_services/locale/ca-es/stop.intent
@@ -8,7 +8,7 @@
 (deixa-ho estar|para|plega|deixa de treballar-hi|no hi treballis més)
 (para|atura) (aquesta activitat|l'activitat actual)
 (para|atura) el procés actual
-(prou|para|estop|stop) (això)
+(prou|para|estop|stop) [això]
 (prou|para|estop|stop) (de fer això|)
 Cancel·la la tasca actual
 Si us plau (atura|para) la tasca actual

--- a/ovos_core/intent_services/locale/de-de/global_stop.intent
+++ b/ovos_core/intent_services/locale/de-de/global_stop.intent
@@ -1,4 +1,4 @@
-(breche|brech) (alles) ab
+(breche|brech) alles ab
 (breche|brech) alles ab
 (schließe|schließ|schliess|stop|stoppe|beende) alles
 Alle Aktionen beenden

--- a/ovos_core/intent_services/locale/it-it/global_stop.voc
+++ b/ovos_core/intent_services/locale/it-it/global_stop.voc
@@ -1,28 +1,5 @@
 ferma tutto
 smetti tutto
-[UNUSED]
-[UNUSED]
-[UNUSED]
-[UNUSED]
-[UNUSED]
-[UNUSED]
-[UNUSED]
-[UNUSED]
-[UNUSED]
-[UNUSED]
-[UNUSED]
-[UNUSED]
-[UNUSED]
-[UNUSED]
-[UNUSED]
-[UNUSED]
-[UNUSED]
-[UNUSED]
-[UNUSED]
-[UNUSED]
-[UNUSED]
-[UNUSED]
-[UNUSED]
 (Interrompi|termina|stoppa|ferma) tutte le attività in esecuzione
 (Interrompi|termina|stoppa|ferma|cancella|annulla) tutte le operazioni in sospeso
 (Termina|Finisci) tutte le attività aperte

--- a/ovos_core/intent_services/locale/it-it/stop.voc
+++ b/ovos_core/intent_services/locale/it-it/stop.voc
@@ -9,9 +9,3 @@ puoi fermarti ora
 (Interrompi|termina|stoppa|ferma) (i|il|le) (processo|processi|azioni|attività) in corso
 (Interrompi|termina|stoppa|ferma) (i|il|le) (processo|processi|azioni|attività) corrente
 (Per favore|per piacere|) (metti fine a|termina) (tutto|) (questo|ciò)
-[UNUSED]
-[UNUSED]
-[UNUSED]
-[UNUSED]
-[UNUSED]
-[UNUSED]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "ovos-config>=0.0.13,<3.0.0",
     "ovos-workshop>=9.0.2a1,<10.0.0",
     "rapidfuzz>=3.6,<4.0",
-    "ovos-spec-tools[langcodes]>=1.1.0a1,<2.0.0",
+    "ovos-spec-tools[langcodes]>=1.5.0a1,<2.0.0",
 ]
 
 [project.urls]

--- a/test/unittests/test_locale_templates.py
+++ b/test/unittests/test_locale_templates.py
@@ -1,0 +1,47 @@
+"""Validate that every locale resource template shipped with the package expands."""
+import os
+import unittest
+
+from ovos_spec_tools.expansion import expand
+
+import ovos_core
+
+PACKAGE_ROOT = os.path.dirname(ovos_core.__file__)
+TEMPLATE_EXTENSIONS = (".voc", ".intent", ".dialog", ".entity", ".rx")
+
+
+def iter_locale_files():
+    """Yield every template resource file under any locale/ directory."""
+    for root, _dirs, files in os.walk(PACKAGE_ROOT):
+        parts = root.split(os.sep)
+        if "locale" not in parts and "res" not in parts:
+            continue
+        for fname in files:
+            if fname.endswith(TEMPLATE_EXTENSIONS):
+                yield os.path.join(root, fname)
+
+
+class TestLocaleTemplates(unittest.TestCase):
+    def test_all_templates_expand(self):
+        failures = []
+        checked = 0
+        for path in iter_locale_files():
+            with open(path, encoding="utf-8") as f:
+                for lineno, line in enumerate(f, start=1):
+                    line = line.strip()
+                    if not line or line.startswith("#"):
+                        continue
+                    checked += 1
+                    try:
+                        expand(line)
+                    except Exception as e:
+                        rel = os.path.relpath(path, PACKAGE_ROOT)
+                        failures.append(f"{rel}:{lineno}: {line!r} -> {e}")
+        self.assertGreater(checked, 0, "no locale template lines found")
+        self.assertEqual(
+            failures, [],
+            "malformed locale templates:\n" + "\n".join(failures))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Every template line under `ovos_core/intent_services/locale` now passes `ovos_spec_tools.expansion.expand`.

- remove `[UNUSED]` placeholder lines from it-it `stop.voc` / `global_stop.voc`
- repair unexpandable brace/group syntax in ca-es and de-de stop templates, keeping the translated wording
- add a regression test that expands every locale template line
- bump ovos-spec-tools floor to 1.5.0a1 for the expansion validator

🤖 Generated with [Claude Code](https://claude.com/claude-code)