### PR TITLE
docs: rewrite review-campaign comment narration as plain invariants

### DIFF
--- a/ovos_core/intent_services/converse_service.py
+++ b/ovos_core/intent_services/converse_service.py
@@ -63,10 +63,8 @@ class ConverseService(PipelinePlugin):
         def _resolve_complete(msg: Message) -> None:
             if msg.data.get("skill_id") and msg.data.get("skill_id") != skill_id:
                 return  # ack from a different skill, ignore
-            # peek at the ack's session id WITHOUT folding its snapshot onto
-            # the live session — the ack still carries the pre-dispatch
-            # snapshot, and folding it would clobber any change the converse
-            # handler made to the live session (e.g. deactivating itself)
+            # no fold here; see IntentService._registry_session_for_context_write
+            # (SESSION-2 §2.6) — only peek at the ack's session id.
             ack_sess = Session.from_message(msg) if "session" in msg.context else None
             if ack_sess and ack_sess.session_id != session_id:
                 return  # ack from a different session, ignore

--- a/ovos_core/intent_services/service.py
+++ b/ovos_core/intent_services/service.py
@@ -402,13 +402,10 @@ class IntentService:
         emit their own end-marker inline; together they give exactly one per
         utterance."""
         msg = dispatch_msg.forward(SpecMessage.UTTERANCE_HANDLED, {})
-        # the dispatch message's session snapshot predates the handler run, and
-        # messages the handler itself emitted (e.g. the framework done-signal)
-        # carry that same stale snapshot — each inbound fold is last-writer-wins,
-        # so a skill that deactivated itself mid-handler gets re-activated by
-        # its own ack. Re-apply the tracked deactivations to the live session
-        # and stamp it on the end-marker so the utterance terminates with the
-        # session state the handler actually requested.
+        # no fold here; see _registry_session_for_context_write (SESSION-2 §2.6).
+        # Re-apply the tracked deactivations to the live session and stamp it
+        # on the end-marker so the utterance terminates with the state the
+        # handler actually requested, not the dispatch message's stale snapshot.
         sid = (dispatch_msg.context.get("session") or {}).get("session_id")
         live = SessionManager.sessions.get(sid) if sid else None
         if live is not None:
@@ -529,12 +526,10 @@ class IntentService:
         Runs the intent-transformer chain, skill activation, session update,
         the OVOS-CONTEXT-1 §4.2 decrement, and ``context['pipeline_id']``
         stamping (§7.1); emits §9.2 ``ovos.intent.matched``; hands the
-        dispatch Message to the IntentDispatcher (§7/§8).
-
-        # OVOS-CONTEXT-1 §4.2: the decrement must run before the dispatch is
-        # put on the bus — a skill's ``SessionManager.get(message)`` fold
-        # would otherwise re-stamp the pre-decrement snapshot onto the
-        # registry, and every later terminal would carry the stale map.
+        dispatch Message to the IntentDispatcher (§7/§8). The §4.2 decrement
+        must run before the dispatch is put on the bus, or a later fold (see
+        _registry_session_for_context_write, SESSION-2 §2.6) would re-stamp
+        the pre-decrement map onto the registry.
 
         Args:
             match (IntentHandlerMatch): The matched intent (utterance, match_type,
@@ -552,8 +547,7 @@ class IntentService:
             LOG.exception("_dispatch_match failed")
 
         reply = None
-        # not SessionManager.get(message): that would fold back the stale
-        # pre-round snapshot and erase a mid-round sync (SESSION-1)
+        # no fold here; see _registry_session_for_context_write (SESSION-2 §2.6).
         sid = (message.context.get("session") or {}).get("session_id")
         sess = (match.updated_session
                 or (sid and SessionManager.sessions.get(sid))
@@ -938,28 +932,18 @@ class IntentService:
     def _registry_session_for_context_write(message: Message) -> "Session":
         """Resolve the session object to mutate for an in-lifecycle context write.
 
-        Wave-3 CONFIRMED (round 4): ``SessionManager.get(message)`` always folds
-        the incoming message's session onto the live registry entry
-        (``SessionManager._store``), and for NAMED sessions that fold is
-        full-replace (``update_from``). Calling it from a context handler means
-        the fold first wipes the registry entry's ``intent_context`` with the
-        message's stale snapshot, then every subsequent mid-lifecycle frame
-        (skill replies, follow-up handler frames) re-wipes it again - a named
-        session's context can never survive to the terminal event. SESSION-2
-        §2.6 is unambiguous: folding a message's session onto the working
-        session belongs at lifecycle entry only; incidental messages must never
-        mutate it. This is not a named-session-only defect: ``update_from``
-        round-trips through full serialize/deserialize for every session id,
-        including ``"default"`` - a stale default-session snapshot arriving
-        on an incidental message wipes the device-local default session's
-        context exactly the same way. The registry-first fix below is load-
-        bearing for the default session too, not only named ones.
+        FOLD LAW: a message's session snapshot folds onto the live registry
+        session only at lifecycle entry; an incidental message arriving
+        mid-lifecycle (a skill reply, a follow-up handler frame) must never
+        fold its stale snapshot onto the registry, or it silently overwrites
+        whatever the registry has accumulated since — including named-session
+        ``update_from`` full-replaces and the same-shaped bug on the
+        ``"default"`` session. Writes belong on the registry session object
+        itself, never on a fresh fold of the message. See SESSION-2 §2.6.
 
