### PR TITLE
chore: drop deprecated bus-client EnclosureAPI from skill_manager

### DIFF
--- a/ovos_core/skill_manager.py
+++ b/ovos_core/skill_manager.py
@@ -19,7 +19,6 @@ import time
 from threading import Thread, Event
 from typing import Callable, List, Optional
 
-from ovos_bus_client.apis.enclosure import EnclosureAPI
 from ovos_bus_client.client import MessageBusClient
 from ovos_bus_client.message import Message
 from ovos_bus_client.util.scheduler import EventScheduler
@@ -127,7 +126,6 @@ class SkillManager(Thread):
         self.plugin_skills = {}
         self._plugin_skills_lock = threading.RLock()
         self._loading_plugin_skills = set()
-        self.enclosure = EnclosureAPI(bus)
         self.num_install_retries = 0
         self.empty_skill_dirs = set()  # Save a record of empty skill dirs.
 


### PR DESCRIPTION
## Summary

Consumer catch-up for the enclosure->GUI migration in `ovos_core.skill_manager`.

`SkillManager.__init__` imported `EnclosureAPI` from `ovos_bus_client.apis.enclosure`
(deprecated, moved to `ovos-gui-api-client`) and stored it as `self.enclosure`.
That attribute was write-only - grepped across `ovos-core` and nothing ever
reads `.enclosure` on a `SkillManager` instance - so instead of switching the
import to the new package, this removes the dead import and attribute
entirely.

## Verification

- `python -W always -c "import ovos_core.skill_manager"` - the
  EnclosureAPI-moved-to-ovos-gui-api-client deprecation warning is gone, no
  new warnings introduced.
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest test/unittests/test_skill_manager.py`
  - 23 passed.

## Test plan
- [x] Import smoke test, warning gone
- [x] `test_skill_manager.py` unit suite green

---
Authored with Claude Code.