### PR TITLE
fix: canonicalize package names before the protected-package check

### DIFF
--- a/ovos_core/skill_installer.py
+++ b/ovos_core/skill_installer.py
@@ -8,6 +8,7 @@ from typing import Optional
 
 import requests
 from combo_lock import NamedLock
+from packaging.utils import canonicalize_name
 from ovos_bus_client import Message
 from ovos_config.config import Configuration
 from ovos_utils.log import LOG
@@ -182,11 +183,15 @@ class SkillsStore:
             cpkgs = ["ovos-core", "ovos-utils", "ovos-plugin-manager",
                      "ovos-config", "ovos-bus-client", "ovos-workshop"]
 
-        # remove version pinning and normalize _ to - (pip accepts both)
-        cpkgs = [p.split("~")[0].split("<")[0].split(">")[0].split("=")[0].replace("_", "-")
-                 for p in cpkgs]
+        # remove version pinning and canonicalize names (PEP 503) so
+        # "ovos_core", "OVOS-Core", "ovos.core", etc. all compare equal
+        # to "ovos-core", matching how pip/pypi identify distributions
+        cpkgs = [canonicalize_name(p.split("~")[0].split("<")[0].split(">")[0].split("=")[0])
+                 for p in cpkgs if p]
 
-        if any(p in cpkgs for p in packages):
+        norm_packages = [canonicalize_name(p) for p in packages]
+
+        if any(p in cpkgs for p in norm_packages):
             LOG.error(f'tried to uninstall a protected package: {cpkgs}')
             self.play_error_sound()
             return False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ requires-python = ">=3.10"
 
 dependencies = [
     "requests>=2.26, <3.0",
+    "packaging>=20.0",
     "python-dateutil>=2.6, <3.0",
     "combo-lock>=0.2.2, <0.4",
     "ovos-utils>=0.13.5a1,<1.0.0",

--- a/test/unittests/test_skill_installer.py
+++ b/test/unittests/test_skill_installer.py
@@ -140,6 +140,21 @@ def test_pip_uninstall_happy_path():
     assert True
 
 
+@pytest.mark.parametrize("requested", ["ovos-core", "ovos_core", "OVOS-Core", "ovos.core"])
+def test_pip_uninstall_protected_package_separator_and_case_variants(skills_store, requested):
+    """The protected-package guard must reject "-", "_" and "." separator
+    variants, and case variants, of a protected name -- not just the exact
+    spelling used in the constraints list (pip/PyPI treat them as the same
+    distribution, per PEP 503)."""
+    skills_store.play_error_sound = Mock()
+    # bypass the constraints-file existence check so we exercise the
+    # built-in default protected-package list ("ovos-core", ...)
+    skills_store.validate_constraints = Mock(return_value=True)
+    res = skills_store.pip_uninstall([requested], constraints="not/a/real/constraints/path")
+    assert res is False
+    skills_store.play_error_sound.assert_called_once()
+
+
 def test_validate_skill_non_github_urls(skills_store):
     """Non-GitHub URLs are always rejected without any network call."""
     assert skills_store.validate_skill("https://gitlab.com/foo/skill-bar") is False


### PR DESCRIPTION
## Summary

`ovos_core/skill_installer.py`'s `pip_uninstall` protects a set of core
packages from being removed via the `ovos.pip.uninstall` bus message. The
protected list was normalized (version pins stripped, `_` replaced with
`-`) before comparison, but the caller-supplied package list was compared
as-is, unnormalized.

pip/PyPI treat `-`, `_` and `.` as equivalent separators in a distribution
name, and names are case-insensitive (PEP 503). So a request spelled with
a different separator or case than the protected entry (e.g. `ovos_core`,
`OVOS-Core`, `ovos.core` vs. the protected `ovos-core`) would not match
the protected list and would pass the guard unnormalized — making the
check weaker than intended.

## Fix

Normalize both the protected list and the requested package list with
`packaging.utils.canonicalize_name`, the standard PEP 503 normalization
that pip itself uses, instead of a hand-rolled `.replace("_", "-")`. This
also covers the `.` separator and case variants that the old code missed.

`packaging` was only present as a transitive dependency, so it's now
declared directly in `pyproject.toml`.

Checked the install path (`pip_install`) for the same pattern — it has no
protected-package check at all, so there was nothing to fix there.

## Test plan

- [x] Added a regression test parametrized over `ovos-core`, `ovos_core`,
      `OVOS-Core`, `ovos.core` asserting the uninstall guard rejects all of
      them.
- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest test/unittests` —
      all pass except one pre-existing, unrelated failure in
      `test_transformers.py` (confirmed present on `dev` before this
      change too).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package name matching during uninstallation to consistently protect essential packages, regardless of capitalization or separator formatting.
  * Prevented accidental removal of protected packages when names use hyphens, underscores, or periods.

* **Tests**
  * Added coverage for package name variations to verify protected-package safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->