-        Fix (this handler's scope only - the general fold-discipline at every
-        ``get(message)`` call site is a tracked follow-up): resolve the
-        session_id off the message and, if the registry already holds a live
-        entry for it, mutate that object directly - no fold. Fall back to
-        ``SessionManager.get(message)`` (today's behavior) only when no
+        This resolves the session_id off the message and, if the registry
+        already holds a live entry for it, returns that object directly - no
+        fold. Falls back to ``SessionManager.get(message)`` only when no
         registry entry exists yet, e.g. out-of-registry/test callers.
         """
         session_data = message.context.get("session") if message and message.context else None
@@ -990,35 +974,15 @@ class IntentService:
         entity['origin'] = origin
         sess = IntentService._registry_session_for_context_write(message)
         sess.context.inject_context(entity)
-        # OVOS-CONTEXT-1 §2/§7: pipelines gate and inject from the canonical
-        # `session.intent_context` map, so a keyword added via `set_context`
-        # must land there too or it never reaches matching. Entries are
-        # keyed by the context token and carry its injected value.
-        #
-        # Round 3 (wave-3 live lead): `sess.context.inject_context()` above
-        # (the legacy `_IntentContextView`, ovos-bus-client) already folded
-        # its own write into `session.intent_context[context]`, stamping
-        # `expires_at = now + timeout` using the adapt `context.timeout`
-        # config convention (`Configuration()["context"]["timeout"]`,
-        # minutes, default 2 -> 120s). The plain-dict overwrite that used to
-        # follow here (`ctx[context] = {"value": ...}`) clobbered that stamp
-        # two lines later - the pre-existing dev "immortal context entries"
-        # bug: `ovos_spec_tools.context.is_live()` treats a missing
-        # `expires_at` as never-expiring, so `prune()` could never reap
-        # these entries. OVOS-CONTEXT-1 sides against that: legacy-sourced
-        # entries carry decay; immortality is reserved for deliberate
-        # writers, which the skill API is not.
-        #
-        # Round 5 (C1): a re-set of the same context key is a wholesale
-        # replace, not a merge (OVOS-CONTEXT-1 §5) - there is no read-back
-        # API for consumers to notice a stale expiry (§5.3). Every re-set
-        # must refresh `expires_at` unconditionally, same as
-        # `inject_context()` above does for the munged key. Preserving a
-        # prior stamp here (reading it back off `ctx`) let this key and the
-        # resolved private key below drift out of sync: a skill re-calling
-        # `set_context` kept the adapt entry alive while the resolved entry
-        # kept dying at its original expiry. One decay policy, computed
-        # once, applied to both keys.
+        # Two dialects meet here: ADAPT's munged `skillidkey` spelling and
+        # CONTEXT-1's `skill.id:key` resolved spelling (OVOS-CONTEXT-1 §2/§7)
+        # never coincide, so both entries are written to `session.intent_context`
+        # below. One decay policy, one computed `expires_at`, applied to both
+        # keys (§5): a missing `expires_at` never expires (`is_live()`), so
+        # every entry - including the munged one `inject_context()` already
+        # wrote above - must carry a fresh stamp. A re-set replaces wholesale
+        # and refreshes expiry for both keys; there is no read-back API for a
+        # consumer to notice a stale one (§5.3).
         context_cfg = Configuration().get('context', {})
         timeout_s = context_cfg.get('timeout', 2) * 60
         now = time.time()
@@ -1028,36 +992,20 @@ class IntentService:
         if expires_at is not None:
             munged_entry["expires_at"] = expires_at
         ctx[context] = munged_entry
-        # Two dialects meet here: legacy ADAPT context is stored under the
-        # producer's munged `alphanumeric_skill_id + key` spelling (above),
-        # while the declarative OVOS-CONTEXT-1 gate resolves a private
-        # declaration to `resolve_key(key, "private", skill_id)` (colon
-        # separated, unsanitized) - the two never coincide. When the
-        # producer (ovos-workshop's set_context) names the original,
-        # unmunged key via `data["key"]` and the message carries a
-        # skill_id, also write the resolved private-scope entry so the
-        # gate becomes reachable. The skill API is private-scope by
-        # construction (its stored key is always skill-prefixed); shared-
-        # scope writes are session-sync territory, not this handler's.
+        # The declarative gate resolves a private declaration via
+        # `resolve_key(key, "private", skill_id)` (colon-separated,
+        # unsanitized) - a different spelling than the munged key above.
+        # Write it too, when the producer (ovos-workshop's set_context) names
+        # the original key and a skill_id. Private-scope only: the skill API's
+        # stored key is always skill-prefixed; shared-scope writes are
+        # session-sync territory, not this handler's.
         key = message.data.get('key')
         skill_id = message.context.get('skill_id') if message.context else None
         if key and skill_id:
             resolved = resolve_key(key, "private", skill_id)
             if resolved:
-                # Round 2 (C3): the fallback value must be the ORIGINAL key,
-                # not the munged legacy context string - the munged spelling
-                # is an internal wire detail of the ADAPT dialect and must
-                # never leak into OVOS-CONTEXT-1 §7 slot injection via this
-                # (declarative-gate) entry.
-                # Round 5 (C1): stamp the SAME `expires_at` computed above
-                # for the munged key, unconditionally, on every re-set - no
-                # setdefault-style preservation of a prior write's expiry.
-                # Preserving it here was the bug: it let this resolved key
-                # keep dying at the FIRST write's expiry while the munged
-                # key above kept getting refreshed by `inject_context()`,
-                # so the declarative gate could close while the legacy
-                # adapt context was still alive (or vice versa). One decay
-                # policy, one computed `expires_at`, both keys.
+                # Value falls back to the ORIGINAL key, never the munged ADAPT
+                # spelling, which must not leak into §7 slot injection here.
                 resolved_entry = {"value": word or key}
                 if expires_at is not None:
                     resolved_entry["expires_at"] = expires_at

--- a/ovos_core/intent_services/stop_service.py
+++ b/ovos_core/intent_services/stop_service.py
@@ -1,6 +1,6 @@
 from os.path import dirname, join
 from threading import Event
-from typing import Optional, Dict, List, Union
+from typing import Optional, Dict, List, NamedTuple, Union
 
 from ovos_bus_client.client import MessageBusClient
 from ovos_bus_client.handler import HandlerLifecycle
@@ -16,6 +16,19 @@ from ovos_utils.log import LOG
 from ovos_utils.parse import match_one
 
 from ovos_core.intent_services.stop_service_legacy import _LegacyStopBridge
+
+
+class PreDrainSnapshot(NamedTuple):
+    """State a targeted stop observed before match() drained the session copy.
+
+    ``match()`` drains ``active_handlers``/``response_mode`` before dispatch,
+    so by the time ``.stop.response`` arrives the live session already lies
+    about both fields. Capture them together at drain time, keyed by
+    ``(session_id, skill_id)``, and pop them together in
+    ``handle_stop_confirmation`` before either result branch runs.
+    """
+    was_active: bool
+    utt_state: UtteranceState
 
 
 class StopService(ConfidenceMatcherPipeline):
@@ -54,24 +67,11 @@ class StopService(ConfidenceMatcherPipeline):
         # §5 global-stop dispatch target; bound once, shared across tiers (§3.1).
         self.bus.on(f"{self.pipeline_id}:global_stop", self.handle_global_stop)
         self._legacy = _LegacyStopBridge(self)
-        #: (session_id, skill_id) -> was the skill active BEFORE match() drained
-        #: the session copy (CONFIRMED-2: the session ``handle_stop_confirmation``
-        #: reads back off the ``.stop.response`` message context is already
-        #: drained by dispatch time, so ``sess.is_active(skill_id)`` there is
-        #: always False; this records the pre-drain truth match() observed
-        #: instead). Keyed by ``(session_id, skill_id)`` rather than bare
-        #: ``skill_id`` — two concurrent targeted stops for the same skill_id
-        #: in different sessions must not clobber/consume each other's snapshot.
-        self._was_active_pre_drain: Dict[tuple, bool] = {}
-        #: (session_id, skill_id) -> its UtteranceState BEFORE match() drained
-        #: the session copy (same drain-ordering class as
-        #: ``_was_active_pre_drain``, including the same per-session keying —
-        #: ``handle_stop_confirmation`` reads ``sess.utterance_states`` off the
-        #: ``.stop.response`` message context, which is already drained —
-        #: ``disable_response_mode`` runs before dispatch — by the time it
-        #: arrives, so the live read is always UtteranceState.INTENT there and
-        #: the RESPONSE branch/``abort_question`` emission was unreachable).
-        self._utt_state_pre_drain: Dict[tuple, UtteranceState] = {}
+        #: (session_id, skill_id) -> PreDrainSnapshot captured by _targeted_stop
+        #: and consumed once by handle_stop_confirmation. Keyed per-session
+        #: (not bare skill_id) so two concurrent targeted stops for the same
+        #: skill_id in different sessions can't clobber each other's snapshot.
+        self._pre_drain: Dict[tuple, PreDrainSnapshot] = {}
 
     def handle_global_stop(self, message: Message) -> None:
         """OVOS-STOP-1 §5.3 — broadcast the universal ``ovos.stop``.
@@ -242,43 +242,26 @@ class StopService(ConfidenceMatcherPipeline):
         """Handle a skill's stop.response and force-terminate any in-flight interactions.
 
         Also resolves the ``IntentDispatcher``'s §8 handler-lifecycle entry for
-        this ``<skill_id>:stop`` dispatch (root cause: the dispatch goes out on
-        the spec colon-topic ``<skill_id>:stop``, which ovos-workshop has no
-        direct listener for — only ``_LegacyStopBridge`` mirrors it onto the
-        dot-topic ``<skill_id>.stop`` skills actually bind, via ``add_event``
-        with ``handler_info=None``, which deliberately disables that dot-topic
-        handler's own ``HandlerLifecycle``/``mycroft.skill.handler.complete``
-        emission. Since workshop is a separate repo/release, that emission
-        cannot be added there for this fix. The stop round-trip's real
-        completion signal IS this ``.stop.response`` — it only fires once the
-        skill has actually finished ``stop()`` — so this is the correct,
-        already-synchronous point to resolve the dispatch, instead of leaving
-        it parked on the dispatcher's 5-minute §8.3 timeout). Emitting the
-        framework done-signal here (rather than reaching into
-        ``IntentDispatcher`` directly) keeps ``StopService`` decoupled from the
-        dispatcher's internals and mirrors exactly what a normal handler
-        completion looks like on the bus.
+        this ``<skill_id>:stop`` dispatch: the dispatch goes out on the spec
+        colon-topic ``<skill_id>:stop``, which ovos-workshop has no direct
+        listener for, so nothing else emits the normal completion signal for
+        it. This ``.stop.response`` is the real completion signal — it only
+        fires once ``stop()`` has actually finished — so it is the correct
+        point to resolve the dispatch, instead of leaving it parked on the
+        dispatcher's 5-minute §8.3 timeout. Emitting the framework done-signal
+        here, rather than reaching into ``IntentDispatcher`` directly, keeps
+        ``StopService`` decoupled from the dispatcher's internals.
         """
         skill_id = (message.data.get("skill_id") or
                     message.context.get("skill_id") or
                     message.msg_type.split(".stop.response")[0])
         sess_id = (message.context.get("session") or {}).get("session_id", "default")
-        # F2 (round-3 adversarial re-review of 6e8c8163be): the pre-drain
-        # snapshots used to be popped ONLY on the result:True branch below —
-        # every error / result:False / never-actually-dispatched stop left
-        # (session_id, skill_id) in BOTH dicts forever (confirmed: 50 failed
-        # stops -> 50 leaked keys, attack5.py). That also kept the
-        # _resolve_dispatch_lifecycle gate permanently open for that pair,
-        # since the gate is presence-based. Pop both dicts UNCONDITIONALLY,
-        # right here, before either branch runs, and thread the popped
-        # values through — this is now both the memory-leak fix and the
-        # single place the gate (and the RESPONSE/active fallbacks below)
-        # consult.
-        utt_state = self._utt_state_pre_drain.pop((sess_id, skill_id), None)
-        was_active = self._was_active_pre_drain.pop((sess_id, skill_id), None)
-        had_pre_drain_snapshot = utt_state is not None or was_active is not None
+        # Pop both snapshots unconditionally before either branch below: the
+        # error/no-dispatch paths must not leak them or hold the
+        # _resolve_dispatch_lifecycle gate open for this (session_id, skill_id).
+        snapshot = self._pre_drain.pop((sess_id, skill_id), None)
         try:
-            if had_pre_drain_snapshot:
+            if snapshot is not None:
                 self._resolve_dispatch_lifecycle(message, skill_id)
         except Exception:
             LOG.exception(f"failed to resolve dispatch lifecycle for {skill_id}:stop")
@@ -287,30 +270,17 @@ class StopService(ConfidenceMatcherPipeline):
             LOG.error(f"{skill_id}: {error_msg}")
         elif message.data.get('result', False):
             sess = SessionManager.get(message)
-            # CONFIRMED-4: same drain-ordering class as CONFIRMED-2 below —
-            # by the time this .stop.response arrives, `sess.utterance_states`
-            # is already drained (disable_response_mode runs before dispatch
-            # in _targeted_stop), so the live read is always
-            # UtteranceState.INTENT here and this RESPONSE branch was
-            # unreachable dead code (abort_question never fired even though
-            # the skill was genuinely blocked in get_response). Consult the
-            # pre-drain snapshot (popped above) instead, falling back to the
-            # live read for direct-invocation callers that bypass
-            # _targeted_stop.
-            if utt_state is None:
-                utt_state = sess.utterance_states.get(skill_id, UtteranceState.INTENT)
+            # The session on this .stop.response is already post-drain, so
+            # live reads of utterance_states/active_handlers lie; consult the
+            # pre-drain snapshot popped above, falling back to the live read
+            # for direct-invocation callers that bypass _targeted_stop.
+            utt_state = snapshot.utt_state if snapshot else sess.utterance_states.get(
+                skill_id, UtteranceState.INTENT)
             if utt_state == UtteranceState.RESPONSE:
                 LOG.debug("Forcing get_response timeout")
                 # force-kill any ongoing get_response - see @killable_event decorator (ovos-workshop)
                 self.bus.emit(message.reply("mycroft.skills.abort_question", {"skill_id": skill_id}))
-            # CONFIRMED-2: by the time this .stop.response arrives, `sess` has
-            # already been drained (the dispatch carried the post-drain session
-            # forward), so `sess.is_active(skill_id)` is always False here.
-            # Fall back to it only when no pre-drain record exists (e.g. a
-            # handler invoked directly, bypassing _targeted_stop) so existing
-            # direct-invocation callers keep working.
-            if was_active is None:
-                was_active = sess.is_active(skill_id)
+            was_active = snapshot.was_active if snapshot else sess.is_active(skill_id)
             if was_active:
                 LOG.debug("Forcing converse timeout")
                 # force-kill any ongoing converse - see @killable_event decorator (ovos-workshop)
@@ -330,43 +300,19 @@ class StopService(ConfidenceMatcherPipeline):
 
         ``IntentDispatcher._on_skill_complete``/``._on_skill_error`` listen for
         exactly these topics and resolve the matching in-flight entry (by
-        session_id + skill_id + ``data["intent_name"]``), cancelling its
-        §8.3 timeout timer. See ``handle_stop_confirmation``'s docstring for
-        why this lives here rather than in ovos-workshop.
+        session_id + skill_id + ``data["intent_name"]``), cancelling its §8.3
+        timeout timer. See ``handle_stop_confirmation``'s docstring for why
+        this lives here rather than in ovos-workshop.
 
