### PR TITLE
fix: unload skills lacking a fallback on network/internet/gui disconnect

### DIFF
--- a/ovos_core/skill_manager.py
+++ b/ovos_core/skill_manager.py
@@ -534,15 +534,30 @@ class SkillManager(Thread):
 
     def _unload_on_network_disconnect(self) -> None:
         """Unload skills that require a network connection to work."""
-        # TODO - implementation missing
+        with self._plugin_skills_lock:
+            skills = dict(self.plugin_skills)
+        for skill_id, skill_loader in skills.items():
+            requirements = skill_loader.runtime_requirements
+            if requirements.requires_network and not requirements.no_network_fallback:
+                self._unload_plugin_skill(skill_id)
 
     def _unload_on_internet_disconnect(self) -> None:
         """Unload skills that require an internet connection to work."""
-        # TODO - implementation missing
+        with self._plugin_skills_lock:
+            skills = dict(self.plugin_skills)
+        for skill_id, skill_loader in skills.items():
+            requirements = skill_loader.runtime_requirements
+            if requirements.requires_internet and not requirements.no_internet_fallback:
+                self._unload_plugin_skill(skill_id)
 
     def _unload_on_gui_disconnect(self) -> None:
         """Unload skills that require a GUI to work."""
-        # TODO - implementation missing
+        with self._plugin_skills_lock:
+            skills = dict(self.plugin_skills)
+        for skill_id, skill_loader in skills.items():
+            requirements = skill_loader.runtime_requirements
+            if requirements.requires_gui and not requirements.no_gui_fallback:
+                self._unload_plugin_skill(skill_id)
 
     def _load_on_startup(self) -> None:
         """Handle offline skills load on startup."""

--- a/test/unittests/test_skill_manager.py
+++ b/test/unittests/test_skill_manager.py
@@ -24,6 +24,7 @@ from ovos_bus_client.message import Message
 from ovos_config import Configuration
 from ovos_config import LocalConf, DEFAULT_CONFIG
 from ovos_core.skill_manager import SkillManager
+from ovos_utils.process_utils import RuntimeRequirements
 from ovos_workshop.skill_launcher import SkillLoader
 
 
@@ -177,6 +178,106 @@ class TestSkillManager(TestCase):
         self.skill_manager.activate_skill(message)
         test_skill_loader.activate.assert_called_once()
         message.response.assert_called_once()
