### PR TITLE
feat: add Kabyle (kab-dz) global stop vocabulary

### DIFF
--- a/ovos_core/intent_services/locale/kab-dz/global_stop.voc
+++ b/ovos_core/intent_services/locale/kab-dz/global_stop.voc
@@ -1,0 +1,22 @@
+seḥbes-iten akk
+ḥbes-iten akk
+ḥbes akk
+ḥbes kullec
+fakk akk
+fakk-iten akk
+fakk kullec
+sefsex akk
+sefsex-iten akk
+sefsex kullec
+kfu akk
+kfu-ten akk
+kfu kullec
+ḥbes kullec tura
+ḥbes-iten akk tura
+seḥbes-iten akk tura
+fakk akk ikalan
+kfu akk tigawtin
+seḥbes akk irmad
+seḥbes akk ikalan i yekkren
+seḥbes akk tigawtin i iteddun
+seḥbes akk tigawtin turmudin


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 5 (claude-opus-5) via Claude Code — NOT human-reviewed. Verify before acting.

Adds `ovos_core/intent_services/locale/kab-dz/global_stop.voc` — ovos-localize issue #249.

**Directory case corrected** to `kab-dz`: every other locale under `intent_services/locale/` in this repository is lowercase (`ca-es`, `de-de`, `pt-pt`). Both spellings resolve through `closest_lang`, so this is consistency rather than correctness.

Kabyle locale resources contributed by @athmanemokraoui through [OVOS Localize](https://openvoiceos.github.io/ovos-localize/).

These were submitted as translation issues on `ovos-localize`, where the automation that normally opens the pull request failed: it asks GitHub for an installation token scoped to the target repository, and `GET /repos/{owner}/{repo}/installation` returns 404 when the OVOS Localize app is not installed there. The translations were preserved in the issues; this applies them by hand.

**Verified:** the file content is exactly what the contributor submitted, decoded from the issue payload. The path was checked against the sibling locales in this repository rather than taken from the issue, because the tool stores a path that can be out of date.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Kabyle (kab-dz) voice commands for stopping all active activities.
  * Supports 22 recognized phrases, including commands equivalent to "stop everything" and "cancel all tasks."

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

