### PR TITLE
fix: registry-first session resolution for converse write paths

### DIFF
--- a/ovos_core/intent_services/converse_service.py
+++ b/ovos_core/intent_services/converse_service.py
@@ -27,6 +27,97 @@ CONVERSE_HANDLER_TIMEOUT = 5 * 60
 class ConverseService(PipelinePlugin):
     """Intent Service handling conversational skills."""
 
+    @staticmethod
+    def _registry_session_for_write(message: Optional[Message]) -> "Session":
+        """Resolve the session object to mutate for an INCIDENTAL converse
+        write path - one that does NOT echo the resulting session back onto
+        the wire (``message.context["session"] = session.serialize()``) and
+        is not part of a chain that already resolved the session once for
+        this lifecycle-entry call.
+
+        FOLD-ORDER CONTRACT (read this before adding a new call site):
+
+        ``SessionManager.get(message)`` is NEVER a pure read. It always
+        folds the incoming message's session snapshot onto the live
+        registry entry (``SessionManager._store`` -> ``Session.update_from``,
+        full serialize/deserialize replace, for every session id including
+        ``"default"``) and returns THAT live object. So every call is a
+        write of the message's declared state onto the registry, whether or
+        not the caller goes on to mutate anything itself.
+
+        That fold is *correct and required* at two kinds of site:
+          1. True lifecycle entry (e.g. ``match()``'s own top-level
+             ``SessionManager.get(message)`` call) - SESSION-2 last-writer-
+             wins: the client's freshly-declared fields (lang, blacklist,
+             client-side (de)activations) must apply here.
+          2. Any site that stamps the resolved session back onto the wire
+             via ``message.context["session"] = session.serialize()``
+             (``activate_skill`` / ``deactivate_skill`` below) - bypassing
+             the fold there would silently discard the client's own
+             declarations from the outgoing message, e.g. resurrecting a
+             skill the client had just blacklisted. These sites MUST use
+             plain ``SessionManager.get(message)``, not this helper.
+
+        The fold is *wrong* (and this helper exists to avoid it) only for
+        an INCIDENTAL write with no wire echo, where a STALE message (one
+        that predates state written to the registry earlier in the same
+        session's lifecycle, e.g. by a prior ``get_response.enable`` call)
+        would otherwise wipe that state via the full-replace fold before
+        this handler's own write lands. ``get_response.enable/disable``
+        below are the load-bearing example: they only ``SessionManager.sync``
+        for the default session, so a named session's write was being
+        wiped on every subsequent fold with no recovery.
+
+        RESIDUAL (not fixed by this helper, tracked as a known gap): a
+        case-2 wire-echo site (``activate_skill`` / ``deactivate_skill``)
+        still full-replaces the registry entry when it folds. So a
+        case-3 write this helper protects (e.g. ``get_response.enable``)
+        only survives until the NEXT stale ``activate_skill`` /
+        ``deactivate_skill`` call for that same session - executed proof:
+        enable get_response for a named session, then drive a stale
+        ``activate_skill`` call for the same session id, and
+        ``utterance_states`` is wiped back to empty. This is pre-existing
+        on ``dev`` (``activate_skill``/``deactivate_skill`` already used
+        plain ``SessionManager.get(message)`` before this PR) and is
+        unchanged by this PR - this helper narrows the window, it does not
+        close it. Fixing it for real needs case-2 sites to fold
+        per-field (client wins only on fields it actually declares) rather
+        than full-replace; out of scope here.
+
+        A THIRD case - repeated folding within a single synchronous call
+        chain sharing one message (``match()`` -> ``_collect_converse_skills``
+        / ``get_active_skills``) - is neither of the above: fold once at
+        the top (case 1) and THREAD that resolved ``session`` object
+        through the rest of the chain via an explicit parameter; do not
+        call ``SessionManager.get(message)``/this helper again per
+        sub-step, each additional call re-folds the same stale message and
+        undoes whatever the previous step in the chain just wrote. Note
+        ``_check_converse_timeout`` does NOT need this treatment: verified
+        by mutation testing, it sits between two folds of the identical
+        message with no intervening write, so re-folding there is
+        idempotent - see its own docstring.
+
+        This mirrors ``IntentService._registry_session_for_context_write``
+        (#857, ``ovos_core/intent_services/service.py``) exactly for case-3
+        incidental writes, but is a deliberately separate copy: the
+        intent-context handlers and these converse write paths are
+        different call sites landing in different PRs. Do not delete this
+        helper assuming #857 covers it - when both PRs are merged, consider
+        consolidating the two into one shared helper, but until then each
+        pairs with its own call sites.
+
+        Resolution: resolve session_id off the message and, if the registry
+        already holds a live entry for it, mutate that object directly - no
+        fold. Fall back to ``SessionManager.get(message)`` (today's
+        behavior) only when no registry entry exists yet, e.g.
+        out-of-registry/test callers or a message with no session context.
+        """
+        session_data = message.context.get("session") if message and message.context else None
+        session_id = session_data.get("session_id") if isinstance(session_data, dict) else None
+        if session_id and session_id in SessionManager.sessions:
+            return SessionManager.sessions[session_id]
+        return SessionManager.get(message)
+
     def __init__(self, bus: Optional[Union[MessageBusClient, FakeBus]] = None,
                  config: Optional[Dict] = None) -> None:
         config = config or Configuration().get("skills", {}).get("converse", {})
