### PR TITLE
fix: mutate session intent context under the context lock

### DIFF
--- a/ovos_core/intent_services/service.py
+++ b/ovos_core/intent_services/service.py
@@ -973,44 +973,57 @@ class IntentService:
         entity['key'] = word
         entity['origin'] = origin
         sess = IntentService._registry_session_for_context_write(message)
-        sess.context.inject_context(entity)
-        # Two dialects meet here: ADAPT's munged `skillidkey` spelling and
-        # CONTEXT-1's `skill.id:key` resolved spelling (OVOS-CONTEXT-1 §2/§7)
-        # never coincide, so both entries are written to `session.intent_context`
-        # below. One decay policy, one computed `expires_at`, applied to both
-        # keys (§5): a missing `expires_at` never expires (`is_live()`), so
-        # every entry - including the munged one `inject_context()` already
-        # wrote above - must carry a fresh stamp. A re-set replaces wholesale
-        # and refreshes expiry for both keys; there is no read-back API for a
-        # consumer to notice a stale one (§5.3).
-        context_cfg = Configuration().get('context', {})
-        timeout_s = context_cfg.get('timeout', 2) * 60
-        now = time.time()
-        ctx = dict(sess.intent_context or {})
-        munged_entry = {"value": word or context}
-        expires_at = now + timeout_s if timeout_s > 0 else None
-        if expires_at is not None:
-            munged_entry["expires_at"] = expires_at
-        ctx[context] = munged_entry
-        # The declarative gate resolves a private declaration via
-        # `resolve_key(key, "private", skill_id)` (colon-separated,
-        # unsanitized) - a different spelling than the munged key above.
-        # Write it too, when the producer (ovos-workshop's set_context) names
-        # the original key and a skill_id. Private-scope only: the skill API's
-        # stored key is always skill-prefixed; shared-scope writes are
-        # session-sync territory, not this handler's.
-        key = message.data.get('key')
-        skill_id = message.context.get('skill_id') if message.context else None
-        if key and skill_id:
-            resolved = resolve_key(key, "private", skill_id)
-            if resolved:
-                # Value falls back to the ORIGINAL key, never the munged ADAPT
-                # spelling, which must not leak into §7 slot injection here.
-                resolved_entry = {"value": word or key}
-                if expires_at is not None:
-                    resolved_entry["expires_at"] = expires_at
-                ctx[resolved] = resolved_entry
-        _replace_intent_context(sess, ctx)
+        # Finding 30a: `sess.context.inject_context()` folds its own write
+        # into `intent_context` under `ovos_bus_client.session._CONTEXT_LOCK`
+        # (the same lock guarding `Session.set_intent_context` /
+        # `remove_intent_context`, which a skill's `set_context`/
+        # `remove_context` call reaches concurrently). The copy-modify-assign
+        # below must run in the SAME critical section as that fold, or a
+        # concurrent skill-side write landing between the read and the
+        # reassign is silently clobbered when the stale snapshot is written
+        # back. Holding `_CONTEXT_LOCK` (an `RLock`) across the whole
+        # sequence - including the nested `inject_context()` call and
+        # `_replace_intent_context()`, both of which reacquire it - makes the
+        # read-modify-write atomic with every other locked mutator.
+        with _CONTEXT_LOCK:
+            sess.context.inject_context(entity)
+            # Two dialects meet here: ADAPT's munged `skillidkey` spelling and
+            # CONTEXT-1's `skill.id:key` resolved spelling (OVOS-CONTEXT-1 §2/§7)
+            # never coincide, so both entries are written to `session.intent_context`
+            # below. One decay policy, one computed `expires_at`, applied to both
+            # keys (§5): a missing `expires_at` never expires (`is_live()`), so
+            # every entry - including the munged one `inject_context()` already
+            # wrote above - must carry a fresh stamp. A re-set replaces wholesale
+            # and refreshes expiry for both keys; there is no read-back API for a
+            # consumer to notice a stale one (§5.3).
+            context_cfg = Configuration().get('context', {})
+            timeout_s = context_cfg.get('timeout', 2) * 60
+            now = time.time()
+            ctx = dict(sess.intent_context or {})
+            munged_entry = {"value": word or context}
+            expires_at = now + timeout_s if timeout_s > 0 else None
+            if expires_at is not None:
+                munged_entry["expires_at"] = expires_at
+            ctx[context] = munged_entry
+            # The declarative gate resolves a private declaration via
+            # `resolve_key(key, "private", skill_id)` (colon-separated,
+            # unsanitized) - a different spelling than the munged key above.
+            # Write it too, when the producer (ovos-workshop's set_context) names
+            # the original key and a skill_id. Private-scope only: the skill API's
+            # stored key is always skill-prefixed; shared-scope writes are
+            # session-sync territory, not this handler's.
+            key = message.data.get('key')
+            skill_id = message.context.get('skill_id') if message.context else None
+            if key and skill_id:
+                resolved = resolve_key(key, "private", skill_id)
+                if resolved:
+                    # Value falls back to the ORIGINAL key, never the munged ADAPT
+                    # spelling, which must not leak into §7 slot injection here.
+                    resolved_entry = {"value": word or key}
+                    if expires_at is not None:
+                        resolved_entry["expires_at"] = expires_at
+                    ctx[resolved] = resolved_entry
+            _replace_intent_context(sess, ctx)
 
     @staticmethod
     def handle_remove_context(message: Message):
