### PR TITLE
chore: drop unused direct watchdog dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ requires-python = ">=3.10"
 dependencies = [
     "requests>=2.26, <3.0",
     "python-dateutil>=2.6, <3.0",
-    "watchdog>=2.1, <3.0",
     "combo-lock>=0.2.2, <0.4",
     "ovos-utils>=0.13.5a1,<1.0.0",
     "ovos_bus_client>=2.6.0a1,<3.0.0",


### PR DESCRIPTION
ovos-core does not import the watchdog library directly; file watching goes through ovos_utils.file_utils.FileWatcher, which declares watchdog itself. The stale <3.0 cap was forcing a downgrade from watchdog 6.0.0 to 2.3.1 in fresh installs. Per review feedback, the unused direct dependency is removed entirely rather than re-pinned.

Authored with Claude Code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application’s runtime dependency configuration.
  * Replaced one file-monitoring dependency with an alternative package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->