+
+    def _make_plugin_skill(self, skill_id, **requirement_overrides):
+        loader = Mock(spec=SkillLoader)
+        loader.skill_id = skill_id
+        loader.instance = Mock()
+        loader.runtime_requirements = RuntimeRequirements(**requirement_overrides)
+        return loader
+
+    def test_unload_on_network_disconnect_unloads_dependent_skills(self):
+        needs_network = self._make_plugin_skill(
+            'needs_network', requires_network=True, no_network_fallback=False)
+        has_fallback = self._make_plugin_skill(
+            'has_fallback', requires_network=True, no_network_fallback=True)
+        no_requirement = self._make_plugin_skill(
+            'no_requirement', requires_network=False, no_network_fallback=False)
+        self.skill_manager.plugin_skills = {
+            'needs_network': needs_network,
+            'has_fallback': has_fallback,
+            'no_requirement': no_requirement,
+        }
+
+        self.skill_manager._unload_on_network_disconnect()
+
+        self.assertNotIn('needs_network', self.skill_manager.plugin_skills)
+        self.assertIn('has_fallback', self.skill_manager.plugin_skills)
+        self.assertIn('no_requirement', self.skill_manager.plugin_skills)
+
+    def test_unload_on_internet_disconnect_unloads_dependent_skills(self):
+        needs_internet = self._make_plugin_skill(
+            'needs_internet', requires_internet=True, no_internet_fallback=False)
+        has_fallback = self._make_plugin_skill(
+            'has_fallback', requires_internet=True, no_internet_fallback=True)
+        no_requirement = self._make_plugin_skill(
+            'no_requirement', requires_internet=False, no_internet_fallback=False)
+        self.skill_manager.plugin_skills = {
+            'needs_internet': needs_internet,
+            'has_fallback': has_fallback,
+            'no_requirement': no_requirement,
+        }
+
+        self.skill_manager._unload_on_internet_disconnect()
+
+        self.assertNotIn('needs_internet', self.skill_manager.plugin_skills)
+        self.assertIn('has_fallback', self.skill_manager.plugin_skills)
+        self.assertIn('no_requirement', self.skill_manager.plugin_skills)
+
+    def test_unload_on_gui_disconnect_unloads_dependent_skills(self):
+        needs_gui = self._make_plugin_skill(
+            'needs_gui', requires_gui=True, no_gui_fallback=False)
+        has_fallback = self._make_plugin_skill(
+            'has_fallback', requires_gui=True, no_gui_fallback=True)
+        no_requirement = self._make_plugin_skill(
+            'no_requirement', requires_gui=False, no_gui_fallback=False)
+        self.skill_manager.plugin_skills = {
+            'needs_gui': needs_gui,
+            'has_fallback': has_fallback,
+            'no_requirement': no_requirement,
+        }
+
+        self.skill_manager._unload_on_gui_disconnect()
+
+        self.assertNotIn('needs_gui', self.skill_manager.plugin_skills)
+        self.assertIn('has_fallback', self.skill_manager.plugin_skills)
+        self.assertIn('no_requirement', self.skill_manager.plugin_skills)
+
+    def test_handle_network_disconnected_unloads_dependent_skills(self):
+        needs_network = self._make_plugin_skill(
+            'needs_network', requires_network=True, no_network_fallback=False)
+        self.skill_manager.plugin_skills = {'needs_network': needs_network}
+        self.skill_manager._network_event.set()
+
+        self.skill_manager.handle_network_disconnected(
+            Message("mycroft.network.disconnected"))
+
+        self.assertFalse(self.skill_manager._network_event.is_set())
+        self.assertNotIn('needs_network', self.skill_manager.plugin_skills)
+
+    def test_handle_internet_disconnected_unloads_dependent_skills(self):
+        needs_internet = self._make_plugin_skill(
+            'needs_internet', requires_internet=True, no_internet_fallback=False)
+        self.skill_manager.plugin_skills = {'needs_internet': needs_internet}
+        self.skill_manager._connected_event.set()
+
+        self.skill_manager.handle_internet_disconnected(
+            Message("mycroft.internet.disconnected"))
+
+        self.assertFalse(self.skill_manager._connected_event.is_set())
+        self.assertNotIn('needs_internet', self.skill_manager.plugin_skills)
+
+    def test_handle_gui_disconnected_unloads_dependent_skills(self):
+        needs_gui = self._make_plugin_skill(
+            'needs_gui', requires_gui=True, no_gui_fallback=False)
+        self.skill_manager.plugin_skills = {'needs_gui': needs_gui}
+        self.skill_manager._gui_event.set()
+
+        self.skill_manager.handle_gui_disconnected(
+            Message("mycroft.gui.unavailable"))
+
+        self.assertFalse(self.skill_manager._gui_event.is_set())
+        self.assertNotIn('needs_gui', self.skill_manager.plugin_skills)
 
     def test_handle_gui_connected_defers_skill_loading_until_startup_complete(self):
         self.skill_manager._load_new_skills = Mock()


### PR DESCRIPTION
## What was broken

`ovos_core/skill_manager.py` had three stub methods:

- `_unload_on_network_disconnect`
- `_unload_on_internet_disconnect`
- `_unload_on_gui_disconnect`

each marked `# TODO - implementation missing`. They are called from
`handle_network_disconnected`, `handle_internet_disconnected` and
`handle_gui_disconnected` respectively, but did nothing.

`RuntimeRequirements` (in `ovos_utils.process_utils`) documents that a
skill can declare `requires_internet` / `requires_network` /
`requires_gui`, with a matching `no_*_fallback` flag for skills that can
degrade gracefully (e.g. via a local cache). The before-load gating in
`load_plugin_skills` already honors `network_before_load` /
`internet_before_load` to avoid loading such a skill while the resource
is unavailable — but a skill that was already loaded and then lost its
required resource was never unloaded, and thus never had a chance to be
reloaded through the existing reload-on-reconnect path.

## How it fails

Disable a resource (internet/network/GUI) that a currently-loaded skill
declares as required with no fallback, and the skill keeps running
(and answering utterances) as if nothing changed, even though its
documented contract says it should be unloaded until the resource comes
back.

## The fix

Implemented all three methods symmetrically, mirroring the existing
before-load gating logic: iterate the currently-loaded
`self.plugin_skills`, and for each skill whose `runtime_requirements`
say it needs the disappearing resource and has no fallback for it,
unload it via the existing `_unload_plugin_skill` helper. Once the
resource reconnects, the existing `_load_on_network` / `_load_on_internet`
/ `_load_new_skills` paths pick the skill back up.

## Verification

Added unit tests in `test/unittests/test_skill_manager.py` covering all
three unload methods (skill unloaded when it requires the resource and
has no fallback; left loaded when it has a fallback or doesn't require
the resource) and covering the `handle_*_disconnected` bus handlers
end-to-end with a `FakeBus`-style mock bus.

Ran:

```
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest test/unittests/test_skill_manager.py test/unittests/test_manager.py -q
```

29 + 14 tests pass, no regressions.

---

Authored with AI assistance (Claude).