-        ``data["intent_name"] = "stop"`` is stamped explicitly (rather than
-        leaving the dispatcher to match on ``skill_id`` alone, as it does for
-        the normal single-handler-at-a-time framework signal): the ``.stop``
-        dispatch is not the only thing that can be in flight for a skill --
-        an ordinary intent handler can legitimately be running concurrently.
-        Without this, a leaked/stale ``.stop.response`` (e.g. reaching
-        ``handle_stop_confirmation`` for a match that was never actually
-        dispatched -- see the ``bus.once`` registered eagerly in
-        ``_targeted_stop`` at match-build time) would resolve whichever
-        in-flight entry for that skill happens to be on top of the LIFO
-        stack, which may be a completely unrelated, still-running intent --
-        a premature/wrong ``ovos.utterance.handled`` end-marker. The
-        (session_id, skill_id) pre-drain-presence gate in
-        ``handle_stop_confirmation`` narrows *when* this fires; this
-        intent_name stamp narrows *what* it can resolve once it does.
+        ``data["intent_name"] = "stop"`` is stamped explicitly, since a
+        skill can have an ordinary intent handler running concurrently with
+        its ``.stop`` — the dispatcher's ``_pop`` needs it to resolve the
+        right in-flight entry rather than whichever is on top of the LIFO
+        stack. It goes on ``data``, not ``context``: see ``_pop``'s docstring
+        in dispatcher.py for why context is client-inherited and unsafe here.
 
-        DATA, not context: ``message.forward`` deep-copies the ORIGINATING
-        dispatch's context forward (that context is CLIENT-INHERITED --
-        ultimately sourced from the utterance message a client sent). A
-        client that happens to set ``context["intent_name"]`` on its own
-        utterance would have that value survive every ``forward()`` down the
-        dispatch chain and land on a totally unrelated skill's REAL
-        ``mycroft.skill.handler.complete`` too, mismatching this filter and
-        silently breaking that skill's OWN handler-lifecycle resolution
-        (parking it on the 5-minute §8.3 timeout instead). ``data``, by
-        contrast, is passed fresh by ``forward()``'s second argument --
-        never inherited from the client -- so only THIS emission ever
-        carries this key.
-
-        §8.2: a ``.stop.response`` carrying ``error`` means the skill's
-        ``stop()`` raised -- that must resolve as an ``error`` terminal, not
-        ``complete``, so a failed stop is distinguishable from a successful
-        one on the §8 trio.
+        §8.2: a ``.stop.response`` carrying ``error`` resolves as an
+        ``error`` terminal, not ``complete``.
         """
         if 'error' in message.data:
             done = message.forward("mycroft.skill.handler.error",
@@ -397,16 +343,13 @@ class StopService(ConfidenceMatcherPipeline):
         ``sess`` passed in is read but never mutated here.
         """
         LOG.debug(f"Telling skill to stop: {skill_id}")
