### PR TITLE
fix: update stale legacy-dispatch e2e golden to the current bridge contract

### DIFF
--- a/test/end2end/test_intent_alias_backcompat.py
+++ b/test/end2end/test_intent_alias_backcompat.py
@@ -1,6 +1,7 @@
 """End-to-end back-compat coverage for the INTENT-4 register-time alias
-collapse (ovos-padatious 2.0.1a1 / padacioso 2.2.2a1) and workshop dual-bind
-(ovos-workshop 9.3.2a1, see ovos-workshop#497).
+collapse (ovos-padatious 2.0.1a1 / padacioso 2.2.2a1) and the canonical <->
+legacy intent DISPATCH topic bridge (``ovos_spec_tools.intent_topics``,
+carried by ``ovos-utils`` >= 0.13.10a1 and ``ovos-bus-client``).
 
 ``test_padatious.py`` now asserts the pipeline reports the CANONICAL
 suffix-less intent id (``<skill_id>:<file>``) on the wire. That is correct per
@@ -14,10 +15,17 @@ migration window — still function. This file closes that gap:
   match time — see ``_canonicalize_blacklist`` in ``ovos_padatious.opm``) and
   must log a one-time deprecation warning pointing at the canonical
   replacement.
-- ``test_legacy_dispatch_topic_fires_handler``: emitting the legacy
-  ``<skill_id>:<file>.intent`` bus topic directly still fires the skill
-  handler, because ``register_intent_file`` binds both the legacy and
-  canonical names (ovos_workshop.skills.ovos.OVOSSkill.register_intent_file).
+- ``test_legacy_dispatch_topic_fires_handler``: current ``ovos-workshop``
+  (>= 9.3.11a2) registers a skill's intent handler on the CANONICAL dispatch
+  topic only — it no longer dual-binds both spellings. What now reaches a
+  handler from a legacy ``.intent``-suffixed emission is the bus's own
+  receive-side bridge: a ``FakeBus``/``MessageBusClient`` with the namespace
+  ``modernize`` flag on re-dispatches any suffixed intent topic it sees onto
+  its canonical twin (RULE 2 in ``FakeBus._bridge_intent_topic`` /
+  ``MessageBusClient._modernize_intent_topic``). With ``modernize`` off — the
+  "spec" namespace below — that bridge does not run, and OVOS-PIPELINE-1 §4
+  only obliges a canonical-only skill to listen on the canonical topic, so a
+  raw legacy-suffixed emission is expected to reach nobody.
 
 Both are exercised on both bus namespaces (spec / legacy), matching the
 parametrization style of ``test_padatious.py``.
@@ -133,53 +141,104 @@ class TestLegacyIntentIdBackCompat(TestCase):
 
             # LEGACY dispatch: bypass intent matching entirely and emit
             # directly on the pre-INTENT-4 `<skill_id>:<file>.intent` topic.
-            # ovos_workshop.skills.ovos.OVOSSkill.register_intent_file binds
-            # the skill handler under BOTH the legacy and canonical names
-            # (ovos-workshop#497), so this must still fire the handler.
+            # Current ovos-workshop registers the skill handler on the
+            # CANONICAL topic ONLY (no dual-bind). Whether this legacy
+            # emission still reaches the handler depends entirely on the
+            # bus's own receive-side bridge (RULE 2), which only runs when
+            # the bus's namespace ``modernize`` flag is on.
             legacy_intent_topic = f"{self.skill_id}:Greetings.intent"
             message = Message(legacy_intent_topic,
                               {"utterance": "good morning", "lang": session.lang},
                               {"session": session.serialize(), "source": "A", "destination": "B"})
 
-            test = End2EndTest(
-                minicroft=minicroft,
-                skill_ids=[self.skill_id],
-                # a raw direct injection on the legacy intent topic (bypassing
-                # the orchestrator/pipeline entirely) does not flip
-                # source/destination the way a routed utterance->dispatch
-                # cycle does, so no flip/entry points are declared here — the
-                # generic source/destination routing check then compares
-                # every message against the injected message's own (A, B),
-                # which is what a raw dual-bound handler dispatch preserves.
-                ignore_messages=["recognizer_loop:audio_output_start",
-                                  "recognizer_loop:audio_output_end"],
-                # a raw dispatch is not an utterance: the orchestrator never
-                # ran, so it emits no PIPELINE-1 §9.5 ``ovos.utterance.handled``
-                # end-marker (ovoscope's default). The workshop done-signal is
-                # the terminal message of this scenario.
-                eof_msgs=["mycroft.skill.handler.complete"],
-                source_message=message,
-                final_session=session,
-                expected_messages=[
-                    message,
-                    Message("mycroft.skill.handler.start",
-                            data={"name": "HelloWorldSkill.handle_greetings"},
-                            context={"skill_id": self.skill_id}),
-                    Message(SPEC_SPEAK,
-                            data={"expect_response": False,
-                                  "meta": {
-                                      "dialog": "hello",
-                                      "data": {},
-                                      "skill": self.skill_id
-                                  }},
-                            context={"skill_id": self.skill_id}),
-                    Message("mycroft.skill.handler.complete",
-                            data={"name": "HelloWorldSkill.handle_greetings"},
-                            context={"skill_id": self.skill_id}),
+            if modernize:
+                # "legacy" namespace: modernize is on, so FakeBus/RULE 2
+                # re-dispatches this suffixed frame onto its canonical twin
+                # and the canonical-bound handler fires.
+                test = End2EndTest(
+                    minicroft=minicroft,
+                    skill_ids=[self.skill_id],
+                    # a raw direct injection on the legacy intent topic
+                    # (bypassing the orchestrator/pipeline entirely) does not
+                    # flip source/destination the way a routed
+                    # utterance->dispatch cycle does, so no flip/entry points
+                    # are declared here — the generic source/destination
+                    # routing check then compares every message against the
+                    # injected message's own (A, B), which is what a raw
+                    # bridged dispatch preserves.
+                    ignore_messages=["recognizer_loop:audio_output_start",
+                                      "recognizer_loop:audio_output_end"],
+                    # a raw dispatch is not an utterance: the orchestrator
+                    # never ran, so it emits no PIPELINE-1 §9.5
+                    # ``ovos.utterance.handled`` end-marker (ovoscope's
+                    # default). The workshop done-signal is the terminal
+                    # message of this scenario.
+                    eof_msgs=["mycroft.skill.handler.complete"],
+                    source_message=message,
+                    final_session=session,
+                    expected_messages=[
+                        message,
+                        Message("mycroft.skill.handler.start",
+                                data={"name": "HelloWorldSkill.handle_greetings"},
+                                context={"skill_id": self.skill_id}),
+                        Message(SPEC_SPEAK,
+                                data={"expect_response": False,
+                                      "meta": {
+                                          "dialog": "hello",
+                                          "data": {},
+                                          "skill": self.skill_id
+                                      }},
+                                context={"skill_id": self.skill_id}),
+                        Message("mycroft.skill.handler.complete",
+                                data={"name": "HelloWorldSkill.handle_greetings"},
+                                context={"skill_id": self.skill_id}),
+                    ]
+                )
+                test.execute(timeout=10)
+            else:
+                # "spec" namespace: modernize is off, so RULE 2 never runs.
+                # The skill is bound canonical-only, so nobody is listening on
+                # the raw legacy-suffixed topic — the emission reaches no
+                # handler at all. Assert that precisely: capture the full
+                # message stream for a bounded window and require it to be
+                # EMPTY of any handler-lifecycle or speak message, not just
+                # "no crash before a timeout". FakeBus.emit() dispatches
+                # synchronously, so by the time bus.emit() returns any local
+                # (would-be) listener has already had its chance to run — a
+                # short settle sleep only guards against handler code that
+                # itself hands off to another thread, which the hello-world
+                # skill's handler does not, but keeps the assertion honest
+                # under a stricter build too.
+                captured = []
+                bus = minicroft.bus
+                capture_types = [
+                    "mycroft.skill.handler.start",
+                    "mycroft.skill.handler.complete",
+                    "mycroft.skill.handler.error",
+                    SPEC_SPEAK,
+                    "speak",
                 ]
-            )
 
-            test.execute(timeout=10)
+                def _capture(msg, _t=None):
+                    captured.append(msg)
+
+                for t in capture_types:
+                    bus.on(t, _capture)
+                try:
+                    bus.emit(message)
+                    from time import sleep
+                    sleep(0.5)
+                finally:
+                    for t in capture_types:
+                        bus.remove(t, _capture)
+
+                self.assertEqual(
+                    captured, [],
+                    "modernize=False must not bridge a raw legacy-suffixed "
+                    f"dispatch to the canonical-only handler, but observed: "
+                    f"{[m.msg_type for m in captured]}"
+                )
+
         finally:
             minicroft.stop()
 


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

test_legacy_dispatch_topic_fires_handler was asserting on a stale premise: its comments cited ovos-workshop#497, where a skill would bind its intent handler under both the canonical topic and the old `.intent`-suffixed one. That dual-bind is gone in current workshop (>= 9.3.11a2), which registers canonical-only, so the old test was failing on dev because nothing binds the legacy topic anymore.

What actually keeps a legacy-suffixed emission working today is the bus itself, not the skill. FakeBus (and MessageBusClient) carry a receive-side bridge that re-dispatches a `.intent`-suffixed frame onto its canonical twin, but only when the bus's `modernize` namespace flag is on. That bridge landed in ovos-utils 0.13.10a1, which is already published on PyPI, so this branch pins against it directly rather than a git ref.

The rewritten test exercises both namespaces on that real contract: with modernize on ("legacy" namespace) the bridge fires and the handler dispatch is asserted exactly as before; with modernize off ("spec" namespace) the raw legacy emission reaches a canonical-only skill nobody, and the test now asserts that precisely — captures the bus stream for a bounded window and requires it to contain zero handler-lifecycle or speak messages, rather than just timing out. The sibling blacklist test's premise (engine-side canonicalization of a legacy blacklist id) was checked and is not stale, so it is untouched.

Ran the file directly (both namespaces pass, 4 subtests) and the full test/end2end/ suite in a fresh uv venv against ovos-utils 0.13.10a1 from PyPI: 37 passed, 48 subtests passed, no unrelated failures. The existing `ovos-utils>=0.13.9a1,<1.0.0` floor in pyproject.toml already covers 0.13.10a1, so no floor bump was needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Legacy topic messages are now delivered to handlers only when the modernization option is enabled.
  - Prevented legacy messages from reaching handlers when modernization is disabled.

- **Documentation**
  - Updated compatibility guidance to clarify receive-side bridging behavior and configuration expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->