### PR TITLE
fix: emit bus reply when pip install/uninstall raises RuntimeError

### DIFF
--- a/ovos_core/skill_installer.py
+++ b/ovos_core/skill_installer.py
@@ -303,7 +303,11 @@ class SkillsStore:
 
         url = message.data["url"]
         if self.validate_skill(url):
-            success = self.pip_install([f"git+{url}"])
+            try:
+                success = self.pip_install([f"git+{url}"])
+            except RuntimeError as e:
+                LOG.error(f"pip failed: {e}")
+                success = False
             if success:
                 self.bus.emit(message.reply("ovos.skills.install.complete"))
             else:
@@ -363,7 +367,12 @@ class SkillsStore:
             return
         pkgs = message.data.get("packages")
         if pkgs:
-            if self.pip_install(pkgs):
+            try:
+                success = self.pip_install(pkgs)
+            except RuntimeError as e:
+                LOG.error(f"pip failed: {e}")
+                success = False
+            if success:
                 self.bus.emit(message.reply("ovos.pip.install.complete"))
             else:
                 self.bus.emit(message.reply("ovos.pip.install.failed",
@@ -382,7 +391,12 @@ class SkillsStore:
             return
         pkgs = message.data.get("packages")
         if pkgs:
-            if self.pip_uninstall(pkgs):
+            try:
+                success = self.pip_uninstall(pkgs)
+            except RuntimeError as e:
+                LOG.error(f"pip failed: {e}")
+                success = False
+            if success:
                 self.bus.emit(message.reply("ovos.pip.uninstall.complete"))
             else:
                 self.bus.emit(message.reply("ovos.pip.uninstall.failed",

--- a/test/unittests/test_skill_installer.py
+++ b/test/unittests/test_skill_installer.py
@@ -350,5 +350,42 @@ def test_handle_uninstall_python_success(skills_store):
     assert skills_store.bus.message_data[-1] == {}
 
 
+@pytest.mark.parametrize('skills_store', [{"allow_pip": True}], indirect=True)
+def test_handle_install_python_pip_raises(skills_store):
+    # pip_install raises RuntimeError on a genuine pip failure (non-zero
+    # exit); the handler must still emit a .failed reply instead of
+    # letting the exception propagate and leaving the caller hanging.
+    skills_store.play_error_sound = Mock()
+    skills_store.pip_install = Mock(side_effect=RuntimeError("pip exited with status 1"))
+    packages = ["some-broken-package"]
+    skills_store.handle_install_python(Message(msg_type="test", data={"packages": packages}))
+    skills_store.pip_install.assert_called_once_with(packages)
+    assert skills_store.bus.message_types[-1] == "ovos.pip.install.failed"
+    assert skills_store.bus.message_data[-1] == {"error": "error in pip subprocess"}
+
+
+@pytest.mark.parametrize('skills_store', [{"allow_pip": True}], indirect=True)
+def test_handle_uninstall_python_pip_raises(skills_store):
+    skills_store.play_error_sound = Mock()
+    skills_store.pip_uninstall = Mock(side_effect=RuntimeError("pip exited with status 1"))
+    packages = ["some-broken-package"]
+    skills_store.handle_uninstall_python(Message(msg_type="test", data={"packages": packages}))
+    skills_store.pip_uninstall.assert_called_once_with(packages)
+    assert skills_store.bus.message_types[-1] == "ovos.pip.uninstall.failed"
+    assert skills_store.bus.message_data[-1] == {"error": "error in pip subprocess"}
+
+
+@pytest.mark.parametrize('skills_store', [{"allow_pip": True}], indirect=True)
+def test_handle_install_skill_pip_raises(skills_store):
+    skills_store.play_error_sound = Mock()
+    skills_store.pip_install = Mock(side_effect=RuntimeError("pip exited with status 1"))
+    skills_store.validate_skill = Mock(return_value=True)
+    skills_store.handle_install_skill(
+        Message(msg_type="test", data={"url": "https://github.com/OpenVoiceOS/skill-foo"}))
+    skills_store.pip_install.assert_called_once_with(["git+https://github.com/OpenVoiceOS/skill-foo"])
+    assert skills_store.bus.message_types[-1] == "ovos.skills.install.failed"
+    assert skills_store.bus.message_data[-1] == {"error": "error in pip subprocess"}
+
+
 if __name__ == "__main__":
     pytest.main()


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Sonnet 5 (claude-sonnet-5) via Claude Code — NOT human-reviewed. Verify before acting.

When pip exits non-zero, `pip_install` and `pip_uninstall` in `ovos_core/skill_installer.py` raise a `RuntimeError` carrying pip's stderr. That is by design — it is the plumbing that lets callers distinguish "no packages given" (returns `False`) from an actual pip failure (raises). The problem is that the three bus handlers built on top of them, `handle_install_python`, `handle_uninstall_python`, and `handle_install_skill`, called `pip_install`/`pip_uninstall` directly and let that exception propagate straight out of the handler. A genuine pip failure is the single commonest way this code path fails, and it produced total silence on the bus: no `ovos.pip.install.failed`, no `ovos.skills.install.failed`, nothing. Whatever asked for the install or uninstall — a skill, a CLI, a UI — just sat waiting until its own timeout expired with no error to show the user.

The fix wraps each of the three calls in a `try/except RuntimeError`, falling back to `success = False` so the existing failure branch runs and emits the `.failed` reply carrying `InstallError.PIP_ERROR`. `handle_uninstall_skill` in the same file already survives this, though by a broader `except Exception` that reports pip's stderr verbatim rather than the vocabulary value. The guard added here matches `ovos_utils`' `ServiceInstaller`, which wraps the same two calls the same way, so the two installer implementations answer a failed pip run identically. Nothing about `pip_install`/`pip_uninstall` themselves changes, and no other behavior is touched.

Three regression tests were added to `test/unittests/test_skill_installer.py`, one per affected handler, each mocking `pip_install`/`pip_uninstall` to raise `RuntimeError` and asserting a `.failed` reply carrying `PIP_ERROR` actually arrives on the bus. All three fail against unmodified `dev` — the `RuntimeError` propagates out of the handler call and the test errors out rather than reaching any assertion — and pass once the guard is in place. The full existing test file (38 tests) passes unchanged after the fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Python package and skill installation or removal failures.
  * Users now receive a clear failure response when a pip operation encounters an error, instead of the process stopping unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->