### PR TITLE
fix: registry-first session resolution for stop write paths (mirrors #858)

### DIFF
--- a/ovos_core/intent_services/_session_fold.py
+++ b/ovos_core/intent_services/_session_fold.py
@@ -1,0 +1,65 @@
+"""Shared fold-order helper for pipeline plugins.
+
+Mirrors ``IntentService._registry_session_for_context_write`` (#857,
+``ovos_core/intent_services/service.py``) and
+``ConverseService._registry_session_for_write`` (#858,
+``ovos_core/intent_services/converse_service.py``) for INCIDENTAL session
+writes in ``stop_service.py`` that have no wire echo. Kept as its own small
+module (rather than importing one plugin's private static method from
+another) so ``stop_service.py``/``fallback_service.py`` don't reach into
+``converse_service.py``'s internals; delete only if/when all three call-site
+families are consolidated together.
+
+FOLD-ORDER CONTRACT (read this before adding a new call site):
+
+``SessionManager.get(message)`` is NEVER a pure read. It always folds the
+incoming message's session snapshot onto the live registry entry
+(``SessionManager._store`` -> ``Session.update_from``, full
+serialize/deserialize replace, for every session id including
+``"default"``) and returns THAT live object. So every call is a write of
+the message's declared state onto the registry, whether or not the caller
+goes on to mutate anything itself.
+
+That fold is *correct and required* at two kinds of site:
+  1. True lifecycle entry - the first fold for this message in this
+     pipeline turn. SESSION-2 last-writer-wins: the client's
+     freshly-declared fields (lang, blacklist, client-side (de)activations)
+     must apply here.
+  2. Any site that stamps the resolved session back onto the wire via
+     ``message.context["session"] = session.serialize()`` - bypassing the
+     fold there would silently discard the client's own declarations from
+     the outgoing message.
+
+The fold is *wrong* (and this helper exists to avoid it) only for an
+INCIDENTAL write with no wire echo, where a STALE message (one that
+predates state written to the registry earlier in the same session's
+lifecycle - by this same pipeline stage OR an earlier one in the same
+turn, e.g. converse's skill activation/deactivation) would otherwise wipe
+that state via the full-replace fold before this handler's own write lands.
+
+RESIDUAL (not fixed by this helper, tracked as a known gap, same as #858):
+a case-2 wire-echo site elsewhere still full-replaces the registry entry
+when it folds, so a write this helper protects only survives until the
+next stale wire-echo call for that session.
+
+Resolution: resolve session_id off the message and, if the registry already
+holds a live entry for it, mutate that object directly - no fold. Fall back
+to ``SessionManager.get(message)`` (today's behavior) only when no registry
+entry exists yet, e.g. out-of-registry/test callers or a message with no
+session context.
+"""
+from typing import Optional
+
+from ovos_bus_client.message import Message
+from ovos_bus_client.session import SessionManager, Session
+
+
+def registry_session_for_write(message: Optional[Message]) -> Session:
+    """Resolve the live registry session to mutate for an incidental write
+    that has no wire echo. See module docstring for the full fold-order
+    contract."""
+    session_data = message.context.get("session") if message and message.context else None
+    session_id = session_data.get("session_id") if isinstance(session_data, dict) else None
+    if session_id and session_id in SessionManager.sessions:
+        return SessionManager.sessions[session_id]
+    return SessionManager.get(message)

--- a/ovos_core/intent_services/fallback_service.py
+++ b/ovos_core/intent_services/fallback_service.py
@@ -22,6 +22,7 @@ from ovos_bus_client.client import MessageBusClient
 from ovos_bus_client.handler import HandlerLifecycle
 from ovos_bus_client.message import Message
 from ovos_bus_client.session import SessionManager, Session
+from ovos_core.intent_services._session_fold import registry_session_for_write
 from ovos_config import Configuration
 from ovos_plugin_manager.templates.pipeline import ConfidenceMatcherPipeline, IntentHandlerMatch
 from ovos_utils import flatten_list
@@ -134,7 +135,12 @@ class FallbackService(ConfidenceMatcherPipeline):
         skill_ids = []  # skill_ids that already answered to ping
         fallback_skills = []  # skill_ids that want to handle fallback
 
-        sess = SessionManager.get(message)
+        # incidental read of registry state (blacklist/active skills), no
+        # wire echo from this method and not a lifecycle entry - resolve via
+        # `registry_session_for_write` so an earlier registry-first write
+        # this same turn (e.g. stop_service's disable_response_mode) isn't
+        # clobbered by this call's fold (see ``_session_fold.py``).
+        sess = registry_session_for_write(message)
         if sess is None:
             return fallback_skills
         # filter skills outside the fallback_range
@@ -219,6 +225,12 @@ class FallbackService(ConfidenceMatcherPipeline):
         message.data["utterances"] = utterances  # all transcripts
         message.data["lang"] = lang
 
+        # KEEP the plain fold here: this is a genuine wire-echo site (case
+        # 2 of the fold-order contract) - the returned IntentHandlerMatch's
+        # `updated_session=sess` is consumed by
+        # ``IntentService._dispatch_match`` (service.py) and stamped back
+        # onto the outgoing message, so this call must apply the message's
+        # own declared session state, not bypass it.
         sess = SessionManager.get(message)
         if sess is None:
             return None

--- a/ovos_core/intent_services/fallback_service.py
+++ b/ovos_core/intent_services/fallback_service.py
@@ -21,7 +21,7 @@ from typing import Callable, Dict, List, Optional, Tuple, Union
 from ovos_bus_client.client import MessageBusClient
 from ovos_bus_client.handler import HandlerLifecycle
 from ovos_bus_client.message import Message
-from ovos_bus_client.session import SessionManager
+from ovos_bus_client.session import SessionManager, Session
 from ovos_config import Configuration
 from ovos_plugin_manager.templates.pipeline import ConfidenceMatcherPipeline, IntentHandlerMatch
 from ovos_utils import flatten_list
@@ -143,8 +143,34 @@ class FallbackService(ConfidenceMatcherPipeline):
                     and s not in (sess.blacklisted_skills or [])]
         skill_ids += [s for s in self.registered_fallbacks if s not in in_range]
 
