### PR TITLE
fix: shut down test-created SkillManager instances to stop leaked watcher threads

### DIFF
--- a/test/unittests/test_manager.py
+++ b/test/unittests/test_manager.py
@@ -21,6 +21,7 @@ class TestSkillManager(unittest.TestCase):
         self.bus.reset_mock()
 
     def tearDown(self):
+        self.skill_manager.shutdown()
         SessionManager.bus = None
 
     def test_blacklist_property(self):

--- a/test/unittests/test_skill_manager.py
+++ b/test/unittests/test_skill_manager.py
@@ -81,6 +81,7 @@ class TestSkillManager(TestCase):
         # setup noise so tests only see messages emitted by the code under test
         self.message_bus_mock.message_types = []
         self.message_bus_mock.message_data = []
+        self.addCleanup(self.skill_manager.shutdown)
 
     def _mock_log(self):
         log_patch = patch(self.mock_package + 'LOG')
@@ -112,27 +113,29 @@ class TestSkillManager(TestCase):
         with patch.dict(Configuration._Configuration__patch, config):
             bus_mock = MessageBusMock()
             skill_manager = SkillManager(bus_mock)
+            try:
+                expected_result = [
+                    'skillmanager.list',
+                    'skillmanager.deactivate',
+                    'skillmanager.keep',
+                    'skillmanager.activate',
+                    #'mycroft.skills.initialized',
+                    'mycroft.skills.is_alive',
+                    'mycroft.skills.is_ready',
+                    'mycroft.skills.all_loaded',
+                    # SessionManager.connect_to_bus() handlers - wired
+                    # unconditionally so skills-only processes (no intent
+                    # service) still get SessionManager.bus set
+                    'recognizer_loop:record_begin',
+                    'recognizer_loop:record_end',
+                    'recognizer_loop:audio_output_start',
+                    'recognizer_loop:audio_output_end',
+                    SpecMessage.SESSION_SYNC,
+                ]
 
-            expected_result = [
-                'skillmanager.list',
-                'skillmanager.deactivate',
-                'skillmanager.keep',
-                'skillmanager.activate',
-                #'mycroft.skills.initialized',
-                'mycroft.skills.is_alive',
-                'mycroft.skills.is_ready',
-                'mycroft.skills.all_loaded',
-                # SessionManager.connect_to_bus() handlers - wired
-                # unconditionally so skills-only processes (no intent
-                # service) still get SessionManager.bus set
-                'recognizer_loop:record_begin',
-                'recognizer_loop:record_end',
-                'recognizer_loop:audio_output_start',
-                'recognizer_loop:audio_output_end',
-                SpecMessage.SESSION_SYNC,
-            ]
-
-            self.assertListEqual(expected_result, bus_mock.event_handlers)
+                self.assertListEqual(expected_result, bus_mock.event_handlers)
+            finally:
+                skill_manager.shutdown()
         SessionManager.bus = None
 
 
@@ -469,6 +472,7 @@ class TestDeferredLoadingConfigFlag(TestCase):
         config['skills']['use_deferred_loading'] = False  # Explicitly set to False
         with patch.dict(Configuration._Configuration__patch, config):
             skill_manager = SkillManager(self.message_bus_mock)
+            self.addCleanup(skill_manager.shutdown)
             self.assertFalse(skill_manager._use_deferred_loading)
 
     def test_deferred_loading_enabled_via_config(self):
@@ -477,6 +481,7 @@ class TestDeferredLoadingConfigFlag(TestCase):
         config['skills']['use_deferred_loading'] = True
         with patch.dict(Configuration._Configuration__patch, config):
             skill_manager = SkillManager(self.message_bus_mock)
+            self.addCleanup(skill_manager.shutdown)
             self.assertTrue(skill_manager._use_deferred_loading)
 
     def test_connectivity_handlers_not_registered_when_deferred_loading_disabled(self):
@@ -484,7 +489,8 @@ class TestDeferredLoadingConfigFlag(TestCase):
         config = mock_config()
         config['skills']['use_deferred_loading'] = False  # Explicitly set to False
         with patch.dict(Configuration._Configuration__patch, config):