@@ -105,28 +196,49 @@ class ConverseService(PipelinePlugin):
             session.activate_skill(skill_id)
 
     @staticmethod
-    def get_active_skills(message: Optional[Message] = None) -> List[str]:
+    def get_active_skills(message: Optional[Message] = None,
+                          session: Optional[Session] = None) -> List[str]:
         """Active skill ids ordered by converse priority
         this represents the order in which converse will be called
+
+        Args:
+            message: bus message to resolve a session from when ``session``
+                     is not already known (standalone/incidental callers).
+            session: an already-resolved session to read from directly -
+                     pass this when called as part of a chain that already
+                     folded once for this lifecycle entry (see
+                     ``_registry_session_for_write``'s fold-order contract);
+                     re-resolving via ``message`` here would re-fold and can
+                     undo a write an earlier step in the same chain made.
 
         Returns:
             active_skills (list): ordered list of skill_ids
         """
-        session = SessionManager.get(message)
+        session = session or SessionManager.get(message)
         return [skill[0] for skill in session.active_skills]
 
     def deactivate_skill(self, skill_id: str, source_skill: Optional[str] = None,
-                         message: Optional[Message] = None) -> None:
+                         message: Optional[Message] = None) -> Optional[Session]:
         """Remove a skill from being targetable by converse.
 
         Args:
             skill_id (str): skill to remove
             source_skill (str): skill requesting the removal
             message (Message): the bus message that requested deactivation
+
+        Returns:
+            the resolved Session if a deactivation actually happened
+            (callers can reuse it instead of re-resolving via
+            ``SessionManager.get(message)``), else None (blocked or
+            already-inactive no-op - nothing changed, nothing to reuse).
         """
         source_skill = source_skill or skill_id
         if self._deactivate_allowed(skill_id, source_skill):
             message = message or Message("")
+            # this session gets stamped back onto the outgoing wire message
+            # below, so the fold must apply here (see the fold-order
+            # contract on _registry_session_for_write): the client's own
+            # declarations must win, not be silently bypassed.
             session = SessionManager.get(message)
             if session.is_active(skill_id):
                 # update converse session
@@ -140,6 +252,8 @@ class ConverseService(PipelinePlugin):
                                     data={"skill_id": skill_id}))
                 if skill_id in self._consecutive_activations:
                     self._consecutive_activations[skill_id] = 0
+                return session
+        return None
 
     def activate_skill(self, skill_id: str, source_skill: Optional[str] = None,
                        message: Optional[Message] = None) -> Optional[Session]:
@@ -156,7 +270,10 @@ class ConverseService(PipelinePlugin):
         source_skill = source_skill or skill_id
         if self._activate_allowed(skill_id, source_skill):
             message = message or Message("")
-            # update converse session
+            # this session gets stamped back onto the outgoing wire message
+            # below, so the fold must apply here (see the fold-order
+            # contract on _registry_session_for_write): the client's own
+            # declarations must win, not be silently bypassed.
             session = SessionManager.get(message)
             session.activate_skill(skill_id)
 