+        # OVOS-CONVERSE-1 §4.2 round correlation: the round IS the utterance
+        # lifecycle, named by context.utterance_id (OVOS-PIPELINE-1 §9.1.1).
+        # The ping carries it by `forward` derivation and the pong carries it
+        # back by `reply` derivation — no skill-side action.
+        round_uid = message.context.get("utterance_id")
+        round_session_id = sess.session_id
+
         def handle_ack(msg):
             skill_id = msg.data["skill_id"]
+
+            # A pong that cannot prove which question it answers never decides a
+            # round: discard pongs from an earlier (or foreign) lifecycle, or
+            # from a foreign session. When the round itself is unnamed the
+            # guard stands down, so a V0 caller that never entered through the
+            # orchestrator behaves as before.
+            if round_uid is not None and \
+                    msg.context.get("utterance_id") != round_uid:
+                LOG.debug(f"discarding stale fallback pong from '{skill_id}': "
+                          f"utterance_id {msg.context.get('utterance_id')!r} "
+                          f"does not match round {round_uid!r}")
+                return
+            ack_sess = Session.from_message(msg) if "session" in msg.context else None
+            if ack_sess and ack_sess.session_id != round_session_id:
+                LOG.debug(f"discarding cross-session fallback pong from '{skill_id}': "
+                          f"session {ack_sess.session_id!r} does not match "
+                          f"round session {round_session_id!r}")
+                return
+
             if msg.data.get("can_handle", True):
                 if skill_id in in_range:
                     fallback_skills.append(skill_id)

--- a/ovos_core/intent_services/stop_service.py
+++ b/ovos_core/intent_services/stop_service.py
@@ -191,7 +191,13 @@ class StopService(ConfidenceMatcherPipeline):
             error_msg = message.data['error']
             LOG.error(f"{skill_id}: {error_msg}")
         elif message.data.get('result', False):
-            sess = SessionManager.get(message)
+            # incidental write (deactivate_skill/enable/disable_response_mode
+            # elsewhere), no wire echo from this handler and not a lifecycle
+            # entry - resolve via `registry_session_for_write` (mirrors
+            # match_high/match_low's own bypass) so a stale stop.response
+            # snapshot can't clobber a write already on the live registry
+            # entry (see ``_session_fold.py`` module docstring).
+            sess = registry_session_for_write(message)
             utt_state = sess.utterance_states.get(skill_id, UtteranceState.INTENT)
             if utt_state == UtteranceState.RESPONSE:
                 LOG.debug("Forcing get_response timeout")

--- a/ovos_core/intent_services/stop_service.py
+++ b/ovos_core/intent_services/stop_service.py
@@ -7,6 +7,8 @@ from ovos_bus_client.handler import HandlerLifecycle
 from ovos_bus_client.message import Message
 from ovos_bus_client.session import SessionManager, UtteranceState, Session
 
+from ovos_core.intent_services._session_fold import registry_session_for_write
+
 from ovos_config.config import Configuration
 from ovos_plugin_manager.templates.pipeline import ConfidenceMatcherPipeline, IntentHandlerMatch
 from ovos_spec_tools import LocaleResources
@@ -45,18 +47,31 @@ class StopService(ConfidenceMatcherPipeline):
             self.bus.emit(message.reply(f"{skill_id}.stop"))
 
     @staticmethod
-    def get_active_skills(message: Optional[Message] = None) -> List[str]:
+    def get_active_skills(message: Optional[Message] = None,
+                          session: Optional[Session] = None) -> List[str]:
         """Active skill ids ordered by converse priority.
 
         This represents the order in which stop will be called.
 
+        Args:
+            message: bus message to resolve a session from when ``session``
+                     is not already known (standalone/incidental callers).
+            session: an already-resolved session to read from directly -
+                     pass this when called as part of a chain that already
+                     resolved the session once for this handler invocation
+                     (see the fold-order contract on
+                     ``registry_session_for_write``); re-resolving via
+                     ``message`` here would re-fold and can undo a write an
+                     earlier step in the same chain just made.
+
         Returns:
             active_skills (list): ordered list of skill_ids
         """