-        # captured before the drain so handle_stop_confirmation's force_timeout
-        # check (CONFIRMED-2) can still see the pre-drain truth once the
-        # (post-drain) session reaches it via the dispatch round-trip.
-        self._was_active_pre_drain[(sess.session_id, skill_id)] = sess.is_active(skill_id)
-        # CONFIRMED-4: same reasoning — snapshot the pre-drain utterance state
-        # so handle_stop_confirmation's abort_question check (RESPONSE state)
-        # can still see it once the (post-drain) session reaches it via the
-        # dispatch round-trip.
-        self._utt_state_pre_drain[(sess.session_id, skill_id)] = sess.utterance_states.get(
-            skill_id, UtteranceState.INTENT)
+        # Captured before the drain: the post-drain session that reaches
+        # handle_stop_confirmation via the dispatch round-trip can no longer
+        # answer either question truthfully.
+        self._pre_drain[(sess.session_id, skill_id)] = PreDrainSnapshot(
+            was_active=sess.is_active(skill_id),
+            utt_state=sess.utterance_states.get(skill_id, UtteranceState.INTENT),
+        )
         drained = Session.deserialize(sess.serialize())
         drained.disable_response_mode(skill_id)
         drained.deactivate_skill(skill_id)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ dependencies = [
     "ovos-workshop>=9.3.11a1,<10.0.0",
     "rapidfuzz>=3.6,<4.0",
     "ovos-spec-tools[langcodes]>=1.6.1a1,<2.0.0",
-
 ]
 
 [project.urls]

--- a/test/end2end/test_context1_reachability.py
+++ b/test/end2end/test_context1_reachability.py
@@ -1,6 +1,6 @@
 """Cross-repo end-to-end reachability proof for OVOS-CONTEXT-1.
 
-Verified defect (audit-loop wave 1): a skill calling the real
+A skill calling the real
 ``OVOSSkill.set_context`` API (ovos-workshop) could never satisfy the
 declarative ``requires_context`` / ``excludes_context`` gate
 (``ovos_spec_tools.context.gate_satisfied`` / ``resolve_key``), because the
@@ -27,25 +27,23 @@ Only with BOTH halves in place does the gate open after ``set_context`` and
 close again after ``remove_context`` - proving the fix is reachable from the
 real skill API, not just from hand-crafted messages.
 
-Round 4 (wave-3 CONFIRMED / this file's known weakness fixed): the original
-version of this test mocked ``SessionManager.get`` to always hand back one
-fixed, never-folded ``Session`` object, so it could never observe the
-wave-3 defect - "in-lifecycle set_context on a NAMED session never survives
-to the terminal event" - because it never exercised
-``SessionManager.get(message)``'s real fold at all. That is exactly why the
-defect escaped to wave 3. ``test_named_session_context_survives_a_second_
-stale_client_message`` below drives the REAL registered-session two-message
-flow instead: a NAMED session is registered in the real
-``SessionManager.sessions`` singleton (no mocking); ``set_context`` is
-invoked from inside a simulated utterance-handling frame (so
-``dig_for_message`` finds the same in-flight ``message`` a real skill
-handler would see); what would be serialized onto the terminal
-``ovos.utterance.handled`` event is read back directly from
+``test_named_session_context_survives_a_second_stale_client_message`` below
+proves a related invariant: in-lifecycle ``set_context`` on a NAMED session
+must survive to the terminal event, even when a second, stale client message
+arrives in between. It drives the REAL registered-session two-message flow:
+a NAMED session is registered in the real ``SessionManager.sessions``
+singleton (no mocking); ``set_context`` is invoked from inside a simulated
+utterance-handling frame (so ``dig_for_message`` finds the same in-flight
+``message`` a real skill handler would see); what would be serialized onto
+the terminal ``ovos.utterance.handled`` event is read back directly from
 ``SessionManager.sessions[sid]`` (never from a private test-local
 reference); and a second message simulates the conformant client's echo of
-the previously-adopted session (SESSION-2 - the client declares the
-session on every subsequent message) to prove the gate stays satisfied
-across that hand-off too.
+the previously-adopted session (SESSION-2 - the client declares the session
+on every subsequent message) to prove the gate stays satisfied across that
+hand-off too. A test that mocks ``SessionManager.get`` to always hand back
+one fixed, never-folded ``Session`` object cannot observe this class of
+defect, because it never exercises ``SessionManager.get(message)``'s real
+fold at all.
 """
 from threading import Event
 from unittest import TestCase
@@ -65,9 +63,9 @@ SESSION_ID = "ctx1-e2e-r4"
 
 class TestContext1EndToEndReachability(TestCase):
     """Drives the real workshop producer against the real core consumer and
-    asks the real gate whether the declaration is satisfied - the auditor's
-    repro for OVOS-CONTEXT-1 reachability, extended (round 4) into the real
-    two-message NAMED-session flow so it also proves the wave-3 fix."""
+    asks the real gate whether the declaration is satisfied - proving
+    OVOS-CONTEXT-1 reachability end to end, including across a real
+    two-message NAMED-session flow."""
 
     def setUp(self):
         self.bus = FakeBus()
@@ -118,24 +116,25 @@ class TestContext1EndToEndReachability(TestCase):
         self.assertFalse(self._gate_open())
 
     def test_set_context_then_remove_context_round_trip(self):
-        """The auditor's repro: set_context (real workshop API) must open
-        the real gate; remove_context must close it again. This is the
-        assertion that fails with either half of the round-1 fix reverted.
+        """set_context (real workshop API) must open the real gate;
+        remove_context must close it again. Without either half of the fix,
+        this assertion fails: the producer's munged legacy key alone can
+        never satisfy the declarative gate's resolved-key lookup.
 
         The workshop producer's ``set_context``/``remove_context`` build
         their outgoing message via ``dig_for_message() or Message("")`` -
         with no explicit in-flight message supplied by this test, whatever
         ambient ``Message`` the OVOSSkill machinery happens to have left on
         the call stack is used, and it carries the real ``default`` session
-        (round-4: the handlers now resolve registry-first off the message's
-        declared session_id, so a fixed-return ``SessionManager.get`` mock
-        alone no longer controls which session object gets mutated once the
-        message actually names a session that is live in the registry - the
+        (the handlers resolve registry-first off the message's declared
+        session_id, so a fixed-return ``SessionManager.get`` mock alone
+        does not control which session object gets mutated once the message
+        actually names a session that is live in the registry - the
         registry entry wins). This test substitutes the object registered
         under the live ``default`` session_id for the duration of the test
         (restored after), so it isolates the ONE thing it is about:
-        private-key resolution reachability, not the round-4 fold-discipline
-        fix (that is what
+        private-key resolution reachability, not the fold-discipline fix
+        (that is what
         ``test_named_session_context_survives_a_second_stale_client_message``
         below exercises, over an explicit NAMED session)."""
         saved_default = SessionManager.sessions.get(DEFAULT_SESSION_ID)
@@ -174,19 +173,21 @@ class TestContext1EndToEndReachability(TestCase):
                 SessionManager.sessions.pop(DEFAULT_SESSION_ID, None)
 
     def test_named_session_context_survives_a_second_stale_client_message(self):
-        """Wave-3 CONFIRMED (round 4).
+        """Without the registry-first fold discipline, this assertion fails:
+        a stale second message wipes a NAMED session's context before it
+        ever reaches the terminal event.
 
         Step 1 drives the REAL producer (``OVOSSkill.set_context``) over the
         bus, in-handler (so ``dig_for_message`` finds the driving message),
-        exactly like the round-1 repro above, but on an explicit NAMED
-        session registered in the real ``SessionManager.sessions`` registry.
-        This opens the gate and moves the registry forward.
+        exactly like the repro above, but on an explicit NAMED session
+        registered in the real ``SessionManager.sessions`` registry. This
+        opens the gate and moves the registry forward.
 
         ``Message.forward()`` (used internally by the workshop producer)
         self-heals staleness for messages derived *within this same
         process* - ``sync_message_session`` re-stamps a derived message's
         session with the CURRENT live registry state at forward-time, so an
