### PR TITLE
feat: address pip requests to the skills service by data.service_name

### DIFF
--- a/ovos_core/skill_installer.py
+++ b/ovos_core/skill_installer.py
@@ -32,10 +32,17 @@ class SkillsStore:
     def __init__(self, bus, config=None):
         self.config = config or Configuration().get("skills", {}).get("installer", {})
         self.bus = bus
+        # service name used for targeted pip install/uninstall routing,
+        # matching ovos_utils.skill_installer.ServiceInstaller's convention
+        self.service_name = "ovos_core"
         self.bus.on("ovos.skills.install", self.handle_install_skill)
         self.bus.on("ovos.skills.uninstall", self.handle_uninstall_skill)
         self.bus.on("ovos.pip.install", self.handle_install_python)
         self.bus.on("ovos.pip.uninstall", self.handle_uninstall_python)
+        # targeted topics, so ovos-core can be addressed specifically
+        # (eg. skills / solvers / personas / utterance transformers)
+        self.bus.on(f"ovos.pip.install.{self.service_name}", self.handle_install_python)
+        self.bus.on(f"ovos.pip.uninstall.{self.service_name}", self.handle_uninstall_python)
 
     def shutdown(self) -> None:
         """Unregister all message bus event handlers."""
@@ -43,6 +50,8 @@ class SkillsStore:
         self.bus.remove("ovos.skills.uninstall", self.handle_uninstall_skill)
         self.bus.remove("ovos.pip.install", self.handle_install_python)
         self.bus.remove("ovos.pip.uninstall", self.handle_uninstall_python)
+        self.bus.remove(f"ovos.pip.install.{self.service_name}", self.handle_install_python)
+        self.bus.remove(f"ovos.pip.uninstall.{self.service_name}", self.handle_uninstall_python)
 
     def play_error_sound(self) -> None:
         """Emit a message to play the configured error sound."""

--- a/ovos_core/skill_installer.py
+++ b/ovos_core/skill_installer.py
@@ -29,6 +29,11 @@ class SkillsStore:
     PIP_LOCK = NamedLock("ovos_pip.lock")
     UV = shutil.which("uv")  # use 'uv pip' if available, speeds things up a lot and is the default in raspOVOS
 
+    #: OVOS-INSTALL-1 §2.3: the name a request addresses this service by,
+    #: in ``data.service_name``. The skills service owns skills, solvers,
+    #: personas, pipeline stages and utterance transformers.
+    SERVICE_NAME = "ovos_core"
+
     def __init__(self, bus, config=None):
         self.config = config or Configuration().get("skills", {}).get("installer", {})
         self.bus = bus
@@ -357,8 +362,29 @@ class SkillsStore:
             self.bus.emit(message.reply("ovos.skills.uninstall.failed",
                                         {"error": str(e)}))
 
+    def _addressed_to_us(self, message: Message) -> bool:
+        """Whether this service should act on a pip request.
+
+        OVOS-INSTALL-1 §2.2: ``data.service_name`` names the one service a
+        request is for. Absent, every installer acts. Naming another service,
+        this one installs nothing and answers nothing, because a decline from
+        every other installer would bury the real answer in a burst the
+        client cannot pick it out of.
+
+        The comparison is exact: a service name is an identifier, not a
+        pattern.
+        """
+        target = message.data.get("service_name")
+        if target is None or target == self.SERVICE_NAME:
+            return True
+        LOG.debug(f"{message.msg_type} is addressed to '{target}', "
+                  f"not '{self.SERVICE_NAME}'; ignoring")
+        return False
+
     def handle_install_python(self, message: Message) -> None:
         """Handle a request to install arbitrary Python packages via pip."""
+        if not self._addressed_to_us(message):
+            return
         if not self.config.get("allow_pip"):
             LOG.error(InstallError.DISABLED.value)
             self.play_error_sound()
@@ -383,6 +409,8 @@ class SkillsStore:
 
     def handle_uninstall_python(self, message: Message) -> None:
         """Handle a request to uninstall Python packages via pip."""
