### PR TITLE
fix: declare real end-markers for non-utterance e2e scenarios

### DIFF
--- a/test/end2end/test_activate.py
+++ b/test/end2end/test_activate.py
@@ -81,6 +81,11 @@ class TestDeactivate(TestCase):
             deactivation_points=[message.msg_type],
             final_session=final_session,
             activation_points=["intent.service.skills.activated"],
+            # this scenario is a plain bus event, NOT an utterance: no pipeline
+            # runs, so PIPELINE-1 §9.5 ``ovos.utterance.handled`` (the ovoscope
+            # default end-marker) is never emitted and must not be waited for.
+            # The skill's own activation ack is the terminal message here.
+            eof_msgs=[f"{self.skill_id}.activate"],
             # messages internal to ovos-core, i.e. would not be sent to clients such as hivemind
             keep_original_src=[
                 #"intent.service.skills.activate", # TODO
@@ -123,6 +128,8 @@ class TestDeactivate(TestCase):
             final_session=final_session,
             activation_points=[message.msg_type], # starts activated
             deactivation_points=["intent.service.skills.deactivated"],
+            # plain bus event, not an utterance — see test_activate above.
+            eof_msgs=[f"{self.skill_id}.deactivate"],
             # messages internal to ovos-core, i.e. would not be sent to clients such as hivemind
             keep_original_src=[
                 #"intent.service.skills.deactivate", # TODO

--- a/test/end2end/test_intent_alias_backcompat.py
+++ b/test/end2end/test_intent_alias_backcompat.py
@@ -153,6 +153,11 @@ class TestLegacyIntentIdBackCompat(TestCase):
                 # which is what a raw dual-bound handler dispatch preserves.
                 ignore_messages=["recognizer_loop:audio_output_start",
                                   "recognizer_loop:audio_output_end"],
+                # a raw dispatch is not an utterance: the orchestrator never
+                # ran, so it emits no PIPELINE-1 §9.5 ``ovos.utterance.handled``
+                # end-marker (ovoscope's default). The workshop done-signal is
+                # the terminal message of this scenario.
+                eof_msgs=["mycroft.skill.handler.complete"],
                 source_message=message,
                 final_session=session,
                 expected_messages=[


### PR DESCRIPTION
> 🤖 Auto-generated by Claude (via Claude Code) — NOT human-reviewed. Verify before acting.

The end-to-end scenario runner decides a capture is complete when it sees the scenario's end marker. Scenarios that don't end with an utterance were borrowing an unrelated message as their marker, which made them time out or pass for the wrong reason depending on timing.

This declares a real end marker for each non-utterance scenario. The three flaky dev tests it caused now pass reliably.
