### PR TITLE
fix: align intent-transformer test with OVOS-TRANSFORM-1 §3.4 identity invariant

### DIFF
--- a/test/unittests/test_transformers.py
+++ b/test/unittests/test_transformers.py
@@ -362,14 +362,37 @@ class TestIntentTransformersServiceTransform(unittest.TestCase):
         p.transform.assert_called_once_with(intent)
 
     def test_transform_returns_modified_intent(self):
-        """The intent returned by a plugin is passed along and returned."""
-        original = _make_intent_match("original:intent")
-        modified = _make_intent_match("modified:intent")
+        """A legitimate capture enrichment (same identity) is passed along.
+
+        OVOS-TRANSFORM-1 §3.4 permits enriching ``Match.captures`` /
+        ``match_data`` while keeping the dispatch identity (match_type/skill_id)
+        unchanged.
+        """
+        original = IntentHandlerMatch(match_type="test:intent", match_data={},
+                                      skill_id="skillA", utterance="hello")
+        enriched = IntentHandlerMatch(match_type="test:intent",
+                                      match_data={"slot": "value"},
+                                      skill_id="skillA", utterance="hello")
+        p = _make_mock_plugin("p", priority=50)
+        p.transform.return_value = enriched
+        svc = _make_intent_service(plugins=[p])
+        result = svc.transform(original)
+        self.assertEqual(result.match_data.get("slot"), "value")
+
+    def test_transform_identity_change_rejected(self):
+        """OVOS-TRANSFORM-1 §3.4: a transformer changing match_type or
+        skill_id is rejected; the prior Match is kept."""
+        original = IntentHandlerMatch(match_type="original:intent",
+                                      match_data={}, skill_id="skillA",
+                                      utterance="hello")
+        modified = IntentHandlerMatch(match_type="modified:intent",
+                                      match_data={}, skill_id="skillA",
+                                      utterance="hello")
         p = _make_mock_plugin("p", priority=50)
         p.transform.return_value = modified
         svc = _make_intent_service(plugins=[p])
         result = svc.transform(original)
-        self.assertEqual(result.match_type, "modified:intent")
+        self.assertEqual(result.match_type, "original:intent")
 
     def test_transform_exception_is_swallowed(self):
         """A plugin exception is caught and processing continues."""


### PR DESCRIPTION
## What broke

ovos-plugin-manager#417 (merged to OPM `dev`) makes `IntentTransformersService` reject an intent-transformer result that changes `match_type`/`skill_id`, per OVOS-TRANSFORM-1 §3.4 (identity invariant: transformers may enrich `match_data`/captures but must not change dispatch identity).

`test/unittests/test_transformers.py::TestIntentTransformersServiceTransform::test_transform_returns_modified_intent` still asserted the old pass-through behavior — a transformer swapping `match_type` from `original:intent` to `modified:intent` and having that change accepted. With OPM installed from git `dev`, that assertion now fails (`'original:intent' != 'modified:intent'`) on every core PR whose CI installs OPM from git dev.

## Fix

Split the stale test into two:
- `test_transform_returns_modified_intent` — a legitimate §3.4-compliant enrichment (same `match_type`/`skill_id`, changed `match_data`) is passed through.
- `test_transform_identity_change_rejected` — a transformer changing `match_type` is rejected and the prior `Match` is kept, per §3.4.

Scope is intentionally narrow: only this test method, no other changes (no pyproject floor bump, no service.py changes).

## Note

Core PR #785 (`fix/transform-1-conformance`) already contains a broader, corrected version of this test file (plus additional §4/§1.3/§7/§8.1 conformance tests and service.py changes) and will rebase over this once merged.

## Test plan
- `pytest test/unittests/test_transformers.py -q` in a fresh uv venv with OPM installed from git dev: 38 passed
- Full unit suite (`pytest test/unittests -q`): 302 passed, no new failures vs dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)