+        if not self._addressed_to_us(message):
+            return
         if not self.config.get("allow_pip"):
             LOG.error(InstallError.DISABLED.value)
             self.play_error_sound()

--- a/test/unittests/test_skill_installer.py
+++ b/test/unittests/test_skill_installer.py
@@ -350,5 +350,37 @@ def test_handle_uninstall_python_success(skills_store):
     assert skills_store.bus.message_data[-1] == {}
 
 
+def test_targeted_pip_topics_registered(skills_store):
+    """The targeted ovos.pip.install.ovos_core / .uninstall.ovos_core topics
+    must be registered alongside the broadcast topics."""
+    assert "ovos.pip.install.ovos_core" in skills_store.bus.event_handlers
+    assert "ovos.pip.uninstall.ovos_core" in skills_store.bus.event_handlers
+
+
+def test_shutdown_removes_targeted_pip_topics(skills_store):
+    """shutdown() must unregister the targeted topics too."""
+    skills_store.shutdown()
+    assert "ovos.pip.install.ovos_core" not in skills_store.bus.event_handlers
+    assert "ovos.pip.uninstall.ovos_core" not in skills_store.bus.event_handlers
+
+
+@pytest.mark.parametrize('skills_store', [{"allow_pip": True}], indirect=True)
+def test_handle_install_python_targeted_topic_replies_on_base_topic(skills_store):
+    """A message received on the targeted ovos.pip.install.ovos_core topic
+    still replies on the base ovos.pip.install.complete topic, since
+    message.reply() derives the reply type from the literal string passed
+    to it, not from the incoming message's msg_type. This is what the
+    web-ui plugin browser expects."""
+    skills_store.play_error_sound = Mock()
+    skills_store.pip_install = Mock(return_value=True)
+    packages = ["requests"]
+    skills_store.handle_install_python(
+        Message(msg_type="ovos.pip.install.ovos_core", data={"packages": packages}))
+    skills_store.play_error_sound.assert_not_called()
+    skills_store.pip_install.assert_called_once_with(packages)
+    assert skills_store.bus.message_types[-1] == "ovos.pip.install.complete"
+    assert skills_store.bus.message_data[-1] == {}
+
+
 if __name__ == "__main__":
     pytest.main()

--- a/test/unittests/test_skill_installer.py
+++ b/test/unittests/test_skill_installer.py
@@ -389,3 +389,68 @@ def test_handle_install_skill_pip_raises(skills_store):
 
 if __name__ == "__main__":
     pytest.main()