@@ -1022,28 +1035,36 @@ class IntentService:
         context = message.data.get('context')
         if context:
             sess = IntentService._registry_session_for_context_write(message)
-            sess.context.remove_context(context)
-            # mirror the removal into the OVOS-CONTEXT-1 map (see
-            # `handle_add_context`)
-            ctx = dict(sess.intent_context or {})
-            ctx.pop(context, None)
-            # mirror-remove the resolved private-scope key too, if the
-            # producer named the original key (see `handle_add_context`)
-            key = message.data.get('key')
-            skill_id = message.context.get('skill_id') if message.context else None
-            if key and skill_id:
-                resolved = resolve_key(key, "private", skill_id)
-                if resolved:
-                    ctx.pop(resolved, None)
-            _replace_intent_context(sess, ctx)
+            # Finding 30a: same atomicity requirement as `handle_add_context`
+            # - hold `_CONTEXT_LOCK` across the `remove_context`-style fold
+            # AND the copy-modify-assign below, so a concurrent skill-side
+            # `set_intent_context`/`remove_intent_context` call can't land
+            # between the read and the reassign and get silently clobbered.
+            with _CONTEXT_LOCK:
+                sess.context.remove_context(context)
+                # mirror the removal into the OVOS-CONTEXT-1 map (see
+                # `handle_add_context`)
+                ctx = dict(sess.intent_context or {})
+                ctx.pop(context, None)
+                # mirror-remove the resolved private-scope key too, if the
+                # producer named the original key (see `handle_add_context`)
+                key = message.data.get('key')
+                skill_id = message.context.get('skill_id') if message.context else None
+                if key and skill_id:
+                    resolved = resolve_key(key, "private", skill_id)
+                    if resolved:
+                        ctx.pop(resolved, None)
+                _replace_intent_context(sess, ctx)
 
     @staticmethod
     def handle_clear_context(message: Message):
         """Clears all keywords from context """
         sess = IntentService._registry_session_for_context_write(message)