-            SkillManager(self.message_bus_mock)
+            skill_manager = SkillManager(self.message_bus_mock)
+            self.addCleanup(skill_manager.shutdown)
 
             # When deferred loading is disabled, connectivity handlers should not be registered
             expected_handlers = [
@@ -513,7 +519,8 @@ class TestDeferredLoadingConfigFlag(TestCase):
         config = mock_config()
         config['skills']['use_deferred_loading'] = True
         with patch.dict(Configuration._Configuration__patch, config):
-            SkillManager(self.message_bus_mock)
+            skill_manager = SkillManager(self.message_bus_mock)
+            self.addCleanup(skill_manager.shutdown)
 
         # When deferred loading is enabled, connectivity handlers should be registered
         expected_handlers = [
@@ -546,6 +553,7 @@ class TestDeferredLoadingConfigFlag(TestCase):
         config['skills']['use_deferred_loading'] = False  # Explicitly set to False
         with patch.dict(Configuration._Configuration__patch, config):
             skill_manager = SkillManager(self.message_bus_mock)
+            self.addCleanup(skill_manager.shutdown)
 
             # Mock a skill plugin
             mock_plugin = Mock()
@@ -576,6 +584,7 @@ class TestDeferredLoadingConfigFlag(TestCase):
         config['skills']['use_deferred_loading'] = True
         with patch.dict(Configuration._Configuration__patch, config):
             skill_manager = SkillManager(self.message_bus_mock)
+            self.addCleanup(skill_manager.shutdown)
 
             # Mock a skill plugin with network requirement
             mock_plugin = Mock()
@@ -604,6 +613,7 @@ class TestDeferredLoadingConfigFlag(TestCase):
         config['skills']['use_deferred_loading'] = False  # Explicitly set to False
         with patch.dict(Configuration._Configuration__patch, config):
             skill_manager = SkillManager(self.message_bus_mock)
+            self.addCleanup(skill_manager.shutdown)
 
             # Mock dependencies
             skill_manager.wait_for_intent_service = Mock()
@@ -629,6 +639,7 @@ class TestDeferredLoadingConfigFlag(TestCase):
         config['skills']['use_deferred_loading'] = True
         with patch.dict(Configuration._Configuration__patch, config):
             skill_manager = SkillManager(self.message_bus_mock)
+            self.addCleanup(skill_manager.shutdown)
 
             # Mock dependencies
             skill_manager.wait_for_intent_service = Mock()
@@ -668,7 +679,7 @@ class TestSkillManagerSessionManagerBus(TestCase):
 
     def test_connect_to_bus_with_intent_service_disabled(self):
         bus = MessageBusMock()
-        SkillManager(bus, enable_intent_service=False)
+        SkillManager(bus, enable_intent_service=False, enable_file_watcher=False)
         self.assertIsNotNone(SessionManager.bus)
         self.assertIs(SessionManager.bus, bus)
 


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Sonnet 5 via Claude Code — NOT human-reviewed. Verify before acting.

`SkillManager.__init__` starts a recursive watchdog `Observer` (a `FileWatcher` on the real XDG skills settings directory) by default (`enable_file_watcher=True`). `test/unittests/test_skill_manager.py` instantiates `SkillManager` about eleven times and `test/unittests/test_manager.py` once, but only a single call site ever calls `shutdown()` — the method that actually stops the observer (`SkillManager.shutdown()` around lines 720-722). Every other instance leaks its Observer/Emitter/Buffer daemon threads for the rest of the test process.

Those leaked threads keep watching the real config directory and fire their callback whenever any test writes a `settings.json` under it — including an unrelated skill in `test_intent_service.py`. When that callback logs after stderr has been torn down at interpreter shutdown, CPython aborts with exit 134 (`_enter_buffered_busy: could not acquire lock for <stderr> at interpreter shutdown`). This is reliable on Python 3.14 and intermittent on 3.11/3.12, and the earlier "race.skill" log line in the CI trace is just one of these leaked observers firing, not the owner of the leak.

The fix makes every test-created `SkillManager` get shut down: via `tearDown` for the instance owned by `setUp`, via `addCleanup` for the method-local instances built inside `with patch.dict(...)` blocks, and via `try/finally` for the one instance that's constructed and asserted on within the same block. One test that never exercises the watcher (`test_connect_to_bus_with_intent_service_disabled`) instead passes `enable_file_watcher=False`, mirroring an existing sibling test in the same class. `test_manager.py` gains a `shutdown()` call in its existing `tearDown`.

Fail-before evidence: running `test_skill_manager.py` + `test_manager.py` together and diffing `threading.enumerate()` before/after showed 38 leaked `InotifyObserver` threads (114 new threads total once their Buffer/Emitter helper threads are counted) before this fix; 0 after, once a brief settle window lets `shutdown()`'s async observer join complete. The full `test/unittests` suite is unchanged at 456 passed, 6 xfailed.

## Test plan
- [x] `test/unittests/test_skill_manager.py` + `test/unittests/test_manager.py` run together, `threading.enumerate()` diffed before/after: 38 leaked Observer threads before, 0 after
- [x] Full `test/unittests` suite: 456 passed, 6 xfailed (unchanged from baseline)
- [x] `pr-hygiene` linter clean, single commit, only the two test files touched