### PR TITLE
spike: context.utterance_id — lifecycle identifier + converse round guard (PIPELINE-1 §9.1.1)

### DIFF
--- a/ovos_core/intent_services/converse_service.py
+++ b/ovos_core/intent_services/converse_service.py
@@ -288,11 +288,28 @@ class ConverseService(PipelinePlugin):
 
         event = Event()
 
+        # OVOS-CONVERSE-1 §4.2 round correlation: the round IS the utterance
+        # lifecycle, named by context.utterance_id (OVOS-PIPELINE-1 §9.1.1).
+        # The ping carries it by `forward` derivation and the pong carries it
+        # back by `reply` derivation — no skill-side action.
+        round_uid = message.context.get("utterance_id")
+
         def handle_ack(msg: Message) -> None:
             nonlocal event
             skill_id = msg.data.get("skill_id")
             if not skill_id:
                 return  # guard against malformed pong messages
+
+            # A pong that cannot prove which question it answers never decides a
+            # round: discard pongs from an earlier (or foreign) lifecycle. When
+            # the round itself is unnamed the guard stands down, so a V0 caller
+            # that never entered through the orchestrator behaves as before.
+            if round_uid is not None and \
+                    msg.context.get("utterance_id") != round_uid:
+                LOG.debug(f"discarding stale converse pong from '{skill_id}': "
+                          f"utterance_id {msg.context.get('utterance_id')!r} "
+                          f"does not match round {round_uid!r}")
+                return
 
             # validate the converse pong; default False — a non-responding skill should not converse
             if all((skill_id not in want_converse,

--- a/ovos_core/intent_services/service.py
+++ b/ovos_core/intent_services/service.py
@@ -16,6 +16,7 @@
 import json
 import re
 import time
+from uuid import uuid4
 from collections import defaultdict
 from typing import Optional, Tuple, Callable, List
 
@@ -577,6 +578,28 @@ class IntentService:
         self.bus.emit(message.reply(SpecMessage.UTTERANCE_CANCELLED, cancel_data))
         self.bus.emit(message.reply(SpecMessage.UTTERANCE_HANDLED))
 
+    @staticmethod
+    def _stamp_utterance_id(message: Message) -> str:
+        """OVOS-PIPELINE-1 §9.1.1 — name this utterance lifecycle.
+
+        The orchestrator stamps ``context.utterance_id`` once, at lifecycle
+        entry. The value is opaque and unique per lifecycle (a UUID here; no
+        format is normative). Consumers compare it for equality and do nothing
+        else. Every derived Message carries it for free, because
+        ``Message.reply``/``Message.forward`` deep-copy ``context``.
+
+        A value already present is kept: a component that opened the lifecycle
+        out-of-band already sat at entry and stamped under this same rule.
+
+        Returns:
+            str: the lifecycle identifier now on the Message.
+        """
+        uid = message.context.get("utterance_id")
+        if not uid:
+            uid = str(uuid4())
+            message.context["utterance_id"] = uid
+        return uid
+
     def handle_utterance(self, message: Message):
         """Main entrypoint for handling user utterances
 
@@ -604,8 +627,22 @@ class IntentService:
         Args:
             message (Message): The messagebus data
         """
+        # OVOS-PIPELINE-1 §9.1.1: stamp the lifecycle identifier exactly once,
+        # at lifecycle entry, before anything derives from this Message. A value
+        # already present is never overwritten — regenerating it downstream would
+        # detach every already-derived Message from its lifecycle.
+        uid = self._stamp_utterance_id(message)
+
         # Get utterance utterance_plugins additional context
         message = self._handle_transformers(message)
+
+        # §9.1.1 drop-guard: UtteranceTransformersService/MetadataTransformersService
+        # REPLACE message.context wholesale, so a plugin returning a fresh dict
+        # silently detaches the lifecycle. Re-assert the entry value (same value,
+        # so this is not an overwrite).
+        if message.context.get("utterance_id") != uid:
+            LOG.debug("transformer chain dropped utterance_id; re-asserting")
+            message.context["utterance_id"] = uid
 
         if message.context.get("canceled"):
             self.send_cancel_event(message)

--- a/test/unittests/test_converse_service.py
+++ b/test/unittests/test_converse_service.py
@@ -807,3 +807,105 @@ class TestConverseHandlerLifecycle(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+# ---------------------------------------------------------------------------
+# OVOS-PIPELINE-1 §9.1.1 / OVOS-CONVERSE-1 §4.2 — round correlation
+# ---------------------------------------------------------------------------
+
+class TestConverseRoundCorrelation(unittest.TestCase):
+    """A pong must prove which round it answers, or it decides nothing."""
+
+    def _run_round(self, svc, ping_msg, pongs):
+        """Drive one _collect_converse_skills round, feeding it `pongs`."""
+        ack_handler = None
+
+        def capture_on(event, handler):
+            nonlocal ack_handler
+            if event == "skill.converse.pong":
+                ack_handler = handler
+
+        svc.bus.on = capture_on
+        svc.bus.remove = MagicMock()
+        svc.bus.emit = MagicMock()
+
+        result_holder = []
+
+        def run():
+            result_holder.append(svc._collect_converse_skills(ping_msg))
+
+        t = threading.Thread(target=run)
+        t.start()
+        time.sleep(0.05)
+        for pong in pongs:
+            if ack_handler:
+                ack_handler(pong)
+        t.join(timeout=2)
+        return result_holder[0]
+
+    def test_stale_pong_from_previous_round_is_discarded(self):
+        """The late-answer-wins-wrong-round reproducer.
+
+        Round N-1 asks 'set a timer'; skill_a is slow. Round N asks
+        'what is the weather'; skill_a's answer to the OLD question lands
+        inside the new round's window. Without a correlation key the new
+        round accepts it and hands the weather utterance to skill_a.
+        """
+        svc = _make_service()
+        sess = Session("s")
+        sess.activate_skill("skill_a")
+
+        round_n = Message("test", {"utterances": ["what is the weather"]},
+                          {"utterance_id": "round-N", "session": sess.serialize()})
+        # skill_a's pong derives from the PREVIOUS round's ping, so it carries
+        # that round's utterance_id (Message.reply deep-copies context).
+        stale_pong = Message("skill.converse.pong",
+                             {"skill_id": "skill_a", "can_handle": True},
+                             {"utterance_id": "round-N-minus-1"})
+
+        with patch.object(ConverseService, "get_active_skills",
+                          return_value=["skill_a"]), \
+             patch("ovos_core.intent_services.converse_service.SessionManager.get",
+                   return_value=sess):
+            result = self._run_round(svc, round_n, [stale_pong])
+
+        self.assertEqual(result, [],
+                         "a pong from an earlier lifecycle decided this round")
+
+    def test_matching_pong_is_accepted(self):
+        """The guard does not reject the round's own answer."""
+        svc = _make_service()
+        sess = Session("s")
+        sess.activate_skill("skill_a")
+
+        round_n = Message("test", {"utterances": ["what is the weather"]},
+                          {"utterance_id": "round-N", "session": sess.serialize()})
+        good_pong = round_n.reply("skill.converse.pong",
+                                  {"skill_id": "skill_a", "can_handle": True})
+
+        with patch.object(ConverseService, "get_active_skills",
+                          return_value=["skill_a"]), \
+             patch("ovos_core.intent_services.converse_service.SessionManager.get",
+                   return_value=sess):
+            result = self._run_round(svc, round_n, [good_pong])
+
+        self.assertEqual(result, ["skill_a"])
+
+    def test_unnamed_round_accepts_pongs_as_before(self):
+        """V0 compat: a round with no utterance_id keeps the old behaviour."""
+        svc = _make_service()
+        sess = Session("s")
+        sess.activate_skill("skill_a")
+
+        round_msg = Message("test", {"utterances": ["hello"]},
+                            {"session": sess.serialize()})
+        pong = Message("skill.converse.pong",
+                       {"skill_id": "skill_a", "can_handle": True})
+
+        with patch.object(ConverseService, "get_active_skills",
+                          return_value=["skill_a"]), \
+             patch("ovos_core.intent_services.converse_service.SessionManager.get",
+                   return_value=sess):
+            result = self._run_round(svc, round_msg, [pong])
+
+        self.assertEqual(result, ["skill_a"])

--- a/test/unittests/test_intent_service_extended.py
+++ b/test/unittests/test_intent_service_extended.py
@@ -961,3 +961,73 @@ class TestBlacklistedPipelines(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+# ---------------------------------------------------------------------------
+# OVOS-PIPELINE-1 §9.1.1 — the lifecycle identifier
+# ---------------------------------------------------------------------------
+
+class TestUtteranceIdStamp(unittest.TestCase):
+    """The orchestrator names each utterance lifecycle exactly once."""
+
+    def test_entry_message_gets_an_identifier(self):
+        """A Message arriving without one is stamped with a non-empty value."""
+        msg = Message("test", {"utterances": ["hello"]})
+        uid = IntentService._stamp_utterance_id(msg)
+        self.assertTrue(uid)
+        self.assertIsInstance(uid, str)
+        self.assertEqual(msg.context["utterance_id"], uid)
+
+    def test_two_lifecycles_get_different_identifiers(self):
+        """The value is unique per lifecycle."""
+        a = IntentService._stamp_utterance_id(Message("test"))
+        b = IntentService._stamp_utterance_id(Message("test"))
+        self.assertNotEqual(a, b)
+
+    def test_existing_identifier_is_never_overwritten(self):
+        """A component that opened the lifecycle out of band already stamped."""
+        msg = Message("test", {}, {"utterance_id": "opened-elsewhere"})
+        uid = IntentService._stamp_utterance_id(msg)
+        self.assertEqual(uid, "opened-elsewhere")
+        self.assertEqual(msg.context["utterance_id"], "opened-elsewhere")
+
+    def test_derived_messages_carry_the_identifier(self):
+        """`reply` and `forward` deep-copy context, so propagation is free."""
+        msg = Message("test", {"utterances": ["hello"]})
+        uid = IntentService._stamp_utterance_id(msg)
+        self.assertEqual(msg.reply("x").context["utterance_id"], uid)
+        self.assertEqual(msg.forward("y").context["utterance_id"], uid)
+        self.assertEqual(
+            msg.forward("y").reply("z").context["utterance_id"], uid)
+
+    def test_transformer_chain_cannot_detach_the_lifecycle(self):
+        """The transformer chain REPLACES message.context wholesale.
+
+        A transformer plugin that returns a fresh dict would otherwise strip
+        the identifier and orphan every Message derived after it.
+        """
+        svc = _make_service()
+        svc.send_complete_intent_failure = MagicMock()
+        sess = Session("s")
+        sess.pipeline = []
+        msg = Message("recognizer_loop:utterance",
+                      data={"utterances": ["hello"]}, context={})
+
+        def nuke_context(m):
+            m.context = {"lang": "en-US"}  # fresh dict, identifier gone
+            return m
+
+        with patch.object(svc, "_handle_transformers", side_effect=nuke_context), \
+             patch("ovos_core.intent_services.service.SessionManager.get",
+                   return_value=sess), \
+             patch("ovos_core.intent_services.service.SessionManager.reset_default_session",
+                   return_value=sess), \
+             patch("ovos_core.intent_services.service.SessionManager.update"), \
+             patch("ovos_core.intent_services.service.SessionManager.sync"), \
+             patch("ovos_core.intent_services.service.get_message_lang",
+                   return_value="en-US"), \
+             patch("ovos_core.intent_services.service.get_valid_languages",
+                   return_value=["en-US"]):
+            svc.handle_utterance(msg)
+
+        self.assertTrue(msg.context.get("utterance_id"))


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

Gives every utterance a lifecycle id, stamped once when the utterance enters the pipeline. It rides along in the message context through replies and forwards, so anything downstream can tell which utterance an event belongs to.

First consumer: the converse poll. Answers from a previous round (same session, older utterance) used to be able to sneak into the current round; now they're matched on session + utterance id and stale ones are dropped. Messages without the id behave exactly as before, so old clients lose nothing.

Unit suite green with new tests covering the stale-answer case and the no-id fallback.