-        in-process round-trip alone can never observe the wave-3 defect.
+        in-process round-trip alone can never observe this defect.
         The defect is specifically about a REMOTE client's message: one that
         arrives over the wire carrying an already-serialized session
         snapshot that no local ``forward()`` gets to refresh. Step 2
@@ -200,11 +201,10 @@ class TestContext1EndToEndReachability(TestCase):
         ``MessageBusClient`` hands a deserialized wire message to the
         registered handler.
 
-        Before the round-4 fix, ``handle_add_context`` called
-        ``SessionManager.get(message)``, which folds this stale snapshot
-        onto the registry entry BEFORE writing - for a NAMED session that
-        fold is full-replace, wiping step 1's entry. This must be RED before
-        the round-4 fix at the ``"kitchen" entry present`` assertion below.
+        Without the fix, ``handle_add_context`` folds this stale snapshot
+        onto the registry entry before writing to it - for a NAMED session
+        that fold is full-replace, wiping step 1's entry - so the
+        ``"kitchen" entry present`` assertion below fails.
         """
         # Step 1: real producer, real consumer, over the bus, in-handler.
         stale_snapshot = self.session.serialize()  # captured BEFORE any write

--- a/test/unittests/test_intent_context.py
+++ b/test/unittests/test_intent_context.py
@@ -695,8 +695,8 @@ class TestDecayPropagatesToTerminalEmissions(unittest.TestCase):
 
     @pytest.mark.xfail(strict=True, reason=_NEEDS_BUS_CLIENT_278)
     def test_same_dispatch_exemption_still_holds(self):
-        # regression guard (commit eec4ae03): a key synced mid-round must not
-        # be decremented by the very round that produced it
+        # A key synced mid-round must not be decremented by the very round
+        # that produced it.
         sess = Session("exempt-sess")
         sess.intent_context = {"person": {"value": "Bob", "turns_remaining": 3}}
         SessionManager.update(sess)

--- a/test/unittests/test_intent_service_extended.py
+++ b/test/unittests/test_intent_service_extended.py
@@ -385,12 +385,12 @@ class TestContextHandlers(unittest.TestCase):
     """Tests for the context management static methods."""
 
     def setUp(self):
-        # Round 4: the handlers now resolve registry-first
-        # (_registry_session_for_context_write), so a leftover real
-        # SessionManager.sessions["s"] entry from `Session.touch()`'s
-        # self-registration (triggered internally by intent_context writes)
-        # would otherwise shadow this test's freshly-constructed, mocked-get
-        # `Session("s")` in later tests. Keep the shared singleton clean.
+        # The handlers resolve registry-first (_registry_session_for_context_write),
+        # so a leftover real SessionManager.sessions["s"] entry from
+        # `Session.touch()`'s self-registration (triggered internally by
+        # intent_context writes) would otherwise shadow this test's
+        # freshly-constructed, mocked-get `Session("s")` in later tests.
+        # Keep the shared singleton clean.
         self._saved_sessions = dict(SessionManager.sessions)
         SessionManager.sessions.clear()
 
@@ -411,7 +411,7 @@ class TestContextHandlers(unittest.TestCase):
         self.assertGreater(len(sess.context.frame_stack), 0)
         # OVOS-CONTEXT-1: the token is mirrored into the intent_context map,
         # keyed by the context token and carrying its injected value.
-        # Round 3: also carries an expires_at decay stamp (see
+        # Also carries an expires_at decay stamp (see
         # test_handle_add_context_stamps_expiry_on_both_spellings) - only
         # "value" is pinned exactly here, expires_at just needs to be present.
         entry = sess.intent_context.get("MyContext")
@@ -484,13 +484,12 @@ class TestContextHandlers(unittest.TestCase):
         self.assertIn("my.skill:kitchen", sess.intent_context)
 
     def test_handle_add_context_resolved_value_falls_back_to_original_key(self):
-        """Round 2 (C3) regression: when no word is given, the resolved
-        twin's fallback 'value' MUST be the original unmunged key, never
-        the munged legacy context string - the munged spelling is an
-        internal ADAPT wire detail and must not leak into OVOS-CONTEXT-1
-        §7 slot injection via the resolved entry. Munged context and
-        original key are deliberately made to differ so a wrong fallback
-        is caught."""
+        """When no word is given, the resolved twin's fallback 'value' must
+        be the original unmunged key, never the munged legacy context
+        string - the munged spelling is an internal ADAPT wire detail and
+        must not leak into OVOS-CONTEXT-1 §7 slot injection via the
+        resolved entry. Munged context and original key are deliberately
+        made to differ so a wrong fallback is caught."""
         sess = Session("s")
         msg = Message("add_context",
                       data={"context": "my_skillkitchen", "key": "kitchen"},
@@ -506,15 +505,14 @@ class TestContextHandlers(unittest.TestCase):
             "my_skillkitchen")
 
     def test_handle_add_context_refreshes_resolved_expiry_on_reset(self):
-        """Round 5 (C1) regression: supersedes Round 2's setdefault-style
-        preservation. OVOS-CONTEXT-1 SECTION 5: a re-set of a key that
-        already exists replaces it wholesale, and SECTION 5.3: there is no
-        read-back API for a caller to notice a stale expiry survived. A
-        re-set of the resolved private key must REFRESH expires_at
-        unconditionally, not keep whatever a prior write established - a
-        stale kept expiry let the resolved key die out of step with the
-        munged legacy key (which inject_context() always refreshes on
-        every call)."""
+        """OVOS-CONTEXT-1 §5: a re-set of a key that already exists
+        replaces it wholesale, and §5.3: there is no read-back API for a
+        caller to notice a stale expiry survived. A re-set of the resolved
+        private key must refresh expires_at unconditionally, not keep
+        whatever a prior write established, or the resolved key dies out
+        of step with the munged legacy key (which inject_context() always
+        refreshes on every call). Without this, the resolved key's
+        expires_at stays pinned to the first write."""
         sess = Session("s")
         sess.intent_context = {"my.skill:kitchen": {"value": "old",
                                                      "expires_at": 999999999.0,
@@ -535,15 +533,13 @@ class TestContextHandlers(unittest.TestCase):
         self.assertNotIn("turns_remaining", entry)
 
     def test_handle_add_context_stamps_expiry_on_both_spellings(self):
-        """Round 3 (wave-3 live lead) regression: a FRESH add_context call
-        must stamp expires_at on BOTH the munged legacy key and the
-        resolved private key, sourced from the same adapt `context.timeout`
-        config convention ovos-bus-client's `_IntentContextView` uses
-        (`Configuration()['context']['timeout']`, minutes -> seconds,
-        default 2min). Without a decay field, OVOS-CONTEXT-1's `is_live()`
-        treats an entry as immortal and `prune()` can never reap it - the
-        pre-existing dev "immortal context entries" bug, which the spec
-        sides against for legacy-sourced entries."""
+        """A fresh add_context call must stamp expires_at on BOTH the
+        munged legacy key and the resolved private key, sourced from the
+        same adapt `context.timeout` config convention ovos-bus-client's
+        `_IntentContextView` uses (`Configuration()['context']['timeout']`,
+        minutes -> seconds, default 2min). Without a decay field,
+        OVOS-CONTEXT-1's `is_live()` treats an entry as immortal and
+        `prune()` can never reap it."""
         import time
         from ovos_config.config import Configuration
         sess = Session("s")
@@ -567,10 +563,9 @@ class TestContextHandlers(unittest.TestCase):
             self.assertLessEqual(entry["expires_at"], after + timeout_s)
 
     def test_handle_add_context_prune_removes_both_spellings_after_expiry(self):
-        """Round 3 regression: ovos_spec_tools.context.prune() must be able
-        to reap BOTH dialect keys once their stamped expires_at is in the
-        past - proving the decay stamp is real (§4 pre-match pruning), not
-        just present."""
+        """ovos_spec_tools.context.prune() must be able to reap BOTH
+        dialect keys once their stamped expires_at is in the past - proving
+        the decay stamp is real (§4 pre-match pruning), not just present."""
         from ovos_spec_tools.context import prune
         sess = Session("s")
         msg = Message("add_context",
@@ -591,20 +586,13 @@ class TestContextHandlers(unittest.TestCase):
         self.assertNotIn("my.skill:kitchen", pruned)
 
     def test_handle_add_context_does_not_double_clobber_injected_expiry(self):
-        """Round 3 regression, precise claim: `sess.context.inject_context()`
-        (ovos-bus-client's legacy `_IntentContextView`) ALWAYS stamps a
-        FRESH `expires_at` on every call - it has no memory of a prior
-        custom value, so a pre-existing custom stamp on the munged key
-        cannot survive a re-`inject_context()` regardless of this handler
-        (that unconditional-fresh-stamp behavior lives in the vendored
-        dependency, out of this fix's scope). What THIS handler must not
-        do is throw the freshly-injected stamp away a second time with its
-        own bare-dict overwrite - which the pre-Round-3 code did. Assert
-        the handler's own write preserves exactly what inject_context()
-        just wrote for the munged key (no extra clobber), by checking the
-        handler's output for that key equals `sess.context`'s own
-        (post-inject) view before the handler's second write would have
-        run."""
+        """`sess.context.inject_context()` (ovos-bus-client's legacy
+        `_IntentContextView`) always stamps a fresh `expires_at` on every
+        call, out of this handler's control. What this handler must not do
+        is throw that freshly-injected stamp away a second time with its
+        own bare-dict overwrite. Assert the handler's own write preserves
+        exactly what inject_context() just wrote for the munged key (no
+        extra clobber)."""
         sess = Session("s")
         entity = {"confidence": 1.0, "data": [("kitchen", "my_skillkitchen")],
                   "match": "kitchen", "key": "kitchen", "origin": ""}
@@ -627,9 +615,9 @@ class TestContextHandlers(unittest.TestCase):
         self.assertGreaterEqual(entry["expires_at"], injected_entry["expires_at"])
 
     def test_handle_add_context_e2e_reachability_unaffected_by_decay_stamp(self):
-        """Round 3 regression: the decay stamp must not break IMMEDIATE
-        gating - a freshly-opened OVOS-CONTEXT-1 gate must still be
-        satisfied right after set_context, decay or no decay."""
+        """The decay stamp must not break immediate gating - a
+        freshly-opened OVOS-CONTEXT-1 gate must still be satisfied right
+        after set_context, decay or no decay."""
         from ovos_spec_tools.context import gate_satisfied
         sess = Session("s")
         msg = Message("add_context",
@@ -644,19 +632,14 @@ class TestContextHandlers(unittest.TestCase):
                                        owner_id="my.skill"))
 
     def test_handle_add_context_reset_refreshes_both_keys_in_lockstep(self):
-        """Round 5 (C1) regression: one decay policy for a logical write.
-        A skill re-calling set_context (a second handle_add_context for the
-        SAME context/key, e.g. re-affirming context mid-conversation) must
-        refresh expires_at on BOTH the munged legacy key and the resolved
-        private key together. Before the fix, the munged key was refreshed
-        (inject_context() always stamps fresh) but the resolved key's
-        setdefault-style merge kept the FIRST write's expiry forever - the
-        two keys decayed on different schedules and the declarative gate
-        could close (resolved key expired) while the legacy adapt context
-        was still alive, or the reverse. Must be RED before the fix: the
-        resolved key's expires_at stays pinned to t0 + timeout instead of
-        being refreshed to t0 + 100 + timeout, so prune() at t0+150 reaps
-        the resolved key but not the munged key."""
+        """One decay policy for a logical write. A skill re-calling
+        set_context (a second handle_add_context for the SAME context/key,
+        e.g. re-affirming context mid-conversation) must refresh expires_at
+        on BOTH the munged legacy key and the resolved private key
+        together. Without a unified refresh, the resolved key's expires_at
+        stays pinned to t0 + timeout instead of being refreshed to
+        t0 + 100 + timeout, so this assertion fails because prune() at
+        t0+150 reaps the resolved key but not the munged key."""
         from ovos_spec_tools.context import prune
 
         sess = Session("s")
@@ -734,19 +717,18 @@ class TestContextHandlers(unittest.TestCase):
 
 
 class TestContextHandlersLiveRegistry(unittest.TestCase):
-    """Round 4 / wave-3 CONFIRMED: SessionManager.get(message) always folds
-    the incoming message's session onto the live registry entry, and for
-    NAMED sessions that fold is full-replace (update_from). Called from a
-    context handler, the fold first wipes the registry entry's
-    intent_context with the message's stale snapshot, then every
-    subsequent mid-lifecycle frame re-wipes it again - a named session's
-    context can never survive to the terminal event. SESSION-2 §2.6:
-    folding a message's session onto the working session belongs at
-    lifecycle entry only; incidental messages must never mutate it.
+    """FOLD LAW (see IntentService._registry_session_for_context_write,
+    SESSION-2 §2.6): a message's session snapshot folds onto the live
+    registry session only at lifecycle entry, never on an incidental
+    mid-lifecycle message. `SessionManager.get(message)` folds unconditionally,
+    and for NAMED sessions that fold is full-replace (`update_from`), so an
+    incidental fold wipes the registry entry's intent_context with a stale
+    snapshot - a named session's context can never survive to the terminal
+    event.
 
     These tests exercise the REAL SessionManager.sessions registry (no
-    mocking of SessionManager.get) so they fail against the pre-fix
-    every-call fold, exactly the mechanism that let the bug reach wave 3.
+    mocking of SessionManager.get) so they fail against an unconditional
+    every-call fold.
     """
 
     def setUp(self):
@@ -801,15 +783,14 @@ class TestContextHandlersLiveRegistry(unittest.TestCase):
         self.assertIn("Second", live.intent_context)
 
     def test_add_context_survives_stale_default_session_snapshot_fold(self):
-        """Round 5 (C3) regression: the registry-first fix is load-bearing
-        for the DEVICE-LOCAL DEFAULT session too, not only named sessions.
-        `Session.update_from` round-trips through full serialize/deserialize
-        for every session id, including "default" - it does not "happen to
-        preserve omitted fields" for the default id, contrary to the old
-        docstring claim. A registry "default" entry's pre-existing context
-        must survive a handle_add_context call driven by a message carrying
-        a STALE default-session snapshot, exactly like the named-session
-        case above."""
+        """The registry-first fix is load-bearing for the DEVICE-LOCAL
+        DEFAULT session too, not only named sessions: `Session.update_from`
+        round-trips through full serialize/deserialize for every session
+        id, including "default", so it does not preserve omitted fields for
+        the default id either. A registry "default" entry's pre-existing
+        context must survive a handle_add_context call driven by a message
+        carrying a STALE default-session snapshot, exactly like the
+        named-session case above."""
         sess = Session(DEFAULT_SESSION_ID)
         sess.intent_context = {"Existing": {"value": "existing"}}
         SessionManager.sessions[DEFAULT_SESSION_ID] = sess
@@ -1050,7 +1031,7 @@ class TestHandleUtterance(unittest.TestCase):
         svc.send_complete_intent_failure.assert_called_once()
 
     def test_blacklisted_targeted_stop_discards_match_session_unchanged(self):
-        """CONFIRMED-3 regression: a Match discarded for a blacklisted intent
+        """A Match discarded for a blacklisted intent
         (service.py ~607) must never have applied its session mutation. Before
         the fix, StopService._targeted_stop drained the LIVE SessionManager
         session in match() itself, so a discarded stop still left the skill
@@ -1071,7 +1052,7 @@ class TestHandleUtterance(unittest.TestCase):
         stop_svc._locale.voc_match.side_effect = (
             lambda utt, voc, lang, exact=False: voc == "stop")
         stop_svc._legacy = MagicMock()
-        stop_svc._was_active_pre_drain = {}
+        stop_svc._pre_drain = {}
 
         sess = Session("s")
         sess.activate_skill("skill_a")

--- a/test/unittests/test_stop_service.py
+++ b/test/unittests/test_stop_service.py
@@ -42,8 +42,7 @@ def _make_service() -> StopService:
         # tests patch svc._locale.voc_match / voc_list.
         svc._locale = MagicMock()
         svc._legacy = MagicMock()
-        svc._was_active_pre_drain = {}
-        svc._utt_state_pre_drain = {}
+        svc._pre_drain = {}
     return svc
 
 
@@ -329,12 +328,12 @@ class TestHandleStopConfirmation(unittest.TestCase):
 
 
 class TestAbortQuestionReachable(unittest.TestCase):
-    """CONFIRMED-4 regression: handle_stop_confirmation's RESPONSE-state
-    check (which emits mycroft.skills.abort_question, the killable-event
-    abort for a blocked get_response) read `sess.utterance_states` off the
-    ALREADY-DRAINED session carried by the dispatched .stop.response message
-    (_targeted_stop's disable_response_mode runs before dispatch) — so it was
-    always UtteranceState.INTENT there and the branch was unreachable."""
+    """handle_stop_confirmation's RESPONSE-state check (which emits
+    mycroft.skills.abort_question, the killable-event abort for a blocked
+    get_response) must consult the pre-drain snapshot: `sess.utterance_states`
+    off the .stop.response message is already drained
+    (_targeted_stop's disable_response_mode runs before dispatch), so a live
+    read is always UtteranceState.INTENT there."""
 
     def test_targeted_stop_of_response_mode_skill_emits_abort_question(self):
         svc = _make_service()
@@ -364,7 +363,7 @@ class TestAbortQuestionReachable(unittest.TestCase):
                       "handle_stop_confirmation is already drained")
 
     def test_force_timeout_still_emitted_for_converse_skill(self):
-        """Regression guard: the CONFIRMED-2 force_timeout fix must stay green."""
+        """force_timeout must still fire for a converse-active skill."""
         svc = _make_service()
         svc.bus.emit = MagicMock()
 
@@ -669,12 +668,11 @@ class TestLegacyStopBridge(unittest.TestCase):
 
 
 class TestLegacyBridgeSingleDelivery(unittest.TestCase):
-    """CONFIRMED-1 regression (double-stop): with the translator active
-    (default on ``FakeBus``/``MessageBusClient``), a legacy skill's ``stop()``
-    handler — bound the way ovos-workshop actually binds it, on BOTH the
-    shared/skill legacy topic AND left listening while the bridge also fires
-    its own §9.2 observer re-emit — must be invoked exactly once per stop
-    event, not twice.
+    """With the translator active (default on ``FakeBus``/``MessageBusClient``),
+    a legacy skill's ``stop()`` handler — bound the way ovos-workshop
+    actually binds it, on BOTH the shared/skill legacy topic AND left
+    listening while the bridge also fires its own §9.2 observer re-emit —
+    must be invoked exactly once per stop event, not twice.
 
     Before the fix, ``_LegacyStopBridge.handle_global_stop`` /
     ``handle_skill_stop`` unconditionally re-emitted ``mycroft.stop`` /
@@ -878,14 +876,14 @@ class TestStopSelectionDeterministic(unittest.TestCase):
 
 
 class TestDispatcherLifecycleResolvedByStopRoundTrip(unittest.TestCase):
-    """L1 regression: the IntentDispatcher's §8 handler-lifecycle entry for a
-    `<skill_id>:stop` dispatch was never resolved by
-    `mycroft.skill.handler.complete`/`.error` -- the colon-topic has no direct
+    """The IntentDispatcher's §8 handler-lifecycle entry for a
+    `<skill_id>:stop` dispatch must be resolved by
+    `mycroft.skill.handler.complete`/`.error`, not left parked on the
+    dispatcher's 5-minute §8.3 timeout — the colon-topic has no direct
     ovos-workshop listener (only the legacy bridge mirrors it onto the
-    dot-topic, bound with `handler_info=None`, which disables that emission).
-    Left unresolved, every stop parks its dispatch entry on the dispatcher's
-    5-minute §8.3 timeout instead of resolving synchronously when the stop
-    round-trip (`.stop.response`) actually completes."""
+    dot-topic, bound with `handler_info=None`, which disables that
+    emission), so the stop round-trip (`.stop.response`) must resolve it
+    synchronously instead."""
 
     def test_stop_round_trip_resolves_dispatcher_entry_synchronously(self):
         from ovos_core.intent_services.dispatcher import IntentDispatcher
@@ -925,8 +923,8 @@ class TestDispatcherLifecycleResolvedByStopRoundTrip(unittest.TestCase):
 
 
 class TestStaleStopOnceDoesNotResolveUnrelatedEntry(unittest.TestCase):
-    """C1 regression (adversarial re-review of the L1 fix): `_targeted_stop`
-    registers `bus.once(f"{skill_id}.stop.response", handle_stop_confirmation)`
+    """`_targeted_stop` registers
+    `bus.once(f"{skill_id}.stop.response", handle_stop_confirmation)`
     at MATCH-BUILD time -- a side effect that survives even when the
     orchestrator later DISCARDS the Match (blacklisted intent, missing
     slots, etc: see service.py's blacklist check) and never actually
@@ -979,13 +977,10 @@ class TestStaleStopOnceDoesNotResolveUnrelatedEntry(unittest.TestCase):
 
 
 class TestFailedStopYieldsErrorTerminal(unittest.TestCase):
-    """C2 regression (adversarial re-review of the L1 fix): a `.stop.response`
-    carrying `error` (the skill's `stop()` raised) was still resolved via
-    `_resolve_dispatch_lifecycle` as a `complete` terminal -- §8.2 requires an
-    `error` terminal so a failed stop is distinguishable from a successful
-    one on the handler-lifecycle trio.
-
-    Mirrors the live auditor's attack3.py::test_stop_error_yields_complete_terminal.
+    """A `.stop.response` carrying `error` (the skill's `stop()` raised)
+    must resolve via `_resolve_dispatch_lifecycle` as an `error` terminal,
+    not `complete` -- §8.2 requires this so a failed stop is distinguishable
+    from a successful one on the handler-lifecycle trio.
     """
 
     def test_stop_response_with_error_yields_error_not_complete_terminal(self):
@@ -1025,22 +1020,16 @@ class TestFailedStopYieldsErrorTerminal(unittest.TestCase):
 
 
 class TestIntentNameFilterIsDataNotContext(unittest.TestCase):
-    """F1 regression (round-3 adversarial re-review of 6e8c8163be): the
-    dispatcher's optional intent_name filter used to be read from
-    `message.context["intent_name"]`. Context is CLIENT-INHERITED --
-    `Message.forward` deep-copies the context of the message it is called
-    on, which for a dispatch chain traces back to the ORIGINATING client
-    utterance. Any client that happens to set `context["intent_name"]` on
-    its own utterance would have that value survive every forward() down
-    the dispatch chain and land on the skill's REAL
-    `mycroft.skill.handler.complete` too -- mismatching the stop-only filter
-    and parking a completely unrelated, successfully-completed intent on
-    the dispatcher's 5-minute §8.3 timeout.
-
-    Mirrors the live auditor's attack4.py
-    (test_1_normal_intent_workshop_complete /
-    test_2_client_supplied_context_intent_name_breaks_resolution /
-    test_3_targeted_stop_still_resolves)."""
+    """The dispatcher's optional intent_name filter must be read from
+    `message.data["intent_name"]`, never `message.context["intent_name"]`.
+    Context is CLIENT-INHERITED -- `Message.forward` deep-copies the context
+    of the message it is called on, which for a dispatch chain traces back
+    to the ORIGINATING client utterance. A client that sets
+    `context["intent_name"]` on its own utterance would have that value
+    survive every forward() down the dispatch chain and land on the skill's
+    REAL `mycroft.skill.handler.complete` too -- mismatching the stop-only
+    filter and parking a completely unrelated, successfully-completed
+    intent on the dispatcher's 5-minute §8.3 timeout."""
 
     def test_client_supplied_context_intent_name_does_not_break_real_completion(self):
         from ovos_bus_client.handler import HandlerLifecycle
@@ -1100,17 +1089,11 @@ class TestIntentNameFilterIsDataNotContext(unittest.TestCase):
 
 
 class TestPreDrainSnapshotsDoNotLeakOnFailedStop(unittest.TestCase):
-    """F2 regression (round-3 adversarial re-review of 6e8c8163be): the
-    pre-drain snapshot dicts were popped ONLY inside the `result: True`
-    branch of `handle_stop_confirmation` -- every failed (`error` in data),
-    declined (`result: False`), or never-actually-dispatched stop left
-    `(session_id, skill_id)` in BOTH `_was_active_pre_drain` and
-    `_utt_state_pre_drain` forever: an unbounded memory leak, AND it kept
-    the `_resolve_dispatch_lifecycle` presence-gate permanently open for
-    that pair (any later unrelated `.stop.response` reusing the same
-    (session_id, skill_id) would pass the gate).
-
-    Mirrors the live auditor's attack5.py."""
+    """The pre-drain snapshot must be popped for every `.stop.response`,
+    not only a successful one: an error, a decline (`result: False`), or a
+    response for a dispatch that never completed must not leave
+    `(session_id, skill_id)` in `_pre_drain` forever, and must not leave the
+    `_resolve_dispatch_lifecycle` presence-gate open for that pair."""
 
     def test_fifty_failed_stops_leave_no_leaked_snapshot_keys(self):
         svc = _make_service()
@@ -1122,8 +1105,7 @@ class TestPreDrainSnapshotsDoNotLeakOnFailedStop(unittest.TestCase):
                 "skillA.stop.response",
                 {"skill_id": "skillA", "error": "boom"},
                 {"skill_id": "skillA", "session": sess.serialize()}))
-        self.assertEqual(len(svc._was_active_pre_drain), 0)
-        self.assertEqual(len(svc._utt_state_pre_drain), 0)
+        self.assertEqual(len(svc._pre_drain), 0)
 
     def test_fifty_declined_stops_leave_no_leaked_snapshot_keys(self):
         svc = _make_service()
@@ -1135,8 +1117,7 @@ class TestPreDrainSnapshotsDoNotLeakOnFailedStop(unittest.TestCase):
                 "skillA.stop.response",
                 {"skill_id": "skillA", "result": False},
                 {"skill_id": "skillA", "session": sess.serialize()}))
