### PR TITLE
fix: padatious is Apache-2.0, drop the lgpl framing and fann2

### DIFF
--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -11,6 +11,6 @@ jobs:
     uses: OpenVoiceOS/gh-automations/.github/workflows/build-tests.yml@dev
     secrets: inherit
     with:
-      system_deps: 'swig libssl-dev portaudio19-dev libpulse-dev libfann-dev'
-      install_extras: 'mycroft,plugins,skills-essential,lgpl,test'
+      system_deps: 'swig libssl-dev portaudio19-dev libpulse-dev'
+      install_extras: 'mycroft,plugins,skills-essential,padatious,test'
       test_path: 'test/unittests'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,8 +12,8 @@ jobs:
     uses: OpenVoiceOS/gh-automations/.github/workflows/coverage.yml@dev
     secrets: inherit
     with:
-      system_deps: 'python3-dev swig libssl-dev portaudio19-dev libpulse-dev libfann-dev'
-      install_extras: '.[mycroft,plugins,skills-essential,lgpl,test]'
+      system_deps: 'python3-dev swig libssl-dev portaudio19-dev libpulse-dev'
+      install_extras: '.[mycroft,plugins,skills-essential,padatious,test]'
       test_path: 'test/unittests'
       coverage_source: 'ovos_core'
       deploy_pages: true

--- a/.github/workflows/license_tests.yml
+++ b/.github/workflows/license_tests.yml
@@ -12,6 +12,6 @@ jobs:
   license_tests:
     uses: OpenVoiceOS/gh-automations/.github/workflows/license-check.yml@dev
     with:
-      install_extras: '[mycroft,lgpl,skills-essential]'
-      system_deps: 'swig libfann-dev portaudio19-dev libpulse-dev'
-      exclude_packages: '^(precise-runner|fann2|ovos-adapt-parser|ovos-padatious|tqdm|bs4|sonopy|caldav|recurring-ical-events|x-wr-timezone|zeroconf|mutagen|attrs|phoonnx).*'
+      install_extras: '[mycroft,padatious,skills-essential]'
+      system_deps: 'portaudio19-dev libpulse-dev'
+      exclude_packages: '^(precise-runner|ovos-adapt-parser|tqdm|bs4|sonopy|caldav|recurring-ical-events|x-wr-timezone|zeroconf|mutagen|attrs|phoonnx).*'

--- a/.github/workflows/opm_check.yml
+++ b/.github/workflows/opm_check.yml
@@ -11,7 +11,7 @@ jobs:
     uses: OpenVoiceOS/gh-automations/.github/workflows/opm-check.yml@dev
     secrets: inherit
     with:
-      system_deps: 'swig libssl-dev portaudio19-dev libpulse-dev libfann-dev'
-      install_extras: 'mycroft,plugins,skills-essential,lgpl,test'
+      system_deps: 'swig libssl-dev portaudio19-dev libpulse-dev'
+      install_extras: 'mycroft,plugins,skills-essential,padatious,test'
       python_version: '3.11'
       plugin_type: 'pipeline'

--- a/.github/workflows/ovoscope.yml
+++ b/.github/workflows/ovoscope.yml
@@ -14,7 +14,7 @@ jobs:
     with:
       runner: "ubuntu-latest"
       python_version: "3.11"
-      system_deps: "python3-dev swig libssl-dev portaudio19-dev libpulse-dev libfann-dev"
+      system_deps: "python3-dev swig libssl-dev portaudio19-dev libpulse-dev"
       install_extras: "test"
       test_path: "test/end2end/"
       require_adapt: true

--- a/FAQ.md
+++ b/FAQ.md
@@ -8,7 +8,7 @@
 ovos-core uses **ovoscope** for end-to-end skill testing. Tests live in `test/end2end/` and run via the `ovoscope.yml` GitHub Actions workflow.
 
 The workflow:
-- Installs ovos-core with `[mycroft,plugins,skills-essential,lgpl,test]` extras
+- Installs ovos-core with `[mycroft,plugins,skills-essential,padatious,test]` extras
 - Runs all tests in `test/end2end/` using pytest
 - Tests Adapt, Padatious, fallback, converse, and stop pipeline behaviours
 - Posts a `🔌 Skill Tests (ovoscope)` section to PR comments

--- a/MAINTENANCE_REPORT.md
+++ b/MAINTENANCE_REPORT.md
@@ -166,7 +166,7 @@ Qwen Code (Qwen 3.5)
 ### Actions Taken
 - **Created `.github/workflows/ovoscope.yml`**: New workflow for end-to-end skill testing using ovoscope framework with bus coverage tracking.
   - Uses `OpenVoiceOS/gh-automations/.github/workflows/ovoscope.yml@dev` reusable workflow
-  - Installs ovos-core with `[mycroft,plugins,skills-essential,lgpl,test]` extras
+  - Installs ovos-core with `[mycroft,plugins,skills-essential,padatious,test]` extras
   - Runs tests from `test/end2end/` directory
   - Enables bus coverage reporting (`bus_coverage: true`)
   - Posts `🔌 Skill Tests (ovoscope)` and `🚌 Bus Coverage` sections to PR comments

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,10 @@ mycroft = [
     "ovos-dinkum-listener[extras]>=0.8.2a2,<1.0.0",
 ]
 padatious = [
-    "ovos_padatious>=2.0.1a1,<3.0.0",
+    # 2.0.0a1 is the first release without fann2 — before it, padatious pulled
+    # in the libfann C extension and its LGPL obligation. Never relax this
+    # floor below 2.x or the build toolchain comes back with it.
+    "ovos_padatious>=2.0.1a2,<3.0.0",
 ]
 # Deprecated alias. Padatious was ported from libfann to pure numpy and is
 # Apache-2.0 with no reservations, so the name no longer describes anything.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,9 +57,14 @@ mycroft = [
     "ovos-messagebus>=0.2.1a1,<1.0.0",
     "ovos-dinkum-listener[extras]>=0.8.2a2,<1.0.0",
 ]
-lgpl = [
+padatious = [
     "ovos_padatious>=2.0.1a1,<3.0.0",
-    "fann2>=1.0.7,<1.1.0",
+]
+# Deprecated alias. Padatious was ported from libfann to pure numpy and is
+# Apache-2.0 with no reservations, so the name no longer describes anything.
+# Kept so existing installs of `ovos-core[lgpl]` keep resolving.
+lgpl = [
+    "ovos-core[padatious]",
 ]
 plugins = [
     "ovos-utterance-corrections-plugin>=0.1.3a5, <1.0.0",


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 5 (claude-opus-5) via Claude Code — NOT human-reviewed. Verify before acting.

Padatious was ported from libfann to pure numpy a while ago and is plain Apache-2.0 now, but our packaging still treated it as an LGPL dependency: an extra literally named `lgpl`, a `fann2` pin nothing uses, and a license-check exemption for a problem that no longer exists.

This renames the extra to `padatious` (keeping `lgpl` as an alias so existing installs don't break), drops the dead `fann2` pin, and removes the license exemption.