+
+
+# ---------------------------------------------------------------------------
+# OVOS-INSTALL-1 §2.2 — data.service_name addresses one installer
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize('skills_store', [{"allow_pip": True}], indirect=True)
+def test_a_pip_request_for_another_service_is_ignored_in_silence(skills_store):
+    """Naming another service, this one installs nothing and answers
+    nothing: a decline from every installer would bury the real answer."""
+    skills_store.pip_install = Mock(return_value=True)
+    skills_store.handle_install_python(Message(
+        "ovos.pip.install",
+        {"packages": ["some-plugin"], "service_name": "ovos_audio"}))
+    skills_store.pip_install.assert_not_called()
+    assert skills_store.bus.message_types == []
+
+
+@pytest.mark.parametrize('skills_store', [{"allow_pip": True}], indirect=True)
+def test_a_pip_request_naming_the_skills_service_is_acted_on(skills_store):
+    skills_store.pip_install = Mock(return_value=True)
+    skills_store.handle_install_python(Message(
+        "ovos.pip.install",
+        {"packages": ["some-plugin"], "service_name": "ovos_core"}))
+    skills_store.pip_install.assert_called_once()
+    assert skills_store.bus.message_types == ["ovos.pip.install.complete"]
+
+
+@pytest.mark.parametrize('skills_store', [{"allow_pip": True}], indirect=True)
+def test_a_pip_request_naming_nobody_still_reaches_this_service(skills_store):
+    """The guard that this change did not narrow the broadcast."""
+    skills_store.pip_install = Mock(return_value=True)
+    skills_store.handle_install_python(
+        Message("ovos.pip.install", {"packages": ["some-plugin"]}))
+    skills_store.pip_install.assert_called_once()
+    assert skills_store.bus.message_types == ["ovos.pip.install.complete"]
+
+
+@pytest.mark.parametrize('skills_store', [{"allow_pip": True}], indirect=True)
+@pytest.mark.parametrize('near_miss', ["OVOS_CORE", "ovos_core_extra", "ovos"])
+def test_the_service_name_comparison_is_exact(skills_store, near_miss):
+    skills_store.pip_install = Mock(return_value=True)
+    skills_store.handle_install_python(Message(
+        "ovos.pip.install",
+        {"packages": ["p"], "service_name": near_miss}))
+    skills_store.pip_install.assert_not_called()
+    assert skills_store.bus.message_types == []
+
+
+@pytest.mark.parametrize('skills_store', [{"allow_pip": True}], indirect=True)
+def test_pip_uninstall_is_addressed_the_same_way(skills_store):
+    skills_store.pip_uninstall = Mock(return_value=True)
+    skills_store.handle_uninstall_python(Message(
+        "ovos.pip.uninstall",
+        {"packages": ["some-plugin"], "service_name": "ovos_audio"}))
+    skills_store.pip_uninstall.assert_not_called()
+    assert skills_store.bus.message_types == []
+
+
+def test_no_suffixed_pip_topic_is_registered(skills_store):
+    """OVOS-MSG-1 §2.1.1 keeps the target out of the topic, so the skills
+    service never subscribes to a service-suffixed pip topic."""
+    suffixed = [e for e in skills_store.bus.event_handlers
+                if e.startswith("ovos.pip.") and e.count(".") > 2]
+    assert suffixed == []


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 5 (claude-opus-5) via Claude Code — NOT human-reviewed. Every claim below was executed, not remembered.

The skills service acts on a pip request addressed to it, and stays out of one addressed elsewhere. Addressing is `data.service_name`, per `OVOS-INSTALL-1` §2.2.

**Merge order**: OpenVoiceOS/architecture#250 (the clause) → OpenVoiceOS/ovos-utils#444 (`ServiceInstaller`) → this. Closes #888.

## Re-cut from the suffixed-topic form

This PR previously subscribed to `ovos.pip.install.ovos_core`. That form is retired before it shipped. OVOS-MSG-1 §2.1.1 keeps a Message's target out of a dotted topic:

> Nothing about a Message's target travels in a dotted topic: addressing beyond the topic is **payload** (`data`)

and admits only two enumerable runtime-shaped dotted patterns, neither of which is a trailing target. Miro ruled the canonical form is the payload field, with the suffixed topics catalogued as pre-spec where they already ship.

The skills service never shipped a suffixed topic, so there is nothing to keep for compatibility here and none is added.

## What changes

| Request | Before | After |
| --- | --- | --- |
| `ovos.pip.install`, no `service_name` | acts | acts |
| `ovos.pip.install`, `service_name: "ovos_core"` | acts, field ignored | acts |
| `ovos.pip.install`, `service_name: "ovos_audio"` | **acts anyway** | ignored, answers nothing |

The third row is the defect. A client that addresses a TTS plugin to the audio service today still gets it installed into the skills container, because every installer acts on everything it receives.

An unaddressed service answers **nothing**, not even a decline. A decline from every installer on the bus would bury the real answer in a burst the client cannot pick it out of. The comparison is exact: a service name is an identifier, not a pattern.

## Verification

| Run | Result |
| --- | --- |
| fail-before: `dev` source with the new tests | 5 failed, 41 passed |
| after | 46 passed |
| full `test/unittests` | 613 passed |

Two of the seven new tests pass before and after by design, and are guards rather than regressions: a request naming nobody still reaches this service, and no suffixed pip topic is ever registered.

## Not in scope

`ovos.skills.install` / `ovos.skills.uninstall` are untouched: `OVOS-INSTALL-1` covers the pip surface only.
