### PR TITLE
fix: normalize pipeline ids when matching session blacklists

### DIFF
--- a/docs/prerelease-quirks.md
+++ b/docs/prerelease-quirks.md
@@ -22,6 +22,18 @@ separable legacy bridge, `_LegacyStopBridge`
 compat shim, not a permanent feature: it is slated for removal at the next
 major version.
 
+## #854 (alpha of 2026-08-14)
+
+`session.blacklisted_pipelines` matched blacklist entries and `session.pipeline`
+matcher ids as literal strings, so a legacy short id (`adapt_high`) never
+matched the canonical suffixed matcher it maps to (`ovos-adapt-pipeline-plugin-high`),
+and a confidence-suffixed entry (either spelling) only denied that one tier,
+leaving the plugin's other tiers invokable. Per OVOS-PIPELINE-1 §3/§5.2 a
+blacklist entry names the plugin, not a matcher variant of it: denying it
+denies every confidence tier, whichever spelling — legacy or canonical,
+suffixed or bare — the entry uses. Both the blacklist and the matcher id are
+now normalized to a bare plugin id before comparison.
+
 ## #868 (alpha of 2026-08-14)
 
 `handle_add_context`/`handle_remove_context`/`handle_clear_context` did a

--- a/ovos_core/intent_services/service.py
+++ b/ovos_core/intent_services/service.py
@@ -342,10 +342,21 @@ class IntentService:
         # orchestrator-only: no `match` call is made and no bus event is
         # emitted for the skip, it is observable only as a non-invocation.
         # Unknown pipeline_ids in the blacklist are harmless no-ops.
-        blacklisted = set(session.blacklisted_pipelines or [])
-        requested = [p for p in session.pipeline if p not in blacklisted]
+        # a blacklist entry denies the plugin (the actor), never a single
+        # confidence tier of it, so entries are normalized to bare plugin ids
+        blacklisted = {
+            _PIPELINE_RE.sub('', _PIPELINE_MIGRATION_MAP.get(pipeline_id, pipeline_id))
+            for pipeline_id in session.blacklisted_pipelines or []
+        }
+
+        def is_blacklisted(matcher_id: str) -> bool:
+            normalized = _PIPELINE_MIGRATION_MAP.get(matcher_id, matcher_id)
+            plugin_id = _PIPELINE_RE.sub('', normalized)
+            return plugin_id in blacklisted
+
+        requested = [p for p in session.pipeline if not is_blacklisted(p)]
         if blacklisted:
-            skipped = [p for p in session.pipeline if p in blacklisted]
+            skipped = [p for p in session.pipeline if is_blacklisted(p)]
             if skipped:
                 LOG.debug(f"Session '{session.session_id}' blacklisted "
                           f"pipelines skipped: {skipped}")

--- a/ovos_core/intent_services/service.py
+++ b/ovos_core/intent_services/service.py
@@ -305,10 +305,19 @@ class IntentService:
         # orchestrator-only: no `match` call is made and no bus event is
         # emitted for the skip, it is observable only as a non-invocation.
         # Unknown pipeline_ids in the blacklist are harmless no-ops.
-        blacklisted = set(session.blacklisted_pipelines or [])
-        requested = [p for p in session.pipeline if p not in blacklisted]
+        blacklisted = {
+            _PIPELINE_MIGRATION_MAP.get(pipeline_id, pipeline_id)
+            for pipeline_id in session.blacklisted_pipelines or []
+        }
+
+        def is_blacklisted(matcher_id: str) -> bool:
+            normalized = _PIPELINE_MIGRATION_MAP.get(matcher_id, matcher_id)
+            plugin_id = _PIPELINE_RE.sub('', normalized)
+            return normalized in blacklisted or plugin_id in blacklisted
+
+        requested = [p for p in session.pipeline if not is_blacklisted(p)]
         if blacklisted:
-            skipped = [p for p in session.pipeline if p in blacklisted]
+            skipped = [p for p in session.pipeline if is_blacklisted(p)]
             if skipped:
                 LOG.debug(f"Session '{session.session_id}' blacklisted "
                           f"pipelines skipped: {skipped}")

--- a/test/unittests/test_intent_service_extended.py
+++ b/test/unittests/test_intent_service_extended.py
@@ -361,6 +361,70 @@ class TestGetPipelineSessionBlacklist(unittest.TestCase):
         result = svc.get_pipeline(session=sess)
         self.assertEqual([m[0] for m in result], ["adapt_high"])
 
+    def test_plugin_blacklist_skips_all_confidence_matchers_before_lookup(self):
+        """A base plugin policy ID blocks its suffixed matcher variants.
+
+        The deployment blacklist is expressed in installed plugin IDs while a
+        session pipeline contains confidence-suffixed matcher IDs.  Filtering
+        must happen before matcher lookup so an intentionally disabled plugin
+        is neither invoked nor reported as unknown.
+        """
+        svc = self._svc_with_adapt_fallback()
+        sess = Session("s")
+        sess.pipeline = [
+            "ovos-adapt-pipeline-plugin-high",
+            "fallback_high",
+        ]
+        sess.blacklisted_pipelines = ["ovos-adapt-pipeline-plugin"]
+
+        with patch.object(svc, "get_pipeline_matcher",
+                          wraps=svc.get_pipeline_matcher) as get_matcher:
+            result = svc.get_pipeline(session=sess)
+
+        self.assertEqual([matcher[0] for matcher in result], ["fallback_high"])
+        get_matcher.assert_called_once_with("fallback_high")
+
+    def test_suffixed_blacklist_entry_denies_all_tiers_of_the_plugin(self):
+        """A confidence-suffixed blacklist entry (legacy spelling) denies the
+        whole plugin, not just the matching tier (§3/§5.2: a blacklist entry
+        names a plugin, i.e. a single actor, that cannot be denied in one
+        tier and invoked in another)."""
+        svc = self._svc_with_adapt_fallback()
+        sess = Session("s")
+        sess.pipeline = [
+            "ovos-adapt-pipeline-plugin-high",
+            "ovos-adapt-pipeline-plugin-medium",
+            "ovos-adapt-pipeline-plugin-low",
+            "fallback_high",
+        ]
+        sess.blacklisted_pipelines = ["adapt_high"]  # legacy suffixed entry
+
+        with patch.object(svc, "get_pipeline_matcher",
+                          wraps=svc.get_pipeline_matcher) as get_matcher:
+            result = svc.get_pipeline(session=sess)
+
+        self.assertEqual([matcher[0] for matcher in result], ["fallback_high"])
+        get_matcher.assert_called_once_with("fallback_high")
+
+    def test_canonical_suffixed_blacklist_entry_denies_all_tiers_of_the_plugin(self):
+        """Same as above but with a canonical (non-legacy) suffixed id."""
+        svc = self._svc_with_adapt_fallback()
+        sess = Session("s")
+        sess.pipeline = [
+            "ovos-adapt-pipeline-plugin-high",
+            "ovos-adapt-pipeline-plugin-medium",
+            "ovos-adapt-pipeline-plugin-low",
+            "fallback_high",
+        ]
+        sess.blacklisted_pipelines = ["ovos-adapt-pipeline-plugin-medium"]
+
+        with patch.object(svc, "get_pipeline_matcher",
+                          wraps=svc.get_pipeline_matcher) as get_matcher:
+            result = svc.get_pipeline(session=sess)
+
+        self.assertEqual([matcher[0] for matcher in result], ["fallback_high"])
+        get_matcher.assert_called_once_with("fallback_high")
+
     def test_no_bus_emission_accompanies_skip(self):
         """The skip is orchestrator-only: no `match` call and no bus event
         is emitted for a blacklisted matcher (§5.2)."""

--- a/test/unittests/test_intent_service_extended.py
+++ b/test/unittests/test_intent_service_extended.py
@@ -359,6 +359,29 @@ class TestGetPipelineSessionBlacklist(unittest.TestCase):
         result = svc.get_pipeline(session=sess)
         self.assertEqual([m[0] for m in result], ["adapt_high"])
 
