### PR TITLE
Cache packaged stop vocabulary in the hot path

### DIFF
--- a/ovos_core/intent_services/stop_service.py
+++ b/ovos_core/intent_services/stop_service.py
@@ -1,3 +1,4 @@
+from functools import lru_cache
 from os.path import dirname, join
 from threading import Event
 from typing import Optional, Dict, List, Union
@@ -16,6 +17,22 @@ from ovos_utils.log import LOG
 from ovos_utils.parse import match_one
 
 
+class _CachedStopResources(LocaleResources):
+    """Cache packaged stop vocabulary expansion for the process lifetime.
+
+    StopService locale files are installed with ovos-core and cannot change
+    without replacing the running process. LocaleResources intentionally
+    provides uncached general-purpose reads, but using it directly in the
+    first pipeline stage repeats file IO and template expansion for every
+    utterance.
+    """
+
+    @lru_cache(maxsize=32)
+    def load_vocabulary(self, base_name: str, lang: str) -> List[str]:
+        """Load each stop vocabulary/language pair at most once."""
+        return super().load_vocabulary(base_name, lang)
+
+
 class StopService(ConfidenceMatcherPipeline):
     """Intent Service that handles stopping skills."""
 
@@ -24,7 +41,9 @@ class StopService(ConfidenceMatcherPipeline):
         config = config if config is not None else Configuration().get("skills", {}).get("stop") or {}
         bus = bus or FakeBus()
         ConfidenceMatcherPipeline.__init__(self, config=config, bus=bus)
-        self._locale = LocaleResources(skill_locale=join(dirname(__file__), "locale"))
+        self._locale = _CachedStopResources(
+            skill_locale=join(dirname(__file__), "locale")
+        )
         self.bus.on("stop:global", self.handle_global_stop)
         self.bus.on("stop:skill", self.handle_skill_stop)
 

--- a/ovos_core/intent_services/stop_service.py
+++ b/ovos_core/intent_services/stop_service.py
@@ -18,7 +18,7 @@ from ovos_utils.parse import match_one
 
 
 class _CachedStopResources(LocaleResources):
-    """Cache packaged stop vocabulary expansion for the process lifetime.
+    """Cache packaged stop vocabulary expansion for the service lifetime.
 
     StopService locale files are installed with ovos-core and cannot change
     without replacing the running process. LocaleResources intentionally
@@ -27,10 +27,21 @@ class _CachedStopResources(LocaleResources):
     utterance.
     """
 
-    @lru_cache(maxsize=32)
+    CACHE_SIZE = 32
+
+    def __init__(self, skill_locale: str) -> None:
+        super().__init__(skill_locale=skill_locale)
+        self._load_vocabulary = lru_cache(maxsize=self.CACHE_SIZE)(
+            super().load_vocabulary
+        )
+
     def load_vocabulary(self, base_name: str, lang: str) -> List[str]:
         """Load each stop vocabulary/language pair at most once."""
-        return super().load_vocabulary(base_name, lang)
+        return self._load_vocabulary(base_name, lang)
+
+    def clear_cache(self) -> None:
+        """Release cached resources when the owning service shuts down."""
+        self._load_vocabulary.cache_clear()
 
 
 class StopService(ConfidenceMatcherPipeline):
@@ -332,5 +343,6 @@ class StopService(ConfidenceMatcherPipeline):
 
     def shutdown(self) -> None:
         """Remove bus listeners registered by this service."""
+        self._locale.clear_cache()
         self.bus.remove("stop:global", self.handle_global_stop)
         self.bus.remove("stop:skill", self.handle_skill_stop)

--- a/test/unittests/test_stop_resource_cache.py
+++ b/test/unittests/test_stop_resource_cache.py
@@ -29,3 +29,19 @@ def test_distinct_vocabulary_names_do_not_share_entries(load_vocabulary):
         "cancel everything"
     ]
     assert load_vocabulary.call_count == 2
+
+
+@patch("ovos_core.intent_services.stop_service.LocaleResources.load_vocabulary")
+def test_cache_is_instance_scoped_and_clearable(load_vocabulary):
+    load_vocabulary.return_value = ["stop"]
+    first = _CachedStopResources(skill_locale="/unused")
+    second = _CachedStopResources(skill_locale="/unused")
+
+    first.load_vocabulary("stop", "en-US")
+    first.load_vocabulary("stop", "en-US")
+    second.load_vocabulary("stop", "en-US")
+    assert load_vocabulary.call_count == 2
+
+    first.clear_cache()
+    first.load_vocabulary("stop", "en-US")
+    assert load_vocabulary.call_count == 3

--- a/test/unittests/test_stop_resource_cache.py
+++ b/test/unittests/test_stop_resource_cache.py
@@ -1,0 +1,31 @@
+"""Tests for the process-local stop vocabulary cache."""
+
+from unittest.mock import patch
+
+from ovos_core.intent_services.stop_service import _CachedStopResources
+
+
+@patch("ovos_core.intent_services.stop_service.LocaleResources.load_vocabulary")
+def test_vocabulary_expansion_is_cached_per_language(load_vocabulary):
+    load_vocabulary.return_value = ["stop", "cancel"]
+    resources = _CachedStopResources(skill_locale="/unused")
+
+    first = resources.load_vocabulary("stop", "en-US")
+    second = resources.load_vocabulary("stop", "en-US")
+    french = resources.load_vocabulary("stop", "fr-FR")
+
+    assert first is second
+    assert french == ["stop", "cancel"]
+    assert load_vocabulary.call_count == 2
+
+
+@patch("ovos_core.intent_services.stop_service.LocaleResources.load_vocabulary")
+def test_distinct_vocabulary_names_do_not_share_entries(load_vocabulary):
+    load_vocabulary.side_effect = [["stop"], ["cancel everything"]]
+    resources = _CachedStopResources(skill_locale="/unused")
+
+    assert resources.load_vocabulary("stop", "en-US") == ["stop"]
+    assert resources.load_vocabulary("global_stop", "en-US") == [
+        "cancel everything"
+    ]
+    assert load_vocabulary.call_count == 2


### PR DESCRIPTION
## Maintainer-requested architecture update

Jarbas correctly requested that resource lifecycle and caching belong to `LocaleResources`, not to a Core-local subclass.

OpenVoiceOS/ovos-spec-tools#95 now implements that ownership model directly:

- installed skill/core resources are snapshotted and pre-expanded at construction;
- dialogs and prompts stay in memory;
- only `user_locale` remains live;
- no bounded LRU, arbitrary capacity, subclass, `getattr`, or compatibility fallback exists.

The exact-head benchmark on the Core stop path measured **720.327 µs → 112.769 µs per request** across `en-us` and `fr-fr`: **6.4× faster** and 607.558 µs CPU saved per request. Full details and multi-skill measurements are in OpenVoiceOS/ovos-spec-tools#95.

## Current state

This branch still contains the superseded `_CachedStopResources` implementation and **must not merge as-is**.

After #95 is merged and released, this PR should be reduced to:

1. rebase onto current `dev`;
2. remove `_CachedStopResources` and its duplicate cache tests;
3. retain the existing plain `LocaleResources(...)` construction;
4. bump the explicit `ovos-spec-tools` minimum to the released version;
5. rerun focused, full, and end-to-end validation.

No consumer API switch is otherwise required because `LocaleResources` now owns the behavior by default. No CI workflow was changed and no upstream PR was merged.
