### PR TITLE
feat(converse): broadcast contest poll (OVOS-CONVERSE-1 §4.2)

### DIFF
--- a/ovos_core/intent_services/converse_service.py
+++ b/ovos_core/intent_services/converse_service.py
@@ -403,15 +403,15 @@ class ConverseService(PipelinePlugin):
                      fresh ``SessionManager.get(message)`` fold for
                      standalone callers.
         """
-        skill_ids = []
-        want_converse = []
+        answered = []  # candidates whose first valid pong already landed
+        claimed = set()  # candidates whose first valid pong was a claim
         session = session or SessionManager.get(message)
 
         # note: this is sorted by priority already
         active_skills = [skill_id for skill_id in self.get_active_skills(message, session=session)
                      if session.utterance_states.get(skill_id, UtteranceState.INTENT) == UtteranceState.INTENT]
         if not active_skills:
-            return want_converse
+            return []
 
         event = Event()
 
@@ -438,30 +438,66 @@ class ConverseService(PipelinePlugin):
                           f"does not match round {round_uid!r}")
                 return
 
-            # validate the converse pong; default False — a non-responding skill should not converse
-            if all((skill_id not in want_converse,
-                    msg.data.get("can_handle", False),
-                    skill_id in active_skills)):
-                want_converse.append(skill_id)
+            # OVOS-CONVERSE-1 §4.2: "the first valid pong per candidate wins".
+            # During the dual-emit compat window a current skill answers the
+            # round twice — once on the broadcast leg, once on the legacy
+            # per-skill leg — so each candidate MUST be counted exactly once.
+            if skill_id in answered:
+                return
+            answered.append(skill_id)
 
-            if skill_id not in skill_ids:  # track which answer we got
-                skill_ids.append(skill_id)
+            # the claim boolean is `result` in OVOS-CONVERSE-1 §4.2 and
+            # `can_handle` on the legacy per-skill leg. A missing or
+            # non-boolean value is a decline: a skill that does not answer
+            # clearly must not converse.
+            claim = msg.data.get("result", msg.data.get("can_handle"))
+            if claim is True:
+                claimed.add(skill_id)
 
-            if all(s in skill_ids for s in active_skills):
-                # all skills answered the ping!
+            if all(s in answered for s in active_skills):
+                # every candidate named by the round has answered — nothing
+                # more can arrive that the round would wait for
                 event.set()
 
-        self.bus.on("skill.converse.pong", handle_ack)
+        self.bus.on("skill.converse.pong", handle_ack)  # legacy leg
+        self.bus.on("ovos.converse.pong", handle_ack)  # OVOS-CONVERSE-1 §6.2
         try:
-            # ask skills if they want to converse
-            for skill_id in active_skills:
-                self.bus.emit(message.forward(f"{skill_id}.converse.ping", {**message.data, "skill_id": skill_id}))
+            # OVOS-CONVERSE-1 §4.2: ONE broadcast ping for the round. No
+            # candidate identity travels in topic or payload — a skill decides
+            # it is a candidate by testing its own skill_id against
+            # context.session.converse_handlers, which `reply` carries along.
+            #
+            # The payload is the inbound data minus skill_id, so a skill that
+            # binds BOTH legs decides the round from identical input whichever
+            # ping reaches it first. Feeding the two legs different data makes
+            # the verdict depend on which leg won the race.
+            broadcast_data = {k: v for k, v in message.data.items()
+                              if k != "skill_id"}
+            self.bus.emit(message.reply("ovos.converse.ping", broadcast_data))
 
-            # wait for all skills to acknowledge they want to converse
+            # V0 compat: skills older than the broadcast binding only listen on
+            # the per-skill legacy ping. Dual-emit keeps them in the contest;
+            # the collector above counts each skill once whichever leg answers.
+            for skill_id in active_skills:
+                self.bus.emit(message.forward(f"{skill_id}.converse.ping",
+                                              {**message.data, "skill_id": skill_id}))
+
+            # one bounded collection window for the whole round, not n x a
+            # per-owner wait (OVOS-CONVERSE-1 §4.2 stage collection ceiling)
             event.wait(timeout=0.5)
         finally:
             self.bus.remove("skill.converse.pong", handle_ack)
-        return want_converse
+            self.bus.remove("ovos.converse.pong", handle_ack)
+
+        # This is also what keeps a foreign pong out of the round
+        # (OVOS-CONVERSE-1 §4.2): a skill_id absent from the candidate set
+        # cannot appear in the returned list, and it can never satisfy the
+        # early-close check above, which is keyed on `active_skills`.
+        #
+        # OVOS-CONVERSE-1 §4.1 step 3: selection is by recency order — the
+        # order of session.converse_handlers — and is NEVER by response-arrival
+        # order. Under a parallel broadcast round the arrival order is a race.
+        return [skill_id for skill_id in active_skills if skill_id in claimed]
 
     def _check_converse_timeout(self, message: Message):
         """ filter active skill list based on timestamps

