### PR TITLE
feat: add skills.installer.upgrade config option to SkillsStore.pip_install

### DIFF
--- a/ovos_core/skill_installer.py
+++ b/ovos_core/skill_installer.py
@@ -118,6 +118,8 @@ class SkillsStore:
             pip_args += ["--break-system-packages"]
         if self.config.get("allow_alphas", False):
             pip_args += ["--pre"]
+        if self.config.get("upgrade", False):
+            pip_args += ["--upgrade"]
 
         with SkillsStore.PIP_LOCK:
             """


### PR DESCRIPTION
`pip_install()` had no way to request `--upgrade`, so calling install again on an already-installed skill/package is a silent no-op — pip reports the requirement as already satisfied and leaves the old version in place, even if the git repo or PyPI release has since moved on.

Confirmed directly, not assumed: installed a package at an old version, called `pip_install()` again unchanged (matching `handle_install_skill()`'s exact call pattern), version stayed the same. Added the `--upgrade` flag, gated behind a new `skills.installer.upgrade` config option — same pattern as the existing `allow_alphas`/`break_system_packages` flags, off by default so it doesn't change behavior for anyone not opting in. Reproduced the exact same scenario with it set and confirmed the version actually advances (0.0.2 → 0.0.3 in testing).

Found while packaging OVOS skill management as a Home Assistant OS Supervisor add-on that calls `handle_install_skill` over the messagebus: https://github.com/andlo/haos-ovos-addons — there was no way for a user to get a newer version of an already-installed skill short of manually uninstalling and reinstalling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Skill installations can now upgrade existing packages when the upgrade option is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->