+    def test_plugin_blacklist_skips_all_confidence_matchers_before_lookup(self):
+        """A base plugin policy ID blocks its suffixed matcher variants.
+
+        The deployment blacklist is expressed in installed plugin IDs while a
+        session pipeline contains confidence-suffixed matcher IDs.  Filtering
+        must happen before matcher lookup so an intentionally disabled plugin
+        is neither invoked nor reported as unknown.
+        """
+        svc = self._svc_with_adapt_fallback()
+        sess = Session("s")
+        sess.pipeline = [
+            "ovos-adapt-pipeline-plugin-high",
+            "fallback_high",
+        ]
+        sess.blacklisted_pipelines = ["ovos-adapt-pipeline-plugin"]
+
+        with patch.object(svc, "get_pipeline_matcher",
+                          wraps=svc.get_pipeline_matcher) as get_matcher:
+            result = svc.get_pipeline(session=sess)
+
+        self.assertEqual([matcher[0] for matcher in result], ["fallback_high"])
+        get_matcher.assert_called_once_with("fallback_high")
+
     def test_no_bus_emission_accompanies_skip(self):
         """The skip is orchestrator-only: no `match` call and no bus event
         is emitted for a blacklisted matcher (§5.2)."""


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5, review and orchestration) with Claude Sonnet 5 (claude-sonnet-5, edits) via Claude Code — NOT human-reviewed. Verify before acting.

`get_pipeline()` compared `session.blacklisted_pipelines` entries against `session.pipeline` matcher ids as literal strings. A deployment blacklist is naturally expressed in installed plugin ids (`ovos-adapt-pipeline-plugin`), while a session pipeline carries confidence-suffixed matcher ids (`ovos-adapt-pipeline-plugin-high`), so a bare plugin id in the blacklist silently failed to block any of its suffixed matcher variants. In addition, a confidence-suffixed blacklist entry itself — legacy spelling (`adapt_high`) or canonical (`ovos-adapt-pipeline-plugin-high`) — only denied that one tier, leaving the plugin's other tiers invokable in the same session.

OVOS-PIPELINE-1 §3 and §5.2 are explicit that a `blacklisted_pipelines` entry names the plugin, a single actor, never a specific matcher configuration of it: a plugin cannot be denied in one confidence tier and invoked in another.

The fix normalizes both sides of the comparison to a bare plugin id before checking membership: each blacklist entry is passed through `_PIPELINE_MIGRATION_MAP` (legacy short id -> canonical id) and then has its confidence suffix stripped by `_PIPELINE_RE`, and the matcher id under test is normalized and stripped the same way. `is_blacklisted()` then only tests plugin-id membership, so a bare or suffixed, legacy or canonical, blacklist entry now denies every confidence tier of the plugin it names.

Two regression tests were added to `test/unittests/test_intent_service_extended.py`: one blacklists the legacy suffixed id `adapt_high` and one the canonical suffixed id `ovos-adapt-pipeline-plugin-medium`, in both cases against a session pipeline listing all three adapt tiers plus `fallback_high`; both assert only `fallback_high` survives and that `get_pipeline_matcher` is called exactly once, with `fallback_high`. Reverting only the source change (`git apply -R` against the source diff, keeping the tests) made both new tests fail with an `AssertionError` showing the adapt matchers still present in the result (e.g. `['ovos-adapt-pipeline-plugin-medium', 'ovos-adapt-pipeline-plugin-low', 'fallback_high'] != ['fallback_high']`); restoring the fix made them pass. The full `test/unittests/test_intent_service_extended.py` and `test/unittests/test_intent_service.py` suites were run after the fix: 88 passed (9 subtests), no regressions.

`docs/prerelease-quirks.md` gained an entry stating that a session blacklist entry now denies the whole plugin regardless of tier spelling, legacy or canonical.