@@ -270,16 +387,28 @@ class ConverseService(PipelinePlugin):
             return False
         return True
 
-    def _collect_converse_skills(self, message: Message) -> List[str]:
+    def _collect_converse_skills(self, message: Message,
+                                 session: Optional[Session] = None) -> List[str]:
         """use the messagebus api to determine which skills want to converse
 
-        Individual skills respond to this request via the `can_converse` method"""
+        Individual skills respond to this request via the `can_converse` method
+
+        Args:
+            message: the bus message driving this converse attempt.
+            session: an already-resolved session to use instead of
+                     re-folding ``message`` (see ``match()``, which folds
+                     once and threads the result through this whole call
+                     chain - see the fold-order contract on
+                     ``_registry_session_for_write``). Falls back to a
+                     fresh ``SessionManager.get(message)`` fold for
+                     standalone callers.
+        """
         skill_ids = []
         want_converse = []
-        session = SessionManager.get(message)
+        session = session or SessionManager.get(message)
 
         # note: this is sorted by priority already
-        active_skills = [skill_id for skill_id in self.get_active_skills(message)
+        active_skills = [skill_id for skill_id in self.get_active_skills(message, session=session)
                      if session.utterance_states.get(skill_id, UtteranceState.INTENT) == UtteranceState.INTENT]
         if not active_skills:
             return want_converse
@@ -335,7 +464,22 @@ class ConverseService(PipelinePlugin):
         return want_converse
 
     def _check_converse_timeout(self, message: Message):
-        """ filter active skill list based on timestamps """
+        """ filter active skill list based on timestamps
+
+        Note: unlike ``_collect_converse_skills``/``get_active_skills``,
+        this method does NOT accept a threaded ``session`` param. Verified
+        by mutation testing (reverting both the param and a
+        registry-first-helper fallback here left the full converse test
+        suite green): ``match()``'s own top-level ``SessionManager.get(message)``
+        fold and a fresh fold here resolve to the identity-same live
+        registry object with no intervening write between the two calls in
+        this synchronous frame, so re-folding here is idempotent - unlike
+        the fold immediately after this call inside ``_collect_converse_skills``,
+        which WOULD wipe the active_skills filter this method just wrote if
+        it re-folded instead of using the threaded object. Keep this site
+        plain (YAGNI); do not add the param back without a red test proving
+        it does something.
+        """
         timeouts = self.config.get("skill_timeouts") or {}
         def_timeout = self.config.get("timeout", 300)
         session = SessionManager.get(message)
@@ -369,13 +513,20 @@ class ConverseService(PipelinePlugin):
             - Attempts conversation with each eligible skill
         """
         lang = standardize_lang(lang)
+        # this is the lifecycle-entry fold for this pipeline's turn at the
+        # utterance (SESSION-2 last-writer-wins is correct here) - `session`
+        # is threaded through every sub-call in this method instead of each
+        # one re-resolving via `message`, which would re-fold the same
+        # message repeatedly and undo whatever the previous sub-call just
+        # wrote (see the fold-order contract on
+        # `_registry_session_for_write`).
         session = SessionManager.get(message)
 
         # we call flatten in case someone is sending the old style list of tuples
         utterances = flatten_list(utterances)
 
         # note: this is sorted by priority already
