### PR TITLE
test: account for ovos.converse.pong broadcast answer in e2e expectations

### DIFF
--- a/test/end2end/test_activate.py
+++ b/test/end2end/test_activate.py
@@ -195,6 +195,10 @@ class TestDeactivate(TestCase):
             keep_original_src=[
                 f"{self.skill_id}.converse.ping",
                 f"{self.skill_id}.converse.request",
+                # ovos.converse.pong (OVOS-CONVERSE-1 §4.2 broadcast answer,
+                # ovos-workshop#534) is emitted on the entry source/destination
+                # pair, not flipped like the per-round response messages.
+                "ovos.converse.pong",
                 #"intent.service.skills.deactivate", # TODO
                 #f"{self.skill_id}.deactivate", # TODO
                 #f"{self.skill_id}.activate", # TODO
@@ -205,6 +209,11 @@ class TestDeactivate(TestCase):
                 # before the legacy per-skill pings (dual-emit compat window).
                 Message("ovos.converse.ping",
                         data={"utterances": ["deactivate skill from within converse"], "lang": session.lang},
+                        context={}),
+                # OVOS-CONVERSE-1 §4.2 broadcast answer (ovos-workshop#534);
+                # result mirrors the legacy skill.converse.pong can_handle=True below.
+                Message("ovos.converse.pong",
+                        data={"skill_id": self.skill_id, "result": True},
                         context={}),
                 Message(f"{self.skill_id}.converse.ping",
                         data={"utterances": ["deactivate skill from within converse"], "skill_id": self.skill_id},

--- a/test/end2end/test_converse.py
+++ b/test/end2end/test_converse.py
@@ -120,6 +120,12 @@ class TestConverse(TestCase):
                 Message("ovos.converse.ping",
                         data={"utterances": ["echo test"], "lang": session.lang},
                         context={}),
+                # OVOS-CONVERSE-1 §4.2 broadcast answer (ovos-workshop#534):
+                # aggregated result of the broadcast poll, one per round,
+                # mirrors the legacy skill.converse.pong's can_handle value.
+                Message("ovos.converse.pong",
+                        data={"skill_id": self.skill_id, "result": True},
+                        context={}),
                 Message(f"{self.skill_id}.converse.ping",
                         data={"utterances": ["echo test"], "skill_id": self.skill_id},
                         context={}),
@@ -166,6 +172,10 @@ class TestConverse(TestCase):
                 message3,
                 Message("ovos.converse.ping",
                         data={"utterances": ["stop parrot"], "lang": session.lang},
+                        context={}),
+                # OVOS-CONVERSE-1 §4.2 broadcast answer (ovos-workshop#534).
+                Message("ovos.converse.pong",
+                        data={"skill_id": self.skill_id, "result": True},
                         context={}),
                 Message(f"{self.skill_id}.converse.ping",
                         data={"utterances": ["stop parrot"], "skill_id": self.skill_id},
@@ -214,6 +224,11 @@ class TestConverse(TestCase):
                 Message("ovos.converse.ping",
                         data={"utterances": ["echo test"], "lang": session.lang},
                         context={}),
+                # OVOS-CONVERSE-1 §4.2 broadcast answer (ovos-workshop#534);
+                # result mirrors the legacy skill.converse.pong can_handle=False below.
+                Message("ovos.converse.pong",
+                        data={"skill_id": self.skill_id, "result": False},
+                        context={}),
                 Message(f"{self.skill_id}.converse.ping",
                         data={"utterances": ["echo test"], "skill_id": self.skill_id},
                         context={}),
@@ -240,8 +255,12 @@ class TestConverse(TestCase):
                 ignore_messages=HANDLER_TRIO,
                 activation_points=[f"{self.skill_id}:start_parrot"],
             # messages internal to ovos-core, i.e. would not be sent to clients such as hivemind
+            # ovos.converse.pong (OVOS-CONVERSE-1 §4.2 broadcast answer, ovos-workshop#534)
+            # is emitted on the same source/destination pair as the entry utterance,
+            # not flipped like the per-round response messages.
                 keep_original_src=[f"{self.skill_id}.converse.ping",
-                                   f"{self.skill_id}.converse.request"
+                                   f"{self.skill_id}.converse.request",
+                                   "ovos.converse.pong"
                                # f"{self.skill_id}.activate",  # TODO
                                    ]
             )


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

ovos-workshop#534 shipped the OVOS-CONVERSE-1 §4.2 broadcast answer path: alongside the existing broadcast poll (`ovos.converse.ping`), core now also emits a broadcast answer (`ovos.converse.pong`) once per converse round, before the legacy per-skill ping/pong pair. That shifted message counts in the two end2end tests that exercise converse rounds, and dev CI has gone red on every PR since the workshop alpha resolved (workshop alpha didn't exist when core#863 merged and dev CI last passed).

Reproduced locally with latest pre-release alphas (ovos-workshop 9.4.0a1) and diffed the captured message list against expectations message by message. In both `test_parrot_mode` and `test_deactivate_inside_converse`, every extra message was exactly one `ovos.converse.pong` per converse round, with a `result` matching the corresponding `skill.converse.pong`'s `can_handle` value — no unexplained duplicates, no genuine double-dispatch. Updated the expected sequences for both the spec and legacy namespace subtests, added a comment where each count lives, and added `ovos.converse.pong` to `keep_original_src` since it's emitted on the entry source/destination pair rather than the flipped direction used by the other per-round response messages.

Verified against the merged result: full `test/end2end/` suite green (37 passed, 48 subtests) and full `test/unittests/` suite green (456 passed, 6 xfailed, matching the documented baseline). No other end2end test's message counts were affected — swept the whole directory.