### PR TITLE
fix: let language disambiguation use the shared distance threshold

### DIFF
--- a/ovos_core/intent_services/service.py
+++ b/ovos_core/intent_services/service.py
@@ -252,9 +252,11 @@ class IntentService:
         for k in lang_keys:
             if k in message.context:
                 v = standardize_lang(message.context[k])
-                # closest_lang already applies the "distance below 10" threshold
-                # and returns None when no candidate is close enough
-                best_lang = closest_lang(v, valid_langs, max_distance=10)
+                # closest_lang applies the language-distance threshold and
+                # returns None when no candidate is close enough. The bound is
+                # inclusive, so a member language still matches its
+                # macrolanguage (distance 10, eg. "arz" against "ar")
+                best_lang = closest_lang(v, valid_langs)
                 if best_lang is None:
                     LOG.warning(f"ignoring {k}, {v} is not in enabled languages: {valid_langs}")
                     continue

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "ovos-config>=2.1.4a5,<3.0.0",
     "ovos-workshop>=9.3.2a1,<10.0.0",
     "rapidfuzz>=3.6,<4.0",
-    "ovos-spec-tools[langcodes]>=1.5.1a2,<2.0.0",
+    "ovos-spec-tools[langcodes]>=1.6.1a1,<2.0.0",
 ]
 
 [project.urls]

--- a/test/unittests/test_intent_service_extended.py
+++ b/test/unittests/test_intent_service_extended.py
@@ -164,6 +164,44 @@ class TestDisambiguateLang(unittest.TestCase):
             result = IntentService.disambiguate_lang(msg)
         self.assertEqual(result, "en-US")
 
+    def test_macrolanguage_member_resolves_to_its_macrolanguage(self):
+        """A tag at the language-distance threshold resolves (arz -> ar)."""
+        for tag in ("arz", "wuu"):
+            macro = "ar" if tag == "arz" else "zh"
+            with self.subTest(tag=tag):
+                msg = Message("test", data={}, context={"stt_lang": tag})
+                with patch("ovos_core.intent_services.service.get_message_lang",
+                           return_value="en-US"), \
+                     patch("ovos_core.intent_services.service.get_valid_languages",
+                           return_value=["en-US", macro]):
+                    result = IntentService.disambiguate_lang(msg)
+                self.assertEqual(result, tag)
+
+    def test_regional_variant_resolves(self):
+        """Regional variants stay inside the threshold."""
+        for tag, supported in (("ar-SA", "ar"), ("en-AU", "en-GB"), ("pt-BR", "pt-PT")):
+            with self.subTest(tag=tag):
+                msg = Message("test", data={}, context={"stt_lang": tag})
+                with patch("ovos_core.intent_services.service.get_message_lang",
+                           return_value="en-US"), \
+                     patch("ovos_core.intent_services.service.get_valid_languages",
+                           return_value=["en-US", supported]):
+                    result = IntentService.disambiguate_lang(msg)
+                self.assertEqual(result, tag)
+
+    def test_unrelated_language_is_ignored(self):
+        """Distant languages stay outside the threshold and fall through."""
+        for tag, supported in (("zh", "en"), ("fr", "es"),
+                               ("de-CH", "fr-CH"), ("nl", "af")):
+            with self.subTest(tag=tag):
+                msg = Message("test", data={}, context={"stt_lang": tag})
+                with patch("ovos_core.intent_services.service.get_message_lang",
+                           return_value="en-US"), \
+                     patch("ovos_core.intent_services.service.get_valid_languages",
+                           return_value=[supported]):
+                    result = IntentService.disambiguate_lang(msg)
+                self.assertEqual(result, "en-US")
+
 
 # ---------------------------------------------------------------------------
 # get_pipeline_matcher


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 5 (claude-opus-5) via Claude Code — NOT human-reviewed. Verify before acting.

Language disambiguation passed its own hardcoded distance threshold instead of using the shared default from the language-matching helper. Two owners for one threshold means they drift; they already had. Now the helper's default is the only threshold, and the spec-tools floor pin moves to the release where that bound became inclusive. Regression tests pin the behavior at the boundary.
