### PR TITLE
fix: extend #859 round guard to fallback/stop ping-pong (PIPELINE-1 §9.1.1)

### DIFF
--- a/ovos_core/intent_services/fallback_service.py
+++ b/ovos_core/intent_services/fallback_service.py
@@ -21,7 +21,7 @@ from typing import Callable, Dict, List, Optional, Tuple, Union
 from ovos_bus_client.client import MessageBusClient
 from ovos_bus_client.handler import HandlerLifecycle
 from ovos_bus_client.message import Message
-from ovos_bus_client.session import SessionManager
+from ovos_bus_client.session import SessionManager, Session
 from ovos_config import Configuration
 from ovos_plugin_manager.templates.pipeline import ConfidenceMatcherPipeline, IntentHandlerMatch
 from ovos_utils import flatten_list
@@ -143,8 +143,34 @@ class FallbackService(ConfidenceMatcherPipeline):
                     and s not in (sess.blacklisted_skills or [])]
         skill_ids += [s for s in self.registered_fallbacks if s not in in_range]
 
+        # OVOS-CONVERSE-1 §4.2 round correlation: the round IS the utterance
+        # lifecycle, named by context.utterance_id (OVOS-PIPELINE-1 §9.1.1).
+        # The ping carries it by `forward` derivation and the pong carries it
+        # back by `reply` derivation — no skill-side action.
+        round_uid = message.context.get("utterance_id")
+        round_session_id = sess.session_id
+
         def handle_ack(msg):
             skill_id = msg.data["skill_id"]
+
+            # A pong that cannot prove which question it answers never decides a
+            # round: discard pongs from an earlier (or foreign) lifecycle, or
+            # from a foreign session. When the round itself is unnamed the
+            # guard stands down, so a V0 caller that never entered through the
+            # orchestrator behaves as before.
+            if round_uid is not None and \
+                    msg.context.get("utterance_id") != round_uid:
+                LOG.debug(f"discarding stale fallback pong from '{skill_id}': "
+                          f"utterance_id {msg.context.get('utterance_id')!r} "
+                          f"does not match round {round_uid!r}")
+                return
+            ack_sess = Session.from_message(msg) if "session" in msg.context else None
+            if ack_sess and ack_sess.session_id != round_session_id:
+                LOG.debug(f"discarding cross-session fallback pong from '{skill_id}': "
+                          f"session {ack_sess.session_id!r} does not match "
+                          f"round session {round_session_id!r}")
+                return
+
             if msg.data.get("can_handle", True):
                 if skill_id in in_range:
                     fallback_skills.append(skill_id)

--- a/ovos_core/intent_services/stop_service.py
+++ b/ovos_core/intent_services/stop_service.py
@@ -178,6 +178,13 @@ class StopService(ConfidenceMatcherPipeline):
 
         event = Event()
 