-        self.assertEqual(len(svc._was_active_pre_drain), 0)
-        self.assertEqual(len(svc._utt_state_pre_drain), 0)
+        self.assertEqual(len(svc._pre_drain), 0)
 
     def test_successful_stop_still_clears_snapshot(self):
         """Regression guard: the success path must keep clearing too."""
@@ -1148,19 +1129,15 @@ class TestPreDrainSnapshotsDoNotLeakOnFailedStop(unittest.TestCase):
             "skillA.stop.response",
             {"skill_id": "skillA", "result": True},
             {"skill_id": "skillA", "session": sess.serialize()}))
-        self.assertEqual(len(svc._was_active_pre_drain), 0)
-        self.assertEqual(len(svc._utt_state_pre_drain), 0)
+        self.assertEqual(len(svc._pre_drain), 0)
 
 
 class TestPreDrainGateBlocksUnknownPair(unittest.TestCase):
-    """F3: the presence-gate mechanism in `handle_stop_confirmation` --
-    "only emit a synthetic handler.complete/.error for a (session_id,
-    skill_id) pair this StopService actually has a pre-drain snapshot
-    for" -- was itself never directly exercised by any test; the suite
-    stayed green even with the gate deleted entirely. Assert it directly:
-    a `.stop.response` for a pair with NO pre-drain snapshot at all (never
-    went through `_targeted_stop`) must emit no
-    `mycroft.skill.handler.complete`/`.error` whatsoever."""
+    """`handle_stop_confirmation` must only emit a synthetic
+    handler.complete/.error for a (session_id, skill_id) pair it actually
+    has a pre-drain snapshot for. A `.stop.response` for a pair with NO
+    pre-drain snapshot at all (never went through `_targeted_stop`) must
+    emit no `mycroft.skill.handler.complete`/`.error` whatsoever."""
 
     def test_stop_response_with_no_pre_drain_snapshot_emits_no_handler_signal(self):
         svc = _make_service()