-        gr_skills = [skill_id for skill_id in self.get_active_skills(message)
+        gr_skills = [skill_id for skill_id in self.get_active_skills(message, session=session)
                      if session.utterance_states.get(skill_id, UtteranceState.INTENT) == UtteranceState.RESPONSE]
 
         # check if any skill wants to capture utterance for self.get_response method
@@ -396,7 +547,7 @@ class ConverseService(PipelinePlugin):
         self._check_converse_timeout(message)
 
         # check if any skill wants to converse
-        for skill_id in self._collect_converse_skills(message):
+        for skill_id in self._collect_converse_skills(message, session=session):
             if skill_id in (session.blacklisted_skills or []):
                 LOG.debug(f"ignoring match, skill_id '{skill_id}' blacklisted by Session '{session.session_id}'")
                 continue
@@ -415,7 +566,7 @@ class ConverseService(PipelinePlugin):
     @staticmethod
     def handle_get_response_enable(message: Message):
         skill_id = message.data["skill_id"]
-        session = SessionManager.get(message)
+        session = ConverseService._registry_session_for_write(message)
         session.enable_response_mode(skill_id)
         if session.session_id == "default":
             SessionManager.sync(message)
@@ -423,7 +574,7 @@ class ConverseService(PipelinePlugin):
     @staticmethod
     def handle_get_response_disable(message: Message):
         skill_id = message.data["skill_id"]
-        session = SessionManager.get(message)
+        session = ConverseService._registry_session_for_write(message)
         session.disable_response_mode(skill_id)
         if session.session_id == "default":
             SessionManager.sync(message)
@@ -435,9 +586,12 @@ class ConverseService(PipelinePlugin):
         # this doesnt happen accidentally at very least
         skill_id = message.data['skill_id']
         source_skill = message.context.get("skill_id")
-        self.activate_skill(skill_id, source_skill, message)
-        sess = SessionManager.get(message)
-        if sess.session_id == "default":
+        # reuse the already-resolved live session `activate_skill` folded
+        # and wrote to - a second `SessionManager.get(message)` here would
+        # re-fold the SAME stale message and, on the reject/no-op path
+        # (`activate_skill` returns None), there is nothing to sync at all.
+        sess = self.activate_skill(skill_id, source_skill, message)
+        if sess is not None and sess.session_id == "default":
             SessionManager.sync(message)
 
     def handle_deactivate_skill_request(self, message: Message):
@@ -447,9 +601,12 @@ class ConverseService(PipelinePlugin):
         # this doesnt happen accidentally
         skill_id = message.data['skill_id']
         source_skill = message.context.get("skill_id") or skill_id
-        self.deactivate_skill(skill_id, source_skill, message)
-        sess = SessionManager.get(message)
-        if sess.session_id == "default":
+        # reuse the already-resolved live session `deactivate_skill` folded
+        # and wrote to - a second `SessionManager.get(message)` here would
+        # re-fold the SAME stale message and, on the reject/no-op path
+        # (`deactivate_skill` returns None), there is nothing to sync at all.
+        sess = self.deactivate_skill(skill_id, source_skill, message)
+        if sess is not None and sess.session_id == "default":
             SessionManager.sync(message)
 
     def handle_get_active_skills(self, message: Message):

--- a/test/unittests/test_converse_service.py
+++ b/test/unittests/test_converse_service.py
@@ -612,54 +612,214 @@ class TestMatch(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
+# match() fold-chain threading (adversarial review finding F2)
+# ---------------------------------------------------------------------------
+
+class TestMatchFoldChainSurvival(unittest.TestCase):
+    """`match()` folds `message` ONCE (legitimate lifecycle entry) and must
+    thread that resolved session through `_check_converse_timeout` and
+    `_collect_converse_skills` rather than letting either re-resolve via
+    `SessionManager.get(message)` - a second fold of the SAME (now stale
+    relative to the timeout filter) message would undo the timeout filter's
+    write. These tests exercise the REAL registry end to end (no mocking of
+    SessionManager.get / _check_converse_timeout / _collect_converse_skills)
+    so they catch a regression to per-step re-folding."""
+
+    def setUp(self):
+        self._saved_sessions = dict(SessionManager.sessions)
+        SessionManager.sessions.clear()
+
+    def tearDown(self):
+        SessionManager.sessions.clear()
+        SessionManager.sessions.update(self._saved_sessions)
+
+    def test_timeout_filtered_skill_stays_filtered_through_collect_converse(self):
+        """A skill removed by the timeout filter must not reappear because
+        `_collect_converse_skills` re-folded the same stale message and
+        restored the client's originally-declared (pre-filter) active_skills
+        list."""
+        bus = FakeBus()
+        svc = _make_service()
+        now = time.time()
+        sess = Session("named-match-1")
+        # client declares both skills as active; skill_old is long expired
+        sess.active_skills = [("skill_old", now - 400), ("skill_new", now - 1)]
+        SessionManager.sessions[sess.session_id] = sess
+
+        msg = Message("recognizer_loop:utterance",
+                      data={"utterances": ["hello"]},
+                      context={"session": sess.serialize()})
+
+        # no skill is listening on skill.converse.pong, so _collect_converse_skills
+        # will time out its 0.5s wait with an empty want_converse - match()
+        # returns None, which is fine, we only care about the registry's
+        # active_skills state afterward.
+        svc.match(["hello"], "en-US", msg)
+
+        live = SessionManager.sessions[sess.session_id]
+        remaining = [s[0] for s in live.active_skills]
+        self.assertNotIn("skill_old", remaining)
+        self.assertIn("skill_new", remaining)
+
+
+# ---------------------------------------------------------------------------
+# handle_activate_skill_request / handle_deactivate_skill_request
+# reject / no-op paths (adversarial review finding F3)
+# ---------------------------------------------------------------------------
+
+class TestActivateDeactivateSkillRequestHandlers(unittest.TestCase):
+    """`handle_activate_skill_request`/`handle_deactivate_skill_request`
+    used to always call a trailing `SessionManager.get(message)` to decide
+    whether to sync, including on the reject (blocked activation) / no-op
+    (deactivating an already-inactive skill) paths - an unconditional fold
+    of a possibly-stale message with nothing to sync. They now reuse the
+    session `activate_skill`/`deactivate_skill` returns (None on those
+    paths) and skip the fold+sync entirely when nothing changed."""
+
+    def setUp(self):
+        self._saved_sessions = dict(SessionManager.sessions)
+        SessionManager.sessions.clear()
+
+    def tearDown(self):
+        SessionManager.sessions.clear()
+        SessionManager.sessions.update(self._saved_sessions)
+
+    def test_activate_skill_request_reject_path_does_not_sync(self):
+        """A blocked activation (cross-activation disallowed) must not call
+        SessionManager.sync."""
+        bus = FakeBus()
+        svc = _make_service()
+        svc.config = {"cross_activation": False}
+        sess = Session("default")
+        SessionManager.sessions[sess.session_id] = sess
+        msg = Message("intent.service.skills.activate",
+                      data={"skill_id": "skill_a"},
+                      context={"session": sess.serialize(), "skill_id": "skill_b"})
+
+        with patch("ovos_core.intent_services.converse_service.SessionManager.sync") as mock_sync:
+            svc.handle_activate_skill_request(msg)
+
+        mock_sync.assert_not_called()
+        live = SessionManager.sessions[sess.session_id]
+        self.assertFalse(live.is_active("skill_a"))
+
+    def test_deactivate_skill_request_noop_path_does_not_sync(self):
+        """Deactivating a skill that isn't active is a no-op and must not
+        call SessionManager.sync."""
+        bus = FakeBus()
+        svc = _make_service()
+        sess = Session("default")
+        SessionManager.sessions[sess.session_id] = sess
+        msg = Message("intent.service.skills.deactivate",
+                      data={"skill_id": "skill_a"},
+                      context={"session": sess.serialize()})
+
+        with patch("ovos_core.intent_services.converse_service.SessionManager.sync") as mock_sync:
+            svc.handle_deactivate_skill_request(msg)
+
+        mock_sync.assert_not_called()
+
+    def test_activate_skill_request_success_path_syncs_default(self):
+        """A successful activation for the default session still syncs."""
+        bus = FakeBus()
+        svc = _make_service()
+        sess = Session("default")
+        SessionManager.sessions[sess.session_id] = sess
+        msg = Message("intent.service.skills.activate",
+                      data={"skill_id": "skill_a"},
+                      context={"session": sess.serialize(), "skill_id": "skill_a"})
+
+        with patch("ovos_core.intent_services.converse_service.SessionManager.sync") as mock_sync:
+            svc.handle_activate_skill_request(msg)
+
+        mock_sync.assert_called_once()
+        live = SessionManager.sessions[sess.session_id]
+        self.assertTrue(live.is_active("skill_a"))
+
+    def test_deactivate_skill_request_success_path_syncs_default(self):
+        """A successful deactivation for the default session still syncs."""
+        bus = FakeBus()
+        svc = _make_service()
+        sess = Session("default")
+        sess.activate_skill("skill_a")
+        SessionManager.sessions[sess.session_id] = sess
+        msg = Message("intent.service.skills.deactivate",
+                      data={"skill_id": "skill_a"},
+                      context={"session": sess.serialize()})
+
+        with patch("ovos_core.intent_services.converse_service.SessionManager.sync") as mock_sync:
+            svc.handle_deactivate_skill_request(msg)
+
+        mock_sync.assert_called_once()
+        live = SessionManager.sessions[sess.session_id]
+        self.assertFalse(live.is_active("skill_a"))
+
+
+# ---------------------------------------------------------------------------
 # handle_get_response_enable / handle_get_response_disable
 # ---------------------------------------------------------------------------
 
 class TestGetResponseHandlers(unittest.TestCase):
-    """Tests for the get_response enable/disable bus handlers."""
+    """Tests for the get_response enable/disable bus handlers.
+
+    These tests exercise the REAL SessionManager.sessions registry (no
+    mocking of SessionManager.get), mirroring
+    test_intent_service_extended.py's registry-first test shape for #857.
+    setUp/tearDown save+clear the real registry so a session id reused
+    across tests in this module (e.g. "s") can never leak state between
+    them and can never accidentally satisfy the registry-first lookup
+    with a stale entry left by an earlier test.
+    """
+
+    def setUp(self):
+        self._saved_sessions = dict(SessionManager.sessions)
+        SessionManager.sessions.clear()
+
+    def tearDown(self):
+        SessionManager.sessions.clear()
+        SessionManager.sessions.update(self._saved_sessions)
 
     def test_handle_get_response_enable_sets_response_state(self):
         """enable handler puts the skill into RESPONSE utterance state."""
         sess = Session("s")
         sess.activate_skill("skill_a")
+        SessionManager.sessions[sess.session_id] = sess
         msg = Message("skill.converse.get_response.enable",
                       data={"skill_id": "skill_a"},
                       context={"session": sess.serialize()})
 
-        with patch("ovos_core.intent_services.converse_service.SessionManager.get",
-                   return_value=sess), \
-             patch("ovos_core.intent_services.converse_service.SessionManager.sync"):
+        with patch("ovos_core.intent_services.converse_service.SessionManager.sync"):
             ConverseService.handle_get_response_enable(msg)
 
-        self.assertEqual(sess.utterance_states.get("skill_a"), UtteranceState.RESPONSE)
+        live = SessionManager.sessions[sess.session_id]
+        self.assertEqual(live.utterance_states.get("skill_a"), UtteranceState.RESPONSE)
 
     def test_handle_get_response_disable_restores_intent_state(self):
         """disable handler removes the skill from RESPONSE state."""
         sess = Session("s")
         sess.activate_skill("skill_a")
         sess.enable_response_mode("skill_a")
+        SessionManager.sessions[sess.session_id] = sess
         msg = Message("skill.converse.get_response.disable",
                       data={"skill_id": "skill_a"},
                       context={"session": sess.serialize()})
 
-        with patch("ovos_core.intent_services.converse_service.SessionManager.get",
-                   return_value=sess), \
-             patch("ovos_core.intent_services.converse_service.SessionManager.sync"):
+        with patch("ovos_core.intent_services.converse_service.SessionManager.sync"):
             ConverseService.handle_get_response_disable(msg)
 
-        self.assertNotEqual(sess.utterance_states.get("skill_a"), UtteranceState.RESPONSE)
+        live = SessionManager.sessions[sess.session_id]
+        self.assertNotEqual(live.utterance_states.get("skill_a"), UtteranceState.RESPONSE)
 
     def test_handle_get_response_enable_syncs_default_session(self):
         """enable handler calls SessionManager.sync for the default session."""
         sess = Session("default")
         sess.activate_skill("skill_a")
+        SessionManager.sessions[sess.session_id] = sess
         msg = Message("skill.converse.get_response.enable",
                       data={"skill_id": "skill_a"},
                       context={"session": sess.serialize()})
 
-        with patch("ovos_core.intent_services.converse_service.SessionManager.get",
-                   return_value=sess), \
-             patch("ovos_core.intent_services.converse_service.SessionManager.sync") as mock_sync:
+        with patch("ovos_core.intent_services.converse_service.SessionManager.sync") as mock_sync:
             ConverseService.handle_get_response_enable(msg)
 
         mock_sync.assert_called_once()
@@ -669,16 +829,146 @@ class TestGetResponseHandlers(unittest.TestCase):
         sess = Session("default")
         sess.activate_skill("skill_a")
         sess.enable_response_mode("skill_a")
+        SessionManager.sessions[sess.session_id] = sess
         msg = Message("skill.converse.get_response.disable",
                       data={"skill_id": "skill_a"},
                       context={"session": sess.serialize()})
 
-        with patch("ovos_core.intent_services.converse_service.SessionManager.get",
-                   return_value=sess), \
-             patch("ovos_core.intent_services.converse_service.SessionManager.sync") as mock_sync:
+        with patch("ovos_core.intent_services.converse_service.SessionManager.sync") as mock_sync:
             ConverseService.handle_get_response_disable(msg)
 
         mock_sync.assert_called_once()
+
+    def test_get_response_enable_survives_stale_named_session_snapshot(self):
+        """Wave-3 regression (converse write-path counterpart to #857):
+        a NAMED session's get_response state written by
+        handle_get_response_enable must land on the LIVE registry entry,
+        not a copy folded from a stale client message snapshot. Before the
+        registry-first fix, `SessionManager.get(message)` folds the
+        message's stale snapshot onto the registry entry first
+        (full-replace for named sessions via `update_from`), then the
+        handler's `enable_response_mode` write lands on that folded copy -
+        the write is visible on the return value but is never actually
+        durable proof of a *registry* write when `.get` is mocked, which is
+        exactly how the pre-fix bug hid in the two tests above. Here we
+        register a live entry, drive the handler with an intentionally
+        STALE message snapshot (unaware of the live entry's other state),
+        and assert the live registry entry itself picked up the write."""
+        sess = Session("named-converse-1")
+        sess.activate_skill("skill_a")
+        sess.activate_skill("skill_b")  # pre-existing state the stale snapshot doesn't know about
+        SessionManager.sessions[sess.session_id] = sess
+
+        stale = Session(sess.session_id)  # unaware of skill_b's activation
+        msg = Message("skill.converse.get_response.enable",
+                      data={"skill_id": "skill_a"},
+                      context={"session": stale.serialize()})
+
+        with patch("ovos_core.intent_services.converse_service.SessionManager.sync"):
+            ConverseService.handle_get_response_enable(msg)
+
+        live = SessionManager.sessions[sess.session_id]
+        self.assertEqual(live.utterance_states.get("skill_a"), UtteranceState.RESPONSE)
+        # the registry entry's pre-existing state must not have been wiped
+        # by the stale snapshot fold
+        self.assertTrue(live.is_active("skill_b"))
+
+    def test_get_response_disable_survives_stale_named_session_snapshot(self):
+        """Same regression as
+        `test_get_response_enable_survives_stale_named_session_snapshot`,
+        for `handle_get_response_disable` (adversarial review finding F4:
+        this site's registry-first fix had no test that actually drove a
+        stale snapshot, so it could regress silently - the previous test
+        registered a session and serialized THAT SAME session for the
+        message context, which the fold cannot distinguish from a correct
+        write since there was nothing else on the registry entry for the
+        fold to wipe)."""
+        sess = Session("named-converse-4")
+        sess.activate_skill("skill_a")
+        sess.enable_response_mode("skill_a")
+        sess.activate_skill("skill_b")  # pre-existing state the stale snapshot doesn't know about
+        SessionManager.sessions[sess.session_id] = sess
+
+        stale = Session(sess.session_id)  # unaware of skill_b's activation
+        msg = Message("skill.converse.get_response.disable",
+                      data={"skill_id": "skill_a"},
+                      context={"session": stale.serialize()})
+
+        with patch("ovos_core.intent_services.converse_service.SessionManager.sync"):
+            ConverseService.handle_get_response_disable(msg)
+
+        live = SessionManager.sessions[sess.session_id]
+        self.assertNotEqual(live.utterance_states.get("skill_a"), UtteranceState.RESPONSE)
+        # the registry entry's pre-existing state must not have been wiped
+        # by the stale snapshot fold
+        self.assertTrue(live.is_active("skill_b"))
+
+    def test_activate_skill_folds_client_blacklist_and_applies_write(self):
+        """Fold-order contract regression (adversarial review finding F1):
+        `activate_skill`/`deactivate_skill` stamp the resolved session back
+        onto the outgoing wire message (`message.context["session"] =
+        session.serialize()`), so - unlike the incidental get_response
+        handlers - they must NOT bypass the fold. The client's own
+        declarations (here, a freshly-declared blacklist entry the registry
+        doesn't know about yet) must win per SESSION-2 last-writer-wins,
+        and the activation write must still land on top of that fold.
+
+        Before this was corrected (an earlier revision of this branch
+        wrongly applied the registry-first bypass here), the client's
+        blacklist declaration would be silently discarded and stamped out
+        of the outgoing message - a client-blacklisted skill could read as
+        not-blacklisted downstream."""
+        bus = FakeBus()
+        svc = ConverseService(bus=bus, config={})
+        sess = Session("named-converse-2")
+        SessionManager.sessions[sess.session_id] = sess
+
+        # client's message declares a blacklist entry the registry entry
+        # does not have yet
+        declaring = Session(sess.session_id)
+        declaring.blacklisted_skills = ["skill_x"]
+        msg = Message("intent.service.skills.activate",
+                      data={"skill_id": "skill_a"},
+                      context={"session": declaring.serialize()})
+
+        svc.activate_skill("skill_a", "skill_a", msg)
+
+        live = SessionManager.sessions[sess.session_id]
+        # the write applied on top of the fold
+        self.assertTrue(live.is_active("skill_a"))
+        # the client's declaration folded onto the registry entry
+        self.assertIn("skill_x", live.blacklisted_skills)
+        # and was NOT stamped out of the outgoing wire message
+        self.assertIn("skill_x", msg.context["session"]["blacklisted_skills"])
+
+    def test_deactivate_skill_folds_client_blacklist_and_applies_write(self):
+        """Same fold-order contract as above, for `deactivate_skill`.
+
+        `declaring` must itself declare skill_a as active - otherwise the
+        fold makes `session.is_active(skill_id)` False and
+        `deactivate_skill`'s write branch (and its
+        `message.context["session"] = ...` re-stamp) never executes at
+        all; the assertions would then pass trivially off `declaring`'s
+        own pre-serialized context rather than off the actual write."""
+        bus = FakeBus()
+        svc = ConverseService(bus=bus, config={})
+        sess = Session("named-converse-3")
+        sess.activate_skill("skill_a")
+        SessionManager.sessions[sess.session_id] = sess
+
+        declaring = Session(sess.session_id)
+        declaring.activate_skill("skill_a")  # must fold in as active for the write branch to run
+        declaring.blacklisted_skills = ["skill_x"]
+        msg = Message("intent.service.skills.deactivate",
+                      data={"skill_id": "skill_a"},
+                      context={"session": declaring.serialize()})
+
+        svc.deactivate_skill("skill_a", "skill_a", msg)
+
+        live = SessionManager.sessions[sess.session_id]
+        self.assertFalse(live.is_active("skill_a"))
+        self.assertIn("skill_x", live.blacklisted_skills)
+        self.assertIn("skill_x", msg.context["session"]["blacklisted_skills"])
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

Cleans up how the converse service handles sessions, after we traced several bugs to the same root cause: `SessionManager.get(message)` is not a read. It takes the session snapshot frozen inside the message and stamps it wholesale over the live registry entry, so calling it "to look something up" can silently undo a write that happened after the snapshot was taken.

The rule applied here: fold the message's session in once, at the start of the lifecycle, and after that write directly to the registry entry. The places that echo a session back onto the wire keep the fold, because there the client's declared state is supposed to win.

Also threads the resolved session through the helpers instead of re-resolving per call, which removes the double-fold that could resurrect a just-removed entry.

Unit suite green, including new tests that fail if any of the fold sites regress.