-        session = SessionManager.get(message)
+        session = session or SessionManager.get(message)
         return [skill[0] for skill in session.active_skills]
 
-    def _collect_stop_skills(self, message: Message) -> List[str]:
+    def _collect_stop_skills(self, message: Message,
+                             session: Optional[Session] = None) -> List[str]:
         """
         Collect skills that can be stopped based on a ping-pong mechanism.
 
@@ -67,6 +82,13 @@ class StopService(ConfidenceMatcherPipeline):
 
         Parameters:
             message (Message): The original message triggering the stop request.
+            session: an already-resolved session to use instead of re-folding
+                     ``message`` (see ``match_high``/``match_low``, which
+                     resolve once via ``registry_session_for_write`` and
+                     thread the result through this call - see the
+                     fold-order contract there). Falls back to a fresh
+                     ``SessionManager.get(message)`` fold for standalone
+                     callers.
 
         Returns:
             List[str]: A list of skill IDs that can be stopped. If no skills explicitly
@@ -78,12 +100,12 @@ class StopService(ConfidenceMatcherPipeline):
             - Waits up to 0.5 seconds for skills to respond
             - Falls back to all active skills if no explicit stop confirmation is received
         """
-        sess = SessionManager.get(message)
+        sess = session or SessionManager.get(message)
 
         want_stop = []
         skill_ids = []
 
-        active_skills = [s for s in self.get_active_skills(message)
+        active_skills = [s for s in self.get_active_skills(message, session=sess)
                          if s not in (sess.blacklisted_skills or [])]
 
         if not active_skills:
@@ -205,19 +227,24 @@ class StopService(ConfidenceMatcherPipeline):
             - Returns None if no stop action could be performed
             - Returns IntentHandlerMatch with handled=True for successful global or skill-specific stop
         """
-        sess = SessionManager.get(message)
+        # incidental write (disable_response_mode below has no wire echo onto
+        # `message`), reached by a `message` shared across every pipeline
+        # stage this turn — see the fold-order contract on
+        # `registry_session_for_write` (mirrors #858's ConverseService case-3
+        # sites, e.g. handle_get_response_disable).
+        sess = registry_session_for_write(message)
 
         # we call flatten in case someone is sending the old style list of tuples
         utterance = flatten_list(utterances)[0]
 
         is_stop = self._locale.voc_match(utterance, 'stop', lang, exact=True)
         is_global_stop = self._locale.voc_match(utterance, 'global_stop', lang, exact=True) or \
-                         (is_stop and not len(self.get_active_skills(message)))
+                         (is_stop and not len(self.get_active_skills(message, session=sess)))
 
         conf = 1.0
 
         if is_global_stop:
-            LOG.info(f"Emitting global stop, {len(self.get_active_skills(message))} active skills")
+            LOG.info(f"Emitting global stop, {len(self.get_active_skills(message, session=sess))} active skills")
             # emit a global stop, full stop anything OVOS is doing
             return IntentHandlerMatch(
                 match_type="stop:global",
@@ -229,7 +256,7 @@ class StopService(ConfidenceMatcherPipeline):
 
         if is_stop:
             # check if any skill can stop
-            for skill_id in self._collect_stop_skills(message):
+            for skill_id in self._collect_stop_skills(message, session=sess):
                 LOG.debug(f"Telling skill to stop: {skill_id}")
                 sess.disable_response_mode(skill_id)
                 self.bus.once(f"{skill_id}.stop.response", self.handle_stop_confirmation)
@@ -297,7 +324,13 @@ class StopService(ConfidenceMatcherPipeline):
             - Handles language-specific vocabulary matching
             - Configurable minimum confidence threshold for stop intent
         """
-        sess = SessionManager.get(message)
+        # incidental write (disable_response_mode below has no wire echo onto
+        # `message`), reached by a `message` shared across every pipeline
+        # stage this turn — see the fold-order contract on
+        # `registry_session_for_write` (mirrors #858's ConverseService case-3
+        # sites, e.g. handle_get_response_disable). Also reached via
+        # match_medium -> match_low with the same message.
+        sess = registry_session_for_write(message)
         # we call flatten in case someone is sending the old style list of tuples
         utterance = flatten_list(utterances)[0]
 
@@ -306,7 +339,7 @@ class StopService(ConfidenceMatcherPipeline):
             return None
 
         conf = match_one(utterance, stop_vocs)[1]
-        if len(self.get_active_skills(message)) > 0:
+        if len(self.get_active_skills(message, session=sess)) > 0:
             conf += 0.1
         conf = round(min(conf, 1.0), 3)
 
@@ -314,7 +347,7 @@ class StopService(ConfidenceMatcherPipeline):
             return None
 
         # check if any skill can stop
-        for skill_id in self._collect_stop_skills(message):
+        for skill_id in self._collect_stop_skills(message, session=sess):
             LOG.debug(f"Telling skill to stop: {skill_id}")
             sess.disable_response_mode(skill_id)
             self.bus.once(f"{skill_id}.stop.response", self.handle_stop_confirmation)
@@ -327,7 +360,7 @@ class StopService(ConfidenceMatcherPipeline):
             )
 
         # emit a global stop, full stop anything OVOS is doing