--- a/test/end2end/test_activate.py
+++ b/test/end2end/test_activate.py
@@ -201,6 +201,11 @@ class TestDeactivate(TestCase):
             ],
             expected_messages=[
                 message,
+                # OVOS-CONVERSE-1 §4.2: one broadcast poll per round, emitted
+                # before the legacy per-skill pings (dual-emit compat window).
+                Message("ovos.converse.ping",
+                        data={"utterances": ["deactivate skill from within converse"], "lang": session.lang},
+                        context={}),
                 Message(f"{self.skill_id}.converse.ping",
                         data={"utterances": ["deactivate skill from within converse"], "skill_id": self.skill_id},
                         context={}),

--- a/test/end2end/test_converse.py
+++ b/test/end2end/test_converse.py
@@ -115,6 +115,11 @@ class TestConverse(TestCase):
             ]
             expected2 = [
                 message2,
+                # OVOS-CONVERSE-1 §4.2: one broadcast poll per round, emitted
+                # before the legacy per-skill pings (dual-emit compat window).
+                Message("ovos.converse.ping",
+                        data={"utterances": ["echo test"], "lang": session.lang},
+                        context={}),
                 Message(f"{self.skill_id}.converse.ping",
                         data={"utterances": ["echo test"], "skill_id": self.skill_id},
                         context={}),
@@ -159,6 +164,9 @@ class TestConverse(TestCase):
             ]
             expected3 = [
                 message3,
+                Message("ovos.converse.ping",
+                        data={"utterances": ["stop parrot"], "lang": session.lang},
+                        context={}),
                 Message(f"{self.skill_id}.converse.ping",
                         data={"utterances": ["stop parrot"], "skill_id": self.skill_id},
                         context={}),
@@ -203,6 +211,9 @@ class TestConverse(TestCase):
             ]
             expected4 = [
                 message4,
+                Message("ovos.converse.ping",
+                        data={"utterances": ["echo test"], "lang": session.lang},
+                        context={}),
                 Message(f"{self.skill_id}.converse.ping",
                         data={"utterances": ["echo test"], "skill_id": self.skill_id},
                         context={}),

--- a/test/unittests/test_converse_service.py
+++ b/test/unittests/test_converse_service.py
@@ -179,9 +179,10 @@ class TestCollectConverseSkills(unittest.TestCase):
 
             svc._collect_converse_skills(Message("test"))
 
-        svc.bus.remove.assert_called_once()
-        args = svc.bus.remove.call_args[0]
-        self.assertEqual(args[0], "skill.converse.pong")
+        # both legs of the dual-emit compat window must be unbound
+        removed = [call[0][0] for call in svc.bus.remove.call_args_list]
+        self.assertEqual(sorted(removed),
+                         ["ovos.converse.pong", "skill.converse.pong"])
 
     def test_response_state_skills_excluded_from_active_skills(self):
         """Skills whose utterance_state is RESPONSE are not included in active_skills ping list."""
@@ -1199,3 +1200,319 @@ class TestConverseRoundCorrelation(unittest.TestCase):
             result = self._run_round(svc, round_msg, [pong])
 
         self.assertEqual(result, ["skill_a"])
+
+
+# ---------------------------------------------------------------------------
+# OVOS-CONVERSE-1 §4.1-§4.2 — the broadcast contest
+# ---------------------------------------------------------------------------
+
+class _FakeSkill:
+    """A candidate on a real FakeBus, at a chosen wire vintage.
+
+    ``legacy`` binds the per-skill ping and answers ``skill.converse.pong``
+    with ``can_handle`` — the shape every ovos-workshop vintage up to and
+    including 9.3.12a1 speaks. ``broadcast`` binds the static
+    ``ovos.converse.ping`` and answers ``ovos.converse.pong`` with ``result``
+    — the OVOS-CONVERSE-1 §4.2 shape. A current skill binds both.
+    """
+
+    def __init__(self, bus, skill_id, claims, legacy=True, broadcast=True,
+                 candidates=None):
+        self.bus = bus
+        self.skill_id = skill_id
+        self.claims = claims
+        self.candidates = candidates
+        self.pings_seen = []
+        if legacy:
+            bus.on(f"{skill_id}.converse.ping", self._legacy_ack)
+        if broadcast:
+            bus.on("ovos.converse.ping", self._broadcast_ack)
+
+    def _legacy_ack(self, message):
+        self.pings_seen.append(message.msg_type)
+        self.bus.emit(message.reply(
+            "skill.converse.pong",
+            {"skill_id": self.skill_id, "can_handle": self.claims}))
+
+    def _broadcast_ack(self, message):
+        if self.candidates is not None and self.skill_id not in self.candidates:
+            return  # not named by this round
+        self.pings_seen.append(message.msg_type)
+        self.bus.emit(message.reply(
+            "ovos.converse.pong",
+            {"skill_id": self.skill_id, "result": self.claims}))
+
+
+class TestBroadcastContest(unittest.TestCase):
+    """One broadcast question per round, answered in parallel."""
+
+    def _round(self, svc, sess, active, utterance_id="round-1"):
+        msg = Message("test", {"utterances": ["hello"], "lang": "en-US"},
+                      {"utterance_id": utterance_id,
+                       "session": sess.serialize()})
+        with patch.object(ConverseService, "get_active_skills",
+                          return_value=active), \
+             patch("ovos_core.intent_services.converse_service.SessionManager.get",
+                   return_value=sess):
+            return svc._collect_converse_skills(msg)
+
+    def _session(self, *skill_ids):
+        sess = Session("s")
+        for skill_id in skill_ids:
+            sess.activate_skill(skill_id)
+        return sess
+
+    # -- FEATURE: the broadcast leg -------------------------------------
+
+    def test_one_broadcast_ping_carries_no_candidate_identity(self):
+        """FEATURE (OVOS-CONVERSE-1 §4.2). The round asks one question.
+
+        The broadcast ping's topic is a static string and its payload names
+        no candidate: membership is read from the session the `reply`
+        derivation carries.
+        """
+        svc = _make_service()
+        emitted = []
+        svc.bus.on("ovos.converse.ping", lambda m: emitted.append(m))
+        sess = self._session("skill_a", "skill_b")
+        self._round(svc, sess, ["skill_a", "skill_b"])
+
+        self.assertEqual(len(emitted), 1,
+                         "the round must ask exactly one broadcast question")
+        self.assertNotIn("skill_id", emitted[0].data)
+        self.assertEqual(sorted(emitted[0].data), ["lang", "utterances"])
+
+    def test_new_core_new_skill_converses_over_broadcast_leg(self):
+        """FEATURE. New core + new skill: the broadcast leg carries the claim."""
+        svc = _make_service()
+        sess = self._session("skill_a")
+        skill = _FakeSkill(svc.bus, "skill_a", claims=True,
+                           candidates=["skill_a"])
+        result = self._round(svc, sess, ["skill_a"])
+
+        self.assertEqual(result, ["skill_a"])
+        self.assertIn("ovos.converse.ping", skill.pings_seen)
+
+    def test_new_core_old_skill_converses_over_legacy_leg(self):
+        """V0 COMPAT. New core + a skill that only binds the legacy ping.
+
+        This is every released ovos-workshop up to 9.3.12a1. It never sees
+        the broadcast question, so the dual-emit's legacy leg is the only
+        thing keeping it in the contest.
+        """
+        svc = _make_service()
+        sess = self._session("skill_a")
+        skill = _FakeSkill(svc.bus, "skill_a", claims=True, broadcast=False)
+        result = self._round(svc, sess, ["skill_a"])
+
+        self.assertEqual(result, ["skill_a"],
+                         "a legacy-only skill lost its converse turn")
+        self.assertEqual(skill.pings_seen, ["skill_a.converse.ping"])
+
+    def test_mixed_fleet_both_vintages_counted(self):
+        """V0 COMPAT. Old and new skills contest the same round."""
+        svc = _make_service()
+        sess = self._session("old_skill", "new_skill")
+        _FakeSkill(svc.bus, "new_skill", claims=False,
+                   candidates=["old_skill", "new_skill"])
+        _FakeSkill(svc.bus, "old_skill", claims=True, broadcast=False)
+        # recency: new_skill activated last, so it heads the list
+        result = self._round(svc, sess, ["new_skill", "old_skill"])
+
+        self.assertEqual(result, ["old_skill"])
+
+    # -- DEFECT: a candidate answering twice was counted twice -----------
+
+    def test_dual_answer_counts_the_skill_once_first_pong_wins(self):
+        """DEFECT (red before fix). §4.2 'the first valid pong per candidate wins'.
+
+        A current skill answers the dual-emitted round twice. The two pongs
+        disagree — the broadcast leg declines, the legacy leg claims. Before
+        the fix the collector took the claim from the second pong, so a
+        skill that declined the round still got the converse dispatch.
+        """
+        svc = _make_service()
+        sess = self._session("skill_a")
+
+        def decline_broadcast(message):
+            svc.bus.emit(message.reply(
+                "ovos.converse.pong", {"skill_id": "skill_a", "result": False}))
+
+        def claim_legacy(message):
+            svc.bus.emit(message.reply(
+                "skill.converse.pong", {"skill_id": "skill_a", "can_handle": True}))
+
+        svc.bus.on("ovos.converse.ping", decline_broadcast)
+        svc.bus.on("skill_a.converse.ping", claim_legacy)
+        result = self._round(svc, sess, ["skill_a"])
+
+        self.assertEqual(result, [],
+                         "the second pong overrode the candidate's first answer")
+
+    def test_repeated_claim_yields_one_entry(self):
+        """DEFECT. A skill answering both legs appears once, not twice."""
+        svc = _make_service()
+        sess = self._session("skill_a")
+        _FakeSkill(svc.bus, "skill_a", claims=True, candidates=["skill_a"])
+        result = self._round(svc, sess, ["skill_a"])
+
+        self.assertEqual(result, ["skill_a"])
+
+    # -- DEFECT: selection followed arrival order, not recency -----------
+
+    def test_selection_is_by_recency_not_arrival_order(self):
+        """DEFECT (red before fix). §4.1 step 3: 'Selection is never by
+        response-arrival order.'
+
+        Both candidates claim. The least-recent one answers first — which is
+        exactly what a parallel broadcast round makes likely, since the
+        candidates now race instead of being polled in order. The winner
+        must still be the head of the recency list.
+        """
+        svc = _make_service()
+        sess = self._session("skill_b", "skill_a")  # skill_a is now head
+        pings = []
+
+        def answer_both(message):
+            pings.append(message)
+            # skill_b (the tail) is quicker off the mark
+            for skill_id in ("skill_b", "skill_a"):
+                svc.bus.emit(message.reply(
+                    "ovos.converse.pong", {"skill_id": skill_id, "result": True}))
+
+        svc.bus.on("ovos.converse.ping", answer_both)
+        result = self._round(svc, sess, ["skill_a", "skill_b"])
+
+        self.assertEqual(result, ["skill_a", "skill_b"],
+                         "the round was decided by who answered first")
+
+    # -- FEATURE: early close --------------------------------------------
+
+    def test_round_closes_early_when_every_candidate_answered(self):
+        """FEATURE (§4.2). The window closes as soon as the answer set is complete.
+
+        Three candidates, all declining. The round must not sit out the
+        0.5s collection ceiling once nothing more can arrive.
+        """
+        svc = _make_service()
+        sess = self._session("skill_a", "skill_b", "skill_c")
+        for skill_id in ("skill_a", "skill_b", "skill_c"):
+            _FakeSkill(svc.bus, skill_id, claims=False,
+                       candidates=["skill_a", "skill_b", "skill_c"])
+
+        start = time.monotonic()
+        result = self._round(svc, sess, ["skill_a", "skill_b", "skill_c"])
+        elapsed = time.monotonic() - start
+
+        self.assertEqual(result, [])
+        self.assertLess(elapsed, 0.4,
+                        "the round waited out the ceiling after every "
+                        "candidate had already answered")
+
+    def test_silent_candidate_waits_out_the_single_window(self):
+        """FEATURE (§4.2). The ceiling is one window for the whole round,
+        not n x a per-owner wait: three silent candidates still cost 0.5s
+        once, and a silent candidate is treated as a decline."""
+        svc = _make_service()
+        sess = self._session("skill_a", "skill_b", "skill_c")
+
+        start = time.monotonic()
+        result = self._round(svc, sess, ["skill_a", "skill_b", "skill_c"])
+        elapsed = time.monotonic() - start
+
+        self.assertEqual(result, [])
+        self.assertLess(elapsed, 1.0,
+                        "the round cost more than one collection window")
+
+    # -- pong hygiene -----------------------------------------------------
+
+    def test_foreign_claim_never_wins_the_round(self):
+        """§4.2. A claim from a skill outside the candidate set decides nothing.
+
+        The stranger is the ONLY claimer of the round, so if the candidate-set
+        filter on the returned list stops carrying this, the round hands the
+        utterance to a skill it never asked. Mutation-checked: returning the
+        raw claim set instead of the filtered recency list fails this test.
+        """
+        svc = _make_service()
+        sess = self._session("skill_a")
+
+        def answer_as_stranger(message):
+            svc.bus.emit(message.reply(
+                "ovos.converse.pong", {"skill_id": "stranger", "result": True}))
+
+        svc.bus.on("ovos.converse.ping", answer_as_stranger)
+        result = self._round(svc, sess, ["skill_a"])
+        self.assertEqual(result, [])
+
+    def test_foreign_pong_does_not_close_the_round_early(self):
+        """§4.2. A stranger's answer must not stand in for a candidate's.
+
+        skill_a is the round's only candidate and stays silent. A stranger
+        answers immediately. The round must still wait out its window rather
+        than treat the stranger's pong as the answer set being complete.
+        """
+        svc = _make_service()
+        sess = self._session("skill_a")
+
+        def answer_as_stranger(message):
+            svc.bus.emit(message.reply(
+                "ovos.converse.pong", {"skill_id": "stranger", "result": False}))
+
+        svc.bus.on("ovos.converse.ping", answer_as_stranger)
+        start = time.monotonic()
+        result = self._round(svc, sess, ["skill_a"])
+        elapsed = time.monotonic() - start
+
+        self.assertEqual(result, [])
+        self.assertGreaterEqual(elapsed, 0.4,
+                                "a stranger's pong satisfied the round's "
+                                "answer bookkeeping")
+
+    def test_both_legs_carry_identical_poll_data(self):
+        """DEFECT (red before fix). A skill that binds both legs must decide
+        from the same input whichever ping reaches it first.
+
+        When the broadcast leg carried a trimmed payload and the legacy leg
+        the full inbound data, the same skill answered the same round from
+        different inputs and the verdict became a thread race.
+        """
+        svc = _make_service()
+        sess = self._session("skill_a")
+        seen = {}
+
+        svc.bus.on("ovos.converse.ping",
+                   lambda m: seen.__setitem__("broadcast", dict(m.data)))
+        svc.bus.on("skill_a.converse.ping",
+                   lambda m: seen.__setitem__("legacy", dict(m.data)))
+
+        msg = Message("test",
+                      {"utterances": ["hello"], "lang": "en-US",
+                       "confidence": 0.9},
+                      {"utterance_id": "round-1", "session": sess.serialize()})
+        with patch.object(ConverseService, "get_active_skills",
+                          return_value=["skill_a"]), \
+             patch("ovos_core.intent_services.converse_service.SessionManager.get",
+                   return_value=sess):
+            svc._collect_converse_skills(msg)
+
+        legacy = {k: v for k, v in seen["legacy"].items() if k != "skill_id"}
+        self.assertEqual(seen["broadcast"], legacy,
+                         "the two legs fed can_converse different data")
+        # the round's extra inbound fields must survive onto the broadcast leg
+        self.assertEqual(seen["broadcast"]["confidence"], 0.9)
+        # and the broadcast leg still names no candidate
+        self.assertNotIn("skill_id", seen["broadcast"])
+
+    def test_non_boolean_result_is_a_decline(self):
+        """§4.2. A missing or non-boolean claim value is treated as False."""
+        svc = _make_service()
+        sess = self._session("skill_a")
+
+        def answer_garbage(message):
+            svc.bus.emit(message.reply(
+                "ovos.converse.pong", {"skill_id": "skill_a", "result": "yes"}))
+
+        svc.bus.on("ovos.converse.ping", answer_garbage)
+        result = self._round(svc, sess, ["skill_a"])
+        self.assertEqual(result, [])


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

Converse polling currently sends one ping per active skill. The CONVERSE-1 spec uses a single broadcast ping that every candidate answers. This PR emits both: the broadcast for spec-aware skills, and the per-skill pings for everyone else, with identical payloads. First valid answer per candidate wins, duplicates are ignored.

Two real bugs fixed along the way: a second answer from the same skill could overwrite its first, and selection followed answer-arrival order instead of session activity order.

For n active skills this is n+1 pings during the transition instead of n; once old skills are gone it becomes 1.

The end-to-end goldens were updated to expect the broadcast ping. Unit and e2e suites green, except one pre-existing dev failure that is being fixed separately in ovos-utils (FakeBus lacks the intent-topic bridge).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Converse requests now support broadcast discovery alongside existing skill-specific messaging.
  - Active skills are selected in priority order, with duplicate responses handled automatically.

- **Bug Fixes**
  - Improved compatibility between current and legacy converse responders.
  - Prevented stale, invalid, or duplicate responses from affecting skill selection.
  - Converse discovery now completes promptly when valid responses are received and cleans up listeners reliably.

- **Tests**
  - Expanded coverage for broadcast discovery, timeouts, response validation, prioritization, and legacy compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->