@@ -1197,13 +1174,9 @@ class TestShutdown(unittest.TestCase):
 
 
 class TestPreDrainSnapshotsAreSessionScoped(unittest.TestCase):
-    """Regression: ``_was_active_pre_drain`` / ``_utt_state_pre_drain`` used to
-    be keyed by bare ``skill_id``. Two concurrent targeted stops for the SAME
-    skill_id but DIFFERENT sessions collided: session B's snapshot overwrote
-    session A's, and whichever confirmation was processed second popped the
-    OTHER session's (already-consumed) entry, producing wrong
-    force_timeout/abort_question decisions. Keying by ``(session_id,
-    skill_id)`` fixes this."""
+    """`_pre_drain` is keyed by ``(session_id, skill_id)``, not bare
+    ``skill_id``: two concurrent targeted stops for the same skill_id in
+    different sessions must not collide or consume each other's snapshot."""
 
     def test_interleaved_targeted_stops_same_skill_different_sessions(self):
         svc = _make_service()
@@ -1228,7 +1201,7 @@ class TestPreDrainSnapshotsAreSessionScoped(unittest.TestCase):
         drained_b = match_b.updated_session
 
         self.assertEqual(
-            len(svc._was_active_pre_drain), 2,
+            len(svc._pre_drain), 2,
             "both sessions' snapshots must coexist, keyed independently")
 
         msg_a = Message("skill_a.stop.response",
@@ -1262,8 +1235,7 @@ class TestPreDrainSnapshotsAreSessionScoped(unittest.TestCase):
                          "session B was never in RESPONSE state; the bug would "
                          "have it consume session A's leftover/absent snapshot")
 