-        LOG.debug(f"Emitting global stop signal, {len(self.get_active_skills(message))} active skills")
+        LOG.debug(f"Emitting global stop signal, {len(self.get_active_skills(message, session=sess))} active skills")
         return IntentHandlerMatch(
             match_type="stop:global",
             match_data={"conf": conf},

--- a/ovos_core/intent_services/stop_service.py
+++ b/ovos_core/intent_services/stop_service.py
@@ -5,7 +5,7 @@ from typing import Optional, Dict, List, Union
 from ovos_bus_client.client import MessageBusClient
 from ovos_bus_client.handler import HandlerLifecycle
 from ovos_bus_client.message import Message
-from ovos_bus_client.session import SessionManager, UtteranceState
+from ovos_bus_client.session import SessionManager, UtteranceState, Session
 
 from ovos_config.config import Configuration
 from ovos_plugin_manager.templates.pipeline import ConfidenceMatcherPipeline, IntentHandlerMatch
@@ -91,6 +91,13 @@ class StopService(ConfidenceMatcherPipeline):
 
         event = Event()
 
+        # OVOS-CONVERSE-1 §4.2 round correlation: the round IS the utterance
+        # lifecycle, named by context.utterance_id (OVOS-PIPELINE-1 §9.1.1).
+        # The ping carries it by `forward` derivation and the pong carries it
+        # back by `reply` derivation — no skill-side action.
+        round_uid = message.context.get("utterance_id")
+        round_session_id = sess.session_id
+
         def handle_ack(msg: Message) -> None:
             """
             Handle acknowledgment from skills during the stop process.
@@ -107,6 +114,24 @@ class StopService(ConfidenceMatcherPipeline):
             skill_id = msg.data.get("skill_id")
             if not skill_id:
                 return  # guard against malformed pong messages
+
+            # A pong that cannot prove which question it answers never decides a
+            # round: discard pongs from an earlier (or foreign) lifecycle, or
+            # from a foreign session. When the round itself is unnamed the
+            # guard stands down, so a V0 caller that never entered through the
+            # orchestrator behaves as before.
+            if round_uid is not None and \
+                    msg.context.get("utterance_id") != round_uid:
+                LOG.debug(f"discarding stale stop pong from '{skill_id}': "
+                          f"utterance_id {msg.context.get('utterance_id')!r} "
+                          f"does not match round {round_uid!r}")
+                return
+            ack_sess = Session.from_message(msg) if "session" in msg.context else None
+            if ack_sess and ack_sess.session_id != round_session_id:
+                LOG.debug(f"discarding cross-session stop pong from '{skill_id}': "
+                          f"session {ack_sess.session_id!r} does not match "
+                          f"round session {round_session_id!r}")
+                return
 
             # validate the stop pong; default False — a non-responding skill
             # should not be assumed stoppable

--- a/test/unittests/test_fallback_service.py
+++ b/test/unittests/test_fallback_service.py
@@ -315,6 +315,52 @@ class TestCollectFallbackSkills(unittest.TestCase):
         self.assertEqual(result, [])
 
 
+class TestCollectFallbackSkillsFoldOrder(unittest.TestCase):
+    """_collect_fallback_skills has no wire echo of its own (it only reads
+    session state and pings skills) and is not lifecycle entry - it can run
+    mid-turn, after an earlier pipeline stage (e.g. stop_service's
+    disable_response_mode, or a client-declared blacklist applied directly
+    to the live registry entry) already wrote to the live registry entry
+    for this session. A plain `SessionManager.get(message)` fold there would
+    full-replace the live entry with the turn's original (now stale)
+    message snapshot, silently undoing that earlier write."""
+
+    SESSION_ID = "collect-fallback-fold-test-session"
+
+    def setUp(self):
+        SessionManager.sessions.pop(self.SESSION_ID, None)
+
+    def tearDown(self):
+        SessionManager.sessions.pop(self.SESSION_ID, None)
+
+    def test_stale_fold_does_not_clobber_earlier_registry_write(self):
+        live = Session(self.SESSION_ID)
+        SessionManager.sessions[self.SESSION_ID] = live
+
+        # message snapshot frozen at turn entry: no blacklist yet
+        msg = Message("recognizer_loop:utterance",
+                      {"utterances": ["hi"], "lang": "en-US"},
+                      {"session": live.serialize(), "utterance_id": "u1"})
+
+        # an earlier pipeline stage this same turn writes directly onto the
+        # live registry entry (registry-first incidental write, #857/#858
+        # pattern), after the message snapshot above was already frozen
+        SessionManager.sessions[self.SESSION_ID].blacklisted_skills = ["skill_evil"]
+
+        svc = _make_service()
+        svc.bus.emit = MagicMock()
+        svc.bus.on = MagicMock()
+        svc.bus.remove = MagicMock()
+
+        svc._collect_fallback_skills(msg, fb_range=FallbackRange(0, 100))
+
+        self.assertEqual(
+            SessionManager.sessions[self.SESSION_ID].blacklisted_skills,
+            ["skill_evil"],
+            "a stale message fold in _collect_fallback_skills clobbered an "
+            "earlier registry-first write made this same turn")
+
+
 class TestFallbackRoundCorrelation(unittest.TestCase):
     """A pong must prove which round it answers, or it decides nothing."""
 

--- a/test/unittests/test_fallback_service.py
+++ b/test/unittests/test_fallback_service.py
@@ -315,6 +315,111 @@ class TestCollectFallbackSkills(unittest.TestCase):
         self.assertEqual(result, [])
 
 
+class TestFallbackRoundCorrelation(unittest.TestCase):
+    """A pong must prove which round it answers, or it decides nothing."""
+
+    def _run_round(self, svc, ping_msg, pongs, fb_range=None):
+        ack_handler = None
+
+        def capture_on(event, handler):
+            nonlocal ack_handler
+            if event == "ovos.skills.fallback.pong":
+                ack_handler = handler
+
+        svc.bus.on = capture_on
+        svc.bus.remove = MagicMock()
+        svc.bus.emit = MagicMock()
+
+        result_holder = []
+
+        def run():
+            result_holder.append(
+                svc._collect_fallback_skills(ping_msg, fb_range=fb_range))
+
+        t = threading.Thread(target=run)
+        t.start()
+        time.sleep(0.05)
+        for pong in pongs:
+            if ack_handler:
+                ack_handler(pong)
+        t.join(timeout=2)
+        return result_holder[0]
+
+    def test_stale_pong_from_previous_round_is_discarded(self):
+        svc = _make_service()
+        svc.registered_fallbacks = {"skill_a": 50}
+        sess = Session("s")
+
+        round_n = Message("test", {}, {"utterance_id": "round-N",
+                                       "session": sess.serialize()})
+        stale_pong = Message("ovos.skills.fallback.pong",
+                             {"skill_id": "skill_a", "can_handle": True},
+                             {"utterance_id": "round-N-minus-1"})
+
+        with patch("ovos_core.intent_services.fallback_service.SessionManager.get",
+                   return_value=sess):
+            result = self._run_round(svc, round_n, [stale_pong],
+                                     fb_range=FallbackRange(5, 90))
+
+        self.assertEqual(result, [],
+                         "a pong from an earlier lifecycle decided this round")
+
+    def test_cross_session_pong_is_discarded(self):
+        svc = _make_service()
+        svc.registered_fallbacks = {"skill_a": 50}
+        sess = Session("s")
+        other_sess = Session("other")
+
+        round_n = Message("test", {}, {"utterance_id": "round-N",
+                                       "session": sess.serialize()})
+        foreign_pong = Message("ovos.skills.fallback.pong",
+                               {"skill_id": "skill_a", "can_handle": True},
+                               {"utterance_id": "round-N",
+                                "session": other_sess.serialize()})
+
+        with patch("ovos_core.intent_services.fallback_service.SessionManager.get",
+                   return_value=sess):
+            result = self._run_round(svc, round_n, [foreign_pong],
+                                     fb_range=FallbackRange(5, 90))
+
+        self.assertEqual(result, [],
+                         "a pong from a foreign session decided this round")
+
+    def test_matching_pong_is_accepted(self):
+        svc = _make_service()
+        svc.registered_fallbacks = {"skill_a": 50}
+        sess = Session("s")
+
+        round_n = Message("test", {}, {"utterance_id": "round-N",
+                                       "session": sess.serialize()})
+        good_pong = round_n.reply("ovos.skills.fallback.pong",
+                                  {"skill_id": "skill_a", "can_handle": True})
+
+        with patch("ovos_core.intent_services.fallback_service.SessionManager.get",
+                   return_value=sess):
+            result = self._run_round(svc, round_n, [good_pong],
+                                     fb_range=FallbackRange(5, 90))
+
+        self.assertEqual(result, ["skill_a"])
+
+    def test_unnamed_round_accepts_pongs_as_before(self):
+        """V0 compat: a round with no utterance_id keeps the old behaviour."""
+        svc = _make_service()
+        svc.registered_fallbacks = {"skill_a": 50}
+        sess = Session("s")
+
+        round_msg = Message("test", {}, {"session": sess.serialize()})
+        pong = Message("ovos.skills.fallback.pong",
+                       {"skill_id": "skill_a", "can_handle": True})
+
+        with patch("ovos_core.intent_services.fallback_service.SessionManager.get",
+                   return_value=sess):
+            result = self._run_round(svc, round_msg, [pong],
+                                     fb_range=FallbackRange(5, 90))
+
+        self.assertEqual(result, ["skill_a"])
+
+
 class TestFallbackRange(unittest.TestCase):
     """Tests for _fallback_range method."""
 

--- a/test/unittests/test_stop_service.py
+++ b/test/unittests/test_stop_service.py
@@ -469,7 +469,73 @@ class TestFoldOrderRegistryFirstWrite(unittest.TestCase):
                       "elsewhere in this session's lifecycle")
 
 
+class TestHandleStopConfirmationFoldOrder(unittest.TestCase):
+    """handle_stop_confirmation fires asynchronously on a `*.stop.response`
+    reply - it has no wire echo and is not lifecycle entry, so its
+    `SessionManager.get(message)` fold must not be allowed to full-replace
+    the live registry entry with a stale snapshot. A stale snapshot can
+    resurrect a skill's RESPONSE utterance_state and undo `disable_response_mode`
+    writes made earlier in the same session's lifecycle (e.g. by
+    match_high/match_low), which previously caused a bogus
+    `mycroft.skills.abort_question` re-emit and clobbered other incidental
+    registry state (blacklist)."""
+
+    SESSION_ID = "stop-confirmation-fold-test-session"
+
+    def setUp(self):
+        SessionManager.sessions.pop(self.SESSION_ID, None)
+
+    def tearDown(self):
+        SessionManager.sessions.pop(self.SESSION_ID, None)
+
+    def test_stale_fold_does_not_clobber_incidental_registry_write(self):
+        live = Session(self.SESSION_ID)
+        live.activate_skill("skill_a")
+        SessionManager.sessions[self.SESSION_ID] = live
+
+        # message snapshot taken EARLY (stale): skill_a still in RESPONSE mode
+        snap = Session(self.SESSION_ID)
+        snap.activate_skill("skill_a")
+        snap.enable_response_mode("skill_a")
+        msg = Message("skill_a.stop.response",
+                      {"skill_id": "skill_a", "result": True},
+                      {"session": snap.serialize(), "utterance_id": "u1"})
+
+        # meanwhile, an incidental registry-first write landed on the live
+        # entry (what match_high/match_low's disable_response_mode does)
+        SessionManager.sessions[self.SESSION_ID].disable_response_mode("skill_a")
+        SessionManager.sessions[self.SESSION_ID].blacklisted_skills = ["skill_z"]
+
+        svc = _make_service()
+        svc.bus.emit = MagicMock()
+        svc.handle_stop_confirmation(msg)
+
+        live_after = SessionManager.sessions[self.SESSION_ID]
+        self.assertEqual(live_after.blacklisted_skills, ["skill_z"],
+                         "a stale stop.response fold clobbered an incidental "
+                         "registry write (blacklist)")
+        self.assertNotEqual(
+            live_after.utterance_states.get("skill_a"), UtteranceState.RESPONSE,
+            "a stale stop.response fold resurrected skill_a's RESPONSE "
+            "utterance_state that was already disabled on the live registry")
+        emitted = [c[0][0].msg_type for c in svc.bus.emit.call_args_list]
+        self.assertNotIn("mycroft.skills.abort_question", emitted,
+                         "abort_question was re-emitted from resurrected "
+                         "RESPONSE state undone by the stale fold")
+
+
 class TestHandleStopConfirmation(unittest.TestCase):
+
+    def setUp(self):
+        # handle_stop_confirmation now resolves via
+        # `registry_session_for_write`, which prefers a live registry entry
+        # over the (possibly mocked-away) `SessionManager.get` fold - so
+        # stray "s" entries left in the registry by other tests must not
+        # bleed in here.
+        SessionManager.sessions.pop("s", None)
+
+    def tearDown(self):
+        SessionManager.sessions.pop("s", None)
 
     def test_error_in_data_is_logged(self):
         svc = _make_service()
@@ -521,6 +587,15 @@ class TestMatchHigh(unittest.TestCase):
 
     def setUp(self):
         self.svc = _make_service()
+        # match_high resolves via `registry_session_for_write`, and
+        # Session.touch() (called by disable_response_mode/activate_skill
+        # etc.) self-registers the session into the live registry as a side
+        # effect - so a stray "s" entry left by another test class must not
+        # bleed in here, and this test must not leak "s" onward either.
+        SessionManager.sessions.pop("s", None)
+
+    def tearDown(self):
+        SessionManager.sessions.pop("s", None)
 
     def test_no_vocab_returns_none(self):
         """If voc_list is empty for the language, match_high returns None."""
@@ -574,6 +649,12 @@ class TestMatchLow(unittest.TestCase):
 
     def setUp(self):
         self.svc = _make_service()
+        # see TestMatchHigh.setUp - registry-first resolution + touch()'s
+        # self-registration side effect means "s" must be isolated per test.
+        SessionManager.sessions.pop("s", None)
+
+    def tearDown(self):
+        SessionManager.sessions.pop("s", None)
 
     def test_no_voc_list_returns_none(self):
         """If voc_list returns empty, match_low returns None."""
@@ -628,6 +709,14 @@ class TestMatchLow(unittest.TestCase):
 
 
 class TestHandleStopConfirmationExtra(unittest.TestCase):
+
+    def setUp(self):
+        # see TestHandleStopConfirmation.setUp - registry-first resolution
+        # means a stray "s" entry from another test must not bleed in here.
+        SessionManager.sessions.pop("s", None)
+
+    def tearDown(self):
+        SessionManager.sessions.pop("s", None)
 
     def test_converse_force_timeout_emitted_when_skill_active(self):
         """When the skill is still in converse (is_active), force converse timeout."""

--- a/test/unittests/test_stop_service.py
+++ b/test/unittests/test_stop_service.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import threading
+import time
 import unittest
 from unittest.mock import MagicMock, patch, call
 from threading import Event
@@ -270,6 +272,125 @@ class TestCollectStopSkills(unittest.TestCase):
         emitted_types = [c[0][0].msg_type for c in svc.bus.emit.call_args_list]
         self.assertTrue(any("ok_skill" in t for t in emitted_types))
         self.assertFalse(any("bad_skill" in t for t in emitted_types))
+
+
+class TestStopRoundCorrelation(unittest.TestCase):
+    """A pong must prove which round it answers, or it decides nothing."""
+
+    def _session_with_skills(self, skill_ids):
+        sess = Session("test-session")
+        for sid in skill_ids:
+            sess.activate_skill(sid)
+        return sess
+
+    def _run_round(self, svc, ping_msg, pongs):
+        ack_handler = None
+
+        def capture_on(event, handler):
+            nonlocal ack_handler
+            if event == "skill.stop.pong":
+                ack_handler = handler
+
+        svc.bus.on = capture_on
+        svc.bus.remove = MagicMock()
+        svc.bus.emit = MagicMock()
+
+        result_holder = []
+
+        def run():
+            result_holder.append(svc._collect_stop_skills(ping_msg))
+
+        t = threading.Thread(target=run)
+        t.start()
+        time.sleep(0.05)
+        for pong in pongs:
+            if ack_handler:
+                ack_handler(pong)
+        t.join(timeout=2)
+        return result_holder[0]
+
+    def test_stale_pong_from_previous_round_is_discarded(self):
+        """skill_a's stale pong must not count as its answer: skill_b answers
+        validly and is included, skill_a's discarded pong leaves it un-answered
+        (so it is NOT the reason it ends up in the result; want_stop stays
+        non-empty from skill_b alone, proving the fallback-to-all path was not
+        what produced skill_b)."""
+        svc = _make_service()
+        sess = self._session_with_skills(["skill_a", "skill_b"])
+
+        round_n = Message("test", {}, {"utterance_id": "round-N",
+                                       "session": sess.serialize()})
+        stale_pong = Message("skill.stop.pong",
+                             {"skill_id": "skill_a", "can_handle": True},
+                             {"utterance_id": "round-N-minus-1"})
+        good_pong = round_n.reply("skill.stop.pong",
+                                  {"skill_id": "skill_b", "can_handle": True})
+
+        with patch.object(StopService, "get_active_skills",
+                          return_value=["skill_a", "skill_b"]), \
+             patch("ovos_core.intent_services.stop_service.SessionManager.get",
+                   return_value=sess):
+            result = self._run_round(svc, round_n, [stale_pong, good_pong])
+
+        self.assertNotIn("skill_a", result,
+                         "a pong from an earlier lifecycle decided this round")
+        self.assertIn("skill_b", result)
+
+    def test_cross_session_pong_is_discarded(self):
+        svc = _make_service()
+        sess = self._session_with_skills(["skill_a", "skill_b"])
+        other_sess = Session("other")
+
+        round_n = Message("test", {}, {"utterance_id": "round-N",
+                                       "session": sess.serialize()})
+        foreign_pong = Message("skill.stop.pong",
+                               {"skill_id": "skill_a", "can_handle": True},
+                               {"utterance_id": "round-N",
+                                "session": other_sess.serialize()})
+        good_pong = round_n.reply("skill.stop.pong",
+                                  {"skill_id": "skill_b", "can_handle": True})
+
+        with patch.object(StopService, "get_active_skills",
+                          return_value=["skill_a", "skill_b"]), \
+             patch("ovos_core.intent_services.stop_service.SessionManager.get",
+                   return_value=sess):
+            result = self._run_round(svc, round_n, [foreign_pong, good_pong])
+
+        self.assertNotIn("skill_a", result,
+                         "a pong from a foreign session decided this round")
+        self.assertIn("skill_b", result)
+
+    def test_matching_pong_is_accepted(self):
+        svc = _make_service()
+        sess = self._session_with_skills(["skill_a"])
+
+        round_n = Message("test", {}, {"utterance_id": "round-N",
+                                       "session": sess.serialize()})
+        good_pong = round_n.reply("skill.stop.pong",
+                                  {"skill_id": "skill_a", "can_handle": True})
+
+        with patch.object(StopService, "get_active_skills", return_value=["skill_a"]), \
+             patch("ovos_core.intent_services.stop_service.SessionManager.get",
+                   return_value=sess):
+            result = self._run_round(svc, round_n, [good_pong])
+
+        self.assertEqual(result, ["skill_a"])
+
+    def test_unnamed_round_accepts_pongs_as_before(self):
+        """V0 compat: a round with no utterance_id keeps the old behaviour."""
+        svc = _make_service()
+        sess = self._session_with_skills(["skill_a"])
+
+        round_msg = Message("test", {}, {"session": sess.serialize()})
+        pong = Message("skill.stop.pong",
+                       {"skill_id": "skill_a", "can_handle": True})
+
+        with patch.object(StopService, "get_active_skills", return_value=["skill_a"]), \
+             patch("ovos_core.intent_services.stop_service.SessionManager.get",
+                   return_value=sess):
+            result = self._run_round(svc, round_msg, [pong])
+
+        self.assertEqual(result, ["skill_a"])
 
 
 class TestHandleStopConfirmation(unittest.TestCase):

--- a/test/unittests/test_stop_service.py
+++ b/test/unittests/test_stop_service.py
@@ -393,6 +393,82 @@ class TestStopRoundCorrelation(unittest.TestCase):
         self.assertEqual(result, ["skill_a"])
 
 
+class TestFoldOrderRegistryFirstWrite(unittest.TestCase):
+    """match_high / match_low's disable_response_mode write has no wire
+    echo (see #858's fold-order contract). A `message` shared across
+    pipeline stages this turn can carry a STALE session snapshot relative
+    to an incidental write made elsewhere in the live registry entry for
+    this session (e.g. a blacklist declared after the message was built).
+    Using `registry_session_for_write` instead of a plain
+    `SessionManager.get(message)` fold must not let that stale snapshot
+    wipe the live registry state out from under the write.
+    """
+
+    SESSION_ID = "stale-fold-test-session"
+
+    def setUp(self):
+        # isolate from other tests / any real registry state
+        SessionManager.sessions.pop(self.SESSION_ID, None)
+
+    def tearDown(self):
+        SessionManager.sessions.pop(self.SESSION_ID, None)
+
+    def _live_session_with_incidental_write(self):
+        """Simulate a prior incidental write (no wire echo) landing directly
+        on the live registry entry, as `registry_session_for_write` itself
+        would do."""
+        live = Session(self.SESSION_ID)
+        live.activate_skill("skill_a")
+        # incidental write not reflected in any message's own snapshot
+        live.blacklisted_skills = ["other_skill_incidentally_blacklisted"]
+        SessionManager.sessions[self.SESSION_ID] = live
+        return live
+
+    def _stale_message(self):
+        """A message whose embedded session snapshot predates the
+        incidental write above (blacklisted_skills is empty). Built without
+        touching the live registry entry (unlike `Session.activate_skill`,
+        which has registry side effects) - a plain `Session(...)` + manual
+        field set + serialize is enough to model a stale wire snapshot."""
+        stale = Session(self.SESSION_ID)
+        stale.active_skills = [["skill_a", 0.0]]
+        return Message("test", {}, {"session": stale.serialize()})
+
+    def test_match_high_write_survives_stale_message_snapshot(self):
+        svc = _make_service()
+        self._live_session_with_incidental_write()
+        msg = self._stale_message()
+
+        svc._locale.voc_match = MagicMock(side_effect=lambda utt, voc, lang, exact: voc == 'stop')
+        with patch.object(svc, "_collect_stop_skills", return_value=["skill_a"]), \
+             patch.object(svc, "bus") as mock_bus:
+            mock_bus.once = MagicMock()
+            svc.match_high(["stop"], "en-us", msg)
+
+        self.assertIn("other_skill_incidentally_blacklisted",
+                      SessionManager.sessions[self.SESSION_ID].blacklisted_skills,
+                      "a stale message fold wiped an incidental write made "
+                      "elsewhere in this session's lifecycle")
+
+    def test_match_low_write_survives_stale_message_snapshot(self):
+        svc = _make_service()
+        self._live_session_with_incidental_write()
+        msg = self._stale_message()
+
+        svc._locale.voc_list = MagicMock(return_value=["stop"])
+        with patch("ovos_core.intent_services.stop_service.match_one",
+                   return_value=("stop", 1.0)), \
+             patch.object(svc, "_collect_stop_skills", return_value=["skill_a"]), \
+             patch.object(svc, "bus") as mock_bus:
+            mock_bus.once = MagicMock()
+            svc.match_low(["stop"], "en-us", msg)
+
+        self.assertIn("other_skill_incidentally_blacklisted",
+                      SessionManager.sessions[self.SESSION_ID].blacklisted_skills,
+                      "a stale message fold wiped an incidental write made "
+                      "elsewhere in this session's lifecycle")
+
+
 class TestHandleStopConfirmation(unittest.TestCase):
 
     def test_error_in_data_is_logged(self):


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

Closed as superseded. The two write-path defects this PR fixed no longer exist on dev: the STOP-1 rewrite (#802) plus the PreDrainSnapshot refactor key pre-drain state per (session_id, skill_id) and pop it in the confirmation handler, so a stale `.stop.response` can no longer fold an old session over the registry and revive a deactivated skill; session writes now travel exclusively through `Match.updated_session`. The remaining `SessionManager.get(message)` sites in the stop and fallback services are read-only (blacklist and fallback-range filtering), which is exactly the intended use. The round-guard commit this branch carried also landed independently as #862. Nothing here is left to merge.
