### PR TITLE
fix: update e2e intent-name expectations for OVOS-INTENT-2 lowercase rename

### DIFF
--- a/test/end2end/test_intent_pipeline.py
+++ b/test/end2end/test_intent_pipeline.py
@@ -143,7 +143,7 @@ class TestIntentPipelineRouting(TestCase):
             ignore_messages=self.ignore_messages,
             source_message=message,
             final_session=final_session,
-            activation_points=[f"{self.skill_id}:count_to_N.intent"],
+            activation_points=[f"{self.skill_id}:count_to_n.intent"],
             expected_messages=[
                 message,
                 Message(
@@ -155,7 +155,7 @@ class TestIntentPipelineRouting(TestCase):
                 Message(
                     SpecMessage.INTENT_MATCHED,
                     data={"skill_id": self.skill_id,
-                          "intent_name": f"{self.skill_id}:count_to_N.intent",
+                          "intent_name": f"{self.skill_id}:count_to_n.intent",
                           "utterance": "count to 3", "lang": session.lang},
                     context={"skill_id": self.skill_id},
                 ),
@@ -163,11 +163,11 @@ class TestIntentPipelineRouting(TestCase):
                 Message(
                     SpecMessage.INTENT_HANDLER_START,
                     data={"skill_id": self.skill_id,
-                          "intent_name": "count_to_N.intent"},
+                          "intent_name": "count_to_n.intent"},
                     context={"skill_id": self.skill_id},
                 ),
                 Message(
-                    f"{self.skill_id}:count_to_N.intent",
+                    f"{self.skill_id}:count_to_n.intent",
                     data={"utterance": "count to 3", "lang": session.lang},
                     context={"skill_id": self.skill_id},
                 ),
@@ -185,7 +185,7 @@ class TestIntentPipelineRouting(TestCase):
                 Message(
                     SpecMessage.INTENT_HANDLER_COMPLETE,
                     data={"skill_id": self.skill_id,
-                          "intent_name": "count_to_N.intent"},
+                          "intent_name": "count_to_n.intent"},
                     context={"skill_id": self.skill_id},
                 ),
                 Message(
@@ -226,7 +226,7 @@ class TestIntentPipelineRouting(TestCase):
             ignore_messages=self.ignore_messages,
             source_message=message,
             final_session=final_session,
-            activation_points=[f"{self.skill_id}:count_to_N.intent"],
+            activation_points=[f"{self.skill_id}:count_to_n.intent"],
             expected_messages=[
                 message,
                 Message(
@@ -238,7 +238,7 @@ class TestIntentPipelineRouting(TestCase):
                 Message(
                     SpecMessage.INTENT_MATCHED,
                     data={"skill_id": self.skill_id,
-                          "intent_name": f"{self.skill_id}:count_to_N.intent",
+                          "intent_name": f"{self.skill_id}:count_to_n.intent",
                           "utterance": "count to 3", "lang": session.lang},
                     context={"skill_id": self.skill_id},
                 ),
@@ -246,11 +246,11 @@ class TestIntentPipelineRouting(TestCase):
                 Message(
                     SpecMessage.INTENT_HANDLER_START,
                     data={"skill_id": self.skill_id,
-                          "intent_name": "count_to_N.intent"},
+                          "intent_name": "count_to_n.intent"},
                     context={"skill_id": self.skill_id},
                 ),
                 Message(
-                    f"{self.skill_id}:count_to_N.intent",
+                    f"{self.skill_id}:count_to_n.intent",
                     data={"utterance": "count to 3", "lang": session.lang},
                     context={"skill_id": self.skill_id},
                 ),
@@ -268,7 +268,7 @@ class TestIntentPipelineRouting(TestCase):
                 Message(
                     SpecMessage.INTENT_HANDLER_COMPLETE,
                     data={"skill_id": self.skill_id,
-                          "intent_name": "count_to_N.intent"},
+                          "intent_name": "count_to_n.intent"},
                     context={"skill_id": self.skill_id},
                 ),
                 Message(

--- a/test/end2end/test_stop.py
+++ b/test/end2end/test_stop.py
@@ -297,7 +297,7 @@ class TestCountSkills(TestCase):
             activate_skill = [
                 message,
                 Message(f"{self.skill_id}.activate", {}),  # skill is activated
-                Message(f"{self.skill_id}:count_to_N.intent", {}),  # intent triggers
+                Message(f"{self.skill_id}:count_to_n.intent", {}),  # intent triggers
 
                 Message("mycroft.skill.handler.start", {
                     "name": "CountSkill.handle_how_are_you_intent"


### PR DESCRIPTION
## Summary

`ovos-skill-count` 0.0.6a1 (2026-07-18, "fix: lowercase intent base name per OVOS-INTENT-2 §2 (#40)") renamed its padatious intent file from `count_to_N.intent` to `count_to_n.intent`, per the OVOS-INTENT-2 §2 spec conformance rule. Confirmed against the skill's current release tree (`ovos_skill_count/locale/en-US/count_to_n.intent`, tag `0.0.6a1`).

Our end2end test harness under `test/end2end/` still asserted the old mixed-case intent name, so the Ovoscope End-to-End Tests workflow has been red on every branch since 2026-07-18 (e.g. run 30042114547), with mismatches like:

```
expected 'ovos-skill-count.openvoiceos:count_to_N.intent' | got 'ovos-skill-count.openvoiceos:count_to_n.intent'
```

This PR realigns the harness expectations with the skill's actual (spec-conformant) intent name in `test/end2end/test_stop.py` and `test/end2end/test_intent_pipeline.py`.

I also checked for other mixed-case `.intent` expectations in `test/end2end/` that might have been affected by the same rename wave. `test/end2end/test_padatious.py` references `Greetings.intent` for `ovos-skill-hello-world`, but that skill's current release (checked via its GitHub `translations/en-us/intents.json`) still uses `Greetings.intent` unchanged, so no edit was made there.

## Test plan

Ran the previously-failing tests live against a real ovoscope-booted core in an isolated venv (Python 3.11, worktree checkout of this branch):

```
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest test/end2end/test_intent_pipeline.py test/end2end/test_stop.py -x -q
```

Result: `11 passed, 22 subtests passed in 257.92s` — covers `TestCountSkills::test_count`, `test_padatious_intent_matched`, and `test_high_priority_stage_handles_before_low` in both the `spec` and `legacy` namespaces.

- [x] `test/end2end/test_stop.py::TestCountSkills::test_count` passes (spec + legacy)
- [x] `test/end2end/test_intent_pipeline.py::test_padatious_intent_matched` passes (spec + legacy)
- [x] `test/end2end/test_intent_pipeline.py::test_high_priority_stage_handles_before_low` passes (spec + legacy)
- [ ] CI Ovoscope End-to-End Tests workflow green (pending)

Authored with [Claude Code](https://claude.com/claude-code).