+        # OVOS-CONVERSE-1 §4.2 round correlation: the round IS the utterance
+        # lifecycle, named by context.utterance_id (OVOS-PIPELINE-1 §9.1.1).
+        # The ping carries it by `forward` derivation and the pong carries it
+        # back by `reply` derivation — no skill-side action.
+        round_uid = message.context.get("utterance_id")
+        round_session_id = SessionManager.get(message).session_id
+
         def handle_ack(msg: Message) -> None:
             """
             Handle acknowledgment from skills during the stop process.
@@ -194,6 +201,24 @@ class StopService(ConfidenceMatcherPipeline):
             skill_id = msg.data.get("skill_id")
             if not skill_id:
                 return  # guard against malformed pong messages
+
+            # A pong that cannot prove which question it answers never decides a
+            # round: discard pongs from an earlier (or foreign) lifecycle, or
+            # from a foreign session. When the round itself is unnamed the
+            # guard stands down, so a V0 caller that never entered through the
+            # orchestrator behaves as before.
+            if round_uid is not None and \
+                    msg.context.get("utterance_id") != round_uid:
+                LOG.debug(f"discarding stale stop pong from '{skill_id}': "
+                          f"utterance_id {msg.context.get('utterance_id')!r} "
+                          f"does not match round {round_uid!r}")
+                return
+            ack_sess = Session.from_message(msg) if "session" in msg.context else None
+            if ack_sess and ack_sess.session_id != round_session_id:
+                LOG.debug(f"discarding cross-session stop pong from '{skill_id}': "
+                          f"session {ack_sess.session_id!r} does not match "
+                          f"round session {round_session_id!r}")
+                return
 
             # validate the stop pong; default False — a non-responding skill
             # should not be assumed stoppable (§4.2)

--- a/test/unittests/test_fallback_service.py
+++ b/test/unittests/test_fallback_service.py
@@ -315,6 +315,111 @@ class TestCollectFallbackSkills(unittest.TestCase):
         self.assertEqual(result, [])
 
 
+class TestFallbackRoundCorrelation(unittest.TestCase):
+    """A pong must prove which round it answers, or it decides nothing."""
+
+    def _run_round(self, svc, ping_msg, pongs, fb_range=None):
+        ack_handler = None
+
+        def capture_on(event, handler):
+            nonlocal ack_handler
+            if event == "ovos.skills.fallback.pong":
+                ack_handler = handler
+
+        svc.bus.on = capture_on
+        svc.bus.remove = MagicMock()
+        svc.bus.emit = MagicMock()
+
+        result_holder = []
+
+        def run():
+            result_holder.append(
+                svc._collect_fallback_skills(ping_msg, fb_range=fb_range))
+
+        t = threading.Thread(target=run)
+        t.start()
+        time.sleep(0.05)
+        for pong in pongs:
+            if ack_handler:
+                ack_handler(pong)
+        t.join(timeout=2)
+        return result_holder[0]
+
+    def test_stale_pong_from_previous_round_is_discarded(self):
+        svc = _make_service()
+        svc.registered_fallbacks = {"skill_a": 50}
+        sess = Session("s")
+
+        round_n = Message("test", {}, {"utterance_id": "round-N",
+                                       "session": sess.serialize()})
+        stale_pong = Message("ovos.skills.fallback.pong",
+                             {"skill_id": "skill_a", "can_handle": True},
+                             {"utterance_id": "round-N-minus-1"})
+
+        with patch("ovos_core.intent_services.fallback_service.SessionManager.get",
+                   return_value=sess):
+            result = self._run_round(svc, round_n, [stale_pong],
+                                     fb_range=FallbackRange(5, 90))
+
+        self.assertEqual(result, [],
+                         "a pong from an earlier lifecycle decided this round")
+
+    def test_cross_session_pong_is_discarded(self):
+        svc = _make_service()
+        svc.registered_fallbacks = {"skill_a": 50}
+        sess = Session("s")
+        other_sess = Session("other")
+
+        round_n = Message("test", {}, {"utterance_id": "round-N",
+                                       "session": sess.serialize()})
+        foreign_pong = Message("ovos.skills.fallback.pong",
+                               {"skill_id": "skill_a", "can_handle": True},
+                               {"utterance_id": "round-N",
+                                "session": other_sess.serialize()})
+
+        with patch("ovos_core.intent_services.fallback_service.SessionManager.get",
+                   return_value=sess):
+            result = self._run_round(svc, round_n, [foreign_pong],
+                                     fb_range=FallbackRange(5, 90))
+
+        self.assertEqual(result, [],
+                         "a pong from a foreign session decided this round")
+
+    def test_matching_pong_is_accepted(self):
+        svc = _make_service()
+        svc.registered_fallbacks = {"skill_a": 50}
+        sess = Session("s")
+
+        round_n = Message("test", {}, {"utterance_id": "round-N",
+                                       "session": sess.serialize()})
+        good_pong = round_n.reply("ovos.skills.fallback.pong",
+                                  {"skill_id": "skill_a", "can_handle": True})
+
+        with patch("ovos_core.intent_services.fallback_service.SessionManager.get",
+                   return_value=sess):
+            result = self._run_round(svc, round_n, [good_pong],
+                                     fb_range=FallbackRange(5, 90))
+
+        self.assertEqual(result, ["skill_a"])
+
+    def test_unnamed_round_accepts_pongs_as_before(self):
+        """V0 compat: a round with no utterance_id keeps the old behaviour."""
+        svc = _make_service()
+        svc.registered_fallbacks = {"skill_a": 50}
+        sess = Session("s")
+
+        round_msg = Message("test", {}, {"session": sess.serialize()})
+        pong = Message("ovos.skills.fallback.pong",
+                       {"skill_id": "skill_a", "can_handle": True})
+
+        with patch("ovos_core.intent_services.fallback_service.SessionManager.get",
+                   return_value=sess):
+            result = self._run_round(svc, round_msg, [pong],
+                                     fb_range=FallbackRange(5, 90))
+
+        self.assertEqual(result, ["skill_a"])
+
+
 class TestFallbackRange(unittest.TestCase):
     """Tests for _fallback_range method."""
 

--- a/test/unittests/test_stop_service.py
+++ b/test/unittests/test_stop_service.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import threading
+import time
 import unittest
 from unittest.mock import MagicMock, patch, call
 from threading import Event
@@ -277,6 +279,125 @@ class TestCollectStopSkills(unittest.TestCase):
         emitted_types = [c[0][0].msg_type for c in svc.bus.emit.call_args_list]
         self.assertTrue(any("ok_skill" in t for t in emitted_types))
         self.assertFalse(any("bad_skill" in t for t in emitted_types))
+
+
+class TestStopRoundCorrelation(unittest.TestCase):
+    """A pong must prove which round it answers, or it decides nothing."""
+
+    def _session_with_skills(self, skill_ids):
+        sess = Session("test-session")
+        for sid in skill_ids:
+            sess.activate_skill(sid)
+        return sess
+
+    def _run_round(self, svc, ping_msg, pongs):
+        ack_handler = None
+
+        def capture_on(event, handler):
+            nonlocal ack_handler
+            if event == SpecMessage.STOP_PONG.value:
+                ack_handler = handler
+
+        svc.bus.on = capture_on
+        svc.bus.remove = MagicMock()
+        svc.bus.emit = MagicMock()
+
+        result_holder = []
+
+        def run():
+            result_holder.append(svc._collect_stop_skills(ping_msg))
+
+        t = threading.Thread(target=run)
+        t.start()
+        time.sleep(0.05)
+        for pong in pongs:
+            if ack_handler:
+                ack_handler(pong)
+        t.join(timeout=2)
+        return result_holder[0]
+
+    def test_stale_pong_from_previous_round_is_discarded(self):
+        """skill_a's stale pong must not count as its answer: skill_b answers
+        validly and is included, skill_a's discarded pong leaves it un-answered
+        (so it is NOT the reason it ends up in the result; want_stop stays
+        non-empty from skill_b alone, proving the fallback-to-all path was not
+        what produced skill_b)."""
+        svc = _make_service()
+        sess = self._session_with_skills(["skill_a", "skill_b"])
+
+        round_n = Message("test", {}, {"utterance_id": "round-N",
+                                       "session": sess.serialize()})
+        stale_pong = Message(SpecMessage.STOP_PONG.value,
+                             {"skill_id": "skill_a", "can_handle": True},
+                             {"utterance_id": "round-N-minus-1"})
+        good_pong = round_n.reply(SpecMessage.STOP_PONG.value,
+                                  {"skill_id": "skill_b", "can_handle": True})
+
+        with patch.object(StopService, "get_active_skills",
+                          return_value=["skill_a", "skill_b"]), \
+             patch("ovos_core.intent_services.stop_service.SessionManager.get",
+                   return_value=sess):
+            result = self._run_round(svc, round_n, [stale_pong, good_pong])
+
+        self.assertNotIn("skill_a", result,
+                         "a pong from an earlier lifecycle decided this round")
+        self.assertIn("skill_b", result)
+
+    def test_cross_session_pong_is_discarded(self):
+        svc = _make_service()
+        sess = self._session_with_skills(["skill_a", "skill_b"])
+        other_sess = Session("other")
+
+        round_n = Message("test", {}, {"utterance_id": "round-N",
+                                       "session": sess.serialize()})
+        foreign_pong = Message(SpecMessage.STOP_PONG.value,
+                               {"skill_id": "skill_a", "can_handle": True},
+                               {"utterance_id": "round-N",
+                                "session": other_sess.serialize()})
+        good_pong = round_n.reply(SpecMessage.STOP_PONG.value,
+                                  {"skill_id": "skill_b", "can_handle": True})
+
+        with patch.object(StopService, "get_active_skills",
+                          return_value=["skill_a", "skill_b"]), \
+             patch("ovos_core.intent_services.stop_service.SessionManager.get",
+                   return_value=sess):
+            result = self._run_round(svc, round_n, [foreign_pong, good_pong])
+
+        self.assertNotIn("skill_a", result,
+                         "a pong from a foreign session decided this round")
+        self.assertIn("skill_b", result)
+
+    def test_matching_pong_is_accepted(self):
+        svc = _make_service()
+        sess = self._session_with_skills(["skill_a"])
+
+        round_n = Message("test", {}, {"utterance_id": "round-N",
+                                       "session": sess.serialize()})
+        good_pong = round_n.reply(SpecMessage.STOP_PONG.value,
+                                  {"skill_id": "skill_a", "can_handle": True})
+
+        with patch.object(StopService, "get_active_skills", return_value=["skill_a"]), \
+             patch("ovos_core.intent_services.stop_service.SessionManager.get",
+                   return_value=sess):
+            result = self._run_round(svc, round_n, [good_pong])
+
+        self.assertEqual(result, ["skill_a"])
+
+    def test_unnamed_round_accepts_pongs_as_before(self):
+        """V0 compat: a round with no utterance_id keeps the old behaviour."""
+        svc = _make_service()
+        sess = self._session_with_skills(["skill_a"])
+
+        round_msg = Message("test", {}, {"session": sess.serialize()})
+        pong = Message(SpecMessage.STOP_PONG.value,
+                       {"skill_id": "skill_a", "can_handle": True})
+
+        with patch.object(StopService, "get_active_skills", return_value=["skill_a"]), \
+             patch("ovos_core.intent_services.stop_service.SessionManager.get",
+                   return_value=sess):
+            result = self._run_round(svc, round_msg, [pong])
+
+        self.assertEqual(result, ["skill_a"])
 
 
 class TestHandleStopConfirmation(unittest.TestCase):


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

Extends the stale-answer guard from the converse poll to the fallback and stop polls.

All three services ask skills a question over the bus and collect answers. Without a round marker, an answer from the previous question could be counted for the current one. Answers are now matched on session + utterance id; anything from an older round is dropped. Messages that carry no utterance id (old clients) are accepted exactly as before, so nothing breaks for them.

An adversarial review tried four ways to make the guard drop a legitimate answer from an old client and could not; mutation tests confirm each guard is actually load-bearing.