-        self.assertEqual(len(svc._was_active_pre_drain), 0)
-        self.assertEqual(len(svc._utt_state_pre_drain), 0)
+        self.assertEqual(len(svc._pre_drain), 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

A quality audit found comments in the intent-context and stop pipelines that narrate the review campaign that produced them — "Round 5 (C1)", "Wave-3 CONFIRMED (round 4)", "F2 (round-3 adversarial re-review of 6e8c8163be)", "attack5.py", "regression guard (commit eec4ae03)" — instead of stating the constraint the code protects. A new contributor can't decode any of that. This rewrites each site as the plain invariant it enforces, keeping spec anchors (§ citations) since those are real constraints, not campaign trivia.

The session-fold rule ("a message's session snapshot folds onto the live registry session at lifecycle entry only; incidental messages must never fold") was previously re-explained at five separate sites in `service.py` and `converse_service.py`. It's now stated once, in `_registry_session_for_context_write`'s docstring (SESSION-2 §2.6), with every other site shrunk to a one-line pointer back to it. `handle_add_context`'s multi-round narration collapses into one comment block describing the two-dialect write it performs. `stop_service.py`'s F2/CONFIRMED-N/attack comments become plain statements of the pop-before-branch and pre-drain-vs-live-read invariants, and its two oversized docstrings are trimmed to the essentials (the data-vs-context rule now lives once, in `dispatcher.py`'s `_pop`, and is referenced from here).

The one non-comment change: `StopService._was_active_pre_drain` and `_utt_state_pre_drain` — two parallel dicts always written and popped together — are merged into a single `_pre_drain` dict of a `PreDrainSnapshot` NamedTuple, with one comment stating the drain-ordering invariant. Everything else is comments/docstrings only. Full `test/unittests` suite: 423 passed, 6 xfailed, identical to `origin/dev`'s baseline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stop and timeout handling when sessions are drained, preserving response-abort behavior and preventing stale session state.
  * Improved lifecycle completion and error handling for targeted stop requests.
  * Improved reliability for concurrent stop requests across separate sessions.
  * Prevented duplicate delivery of legacy stop responses and improved handling of stale listeners.

* **Tests**
  * Expanded regression coverage for session context expiry, stop behavior, lifecycle resolution, and stale-state cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->