-        sess.context.clear_context()
-        # mirror the clear into the OVOS-CONTEXT-1 map (see `handle_add_context`)
-        _replace_intent_context(sess, {})
+        # Finding 30a: same atomicity requirement as `handle_add_context`.
+        with _CONTEXT_LOCK:
+            sess.context.clear_context()
+            # mirror the clear into the OVOS-CONTEXT-1 map (see `handle_add_context`)
+            _replace_intent_context(sess, {})
 
     def handle_get_intent(self, message):
         """Get intent from either adapt or padatious.

--- a/test/unittests/test_intent_service.py
+++ b/test/unittests/test_intent_service.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import threading
 import time
 import unittest
 from copy import deepcopy
@@ -19,13 +20,16 @@ from unittest import TestCase, mock
 
 from ovos_bus_client.message import Message
 from ovos_bus_client.session import IntentContextManager as ContextManager
+from ovos_bus_client.session import Session, SessionManager
 from ovos_bus_client.util import get_message_lang
 from ovos_config import Configuration
 from ovos_config import LocalConf, DEFAULT_CONFIG
 from ovos_config.locale import setup_locale
 from ovos_core.intent_services import IntentService
+from ovos_core.intent_services import service as intent_service_module
 from ovos_utils.fakebus import FakeBus
 from ovos_workshop.intents import IntentBuilder
+from ovos_workshop.skills.ovos import OVOSSkill
 
 # Setup configurations to use with default language tests
 BASE_CONF = deepcopy(LocalConf(DEFAULT_CONFIG))
@@ -80,4 +84,94 @@ class TestLanguageExtraction(TestCase):
         self.assertEqual(get_message_lang(msg), 'de-DE')
         msg = Message('test msg', data={'lang': 'sv-se'})
         self.assertEqual(get_message_lang(msg), 'sv-SE')
+
+
+class TestContextWriteLockRace(TestCase):
+    """Finding 30a: `IntentService.handle_add_context` copy-modify-assigns
+    `Session.intent_context` (`ctx = dict(sess.intent_context); ...;
+    sess.intent_context = ctx`) OUTSIDE `ovos_bus_client.session._CONTEXT_LOCK`,
+    while a concurrent skill-side write (`ovos-workshop` >=9.3.13a1's
+    registry-first `set_context`/`remove_context`, calling
+    `Session.set_intent_context`/`remove_intent_context` directly) mutates the
+    SAME map under that lock. If the skill's write lands between core's
+    snapshot read and its write-back, the stale snapshot silently overwrites
+    it - the skill's write is lost with no error and no trace.
+
+    This interleave is sequenced deterministically with `threading.Event`s
+    (no `sleep`-based timing): a patched `resolve_key` - called by
+    `handle_add_context` right after it snapshots `sess.intent_context` and
+    right before it writes the result back - signals readiness and then
+    blocks, giving the "skill" thread a bounded window to run its own
+    registry write before core's write-back proceeds.
+    """
+
+    def setUp(self):
+        self.bus = FakeBus()
+        self.skill = OVOSSkill(bus=self.bus, skill_id="race.skill")
+        self.sess = Session(session_id="s-race-lock-test")
+        SessionManager.update(self.sess)
+        # seed a live layer0 entry, as if an earlier turn set it
+        self.sess.set_intent_context("layer0", "1", scope="private",
+                                     owner_id="race.skill")
+
+    def tearDown(self):
+        SessionManager.sessions.pop("s-race-lock-test", None)
+
+    def test_concurrent_skill_write_survives_core_add_context(self):
+        skill_msg = Message("some.intent", {}, {
+            "skill_id": "race.skill",
+            "session": SessionManager.sessions["s-race-lock-test"].serialize()})
+        # core processing a (possibly stale/duplicate) add_context for the
+        # skill's OWN previously-set key, concurrently with the skill moving
+        # on to a new context layer
+        core_msg = Message("add_context",
+                           {"context": "racskilllayer0", "word": "1",
+                            "key": "layer0"},
+                           {"skill_id": "race.skill",
+                            "session": SessionManager.sessions[
+                                "s-race-lock-test"].serialize()})
+
+        core_ready = threading.Event()
+        skill_done = threading.Event()
+        orig_resolve_key = intent_service_module.resolve_key
+
+        def patched_resolve_key(*args, **kwargs):
+            # fires between `handle_add_context`'s `ctx = dict(...)` snapshot
+            # and its `sess.intent_context = ctx` write-back
+            core_ready.set()
+            skill_done.wait(timeout=5)
+            return orig_resolve_key(*args, **kwargs)
+
+        def skill_turn(triggering_msg):
+            # `triggering_msg` is a positional arg on THIS frame so
+            # `dig_for_message()` (walked internally by
+            # `skill.remove_context`/`set_context`) resolves the right
+            # session - mirroring a real skill handler.
+            self.skill.remove_context("layer0")  # tombstone layer0
+            self.skill.set_context("layer1", "1")
+
+        core_thread = threading.Thread(
+            target=IntentService.handle_add_context, args=(core_msg,))
+        intent_service_module.resolve_key = patched_resolve_key
+        try:
+            core_thread.start()
+            self.assertTrue(core_ready.wait(timeout=5),
+                            "core thread never reached the snapshot window")
+            skill_turn(skill_msg)
+            skill_done.set()
+            core_thread.join(timeout=5)
+            self.assertFalse(core_thread.is_alive(),
+                             "core thread did not finish")
+        finally:
+            intent_service_module.resolve_key = orig_resolve_key
+
+        final_ctx = SessionManager.sessions["s-race-lock-test"].intent_context
+        # the skill's new write (layer1) must not be silently dropped
+        self.assertIn("race.skill:layer1", final_ctx)
+        self.assertEqual(final_ctx["race.skill:layer1"]["value"], "1")
+        # the skill's tombstone (layer0 removal), applied after core's
+        # write-back completed (it was blocked on `_CONTEXT_LOCK` until
+        # then), must stick - not be silently un-done by a leftover stale
+        # snapshot
+        self.assertIsNone(final_ctx.get("race.skill:layer0"))
 


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

The context handlers built a copy of the session's context map, modified it, and assigned it back — all without taking the lock that the session's own context methods use. Since skills started writing context into the session directly (workshop#535), a skill write landing in that window was silently thrown away: the reproducer loses both a layer removal and the following layer's activation, which wedges intent layers.

The fix wraps the read-modify-write in the same lock. No behavior change beyond atomicity.

The new regression test sequences the two writers deterministically with events (no sleeps); it fails on the unfixed code with the skill's write missing, and passes with the lock. Full unit suite: 343 passed.
