### PR TITLE
fix: invalidate ovos-config merge cache in deferred-loading config-flag tests

### DIFF
--- a/test/unittests/test_skill_manager.py
+++ b/test/unittests/test_skill_manager.py
@@ -471,6 +471,7 @@ class TestDeferredLoadingConfigFlag(TestCase):
         config = mock_config()
         config['skills']['use_deferred_loading'] = False  # Explicitly set to False
         with patch.dict(Configuration._Configuration__patch, config):
+            Configuration._invalidate_cache()
             skill_manager = SkillManager(self.message_bus_mock)
             self.addCleanup(skill_manager.shutdown)
             self.assertFalse(skill_manager._use_deferred_loading)
@@ -480,6 +481,7 @@ class TestDeferredLoadingConfigFlag(TestCase):
         config = mock_config()
         config['skills']['use_deferred_loading'] = True
         with patch.dict(Configuration._Configuration__patch, config):
+            Configuration._invalidate_cache()
             skill_manager = SkillManager(self.message_bus_mock)
             self.addCleanup(skill_manager.shutdown)
             self.assertTrue(skill_manager._use_deferred_loading)
@@ -489,6 +491,7 @@ class TestDeferredLoadingConfigFlag(TestCase):
         config = mock_config()
         config['skills']['use_deferred_loading'] = False  # Explicitly set to False
         with patch.dict(Configuration._Configuration__patch, config):
+            Configuration._invalidate_cache()
             skill_manager = SkillManager(self.message_bus_mock)
             self.addCleanup(skill_manager.shutdown)
 
@@ -519,6 +522,7 @@ class TestDeferredLoadingConfigFlag(TestCase):
         config = mock_config()
         config['skills']['use_deferred_loading'] = True
         with patch.dict(Configuration._Configuration__patch, config):
+            Configuration._invalidate_cache()
             skill_manager = SkillManager(self.message_bus_mock)
             self.addCleanup(skill_manager.shutdown)
 
@@ -552,6 +556,7 @@ class TestDeferredLoadingConfigFlag(TestCase):
         config = mock_config()
         config['skills']['use_deferred_loading'] = False  # Explicitly set to False
         with patch.dict(Configuration._Configuration__patch, config):
+            Configuration._invalidate_cache()
             skill_manager = SkillManager(self.message_bus_mock)
             self.addCleanup(skill_manager.shutdown)
 
@@ -583,6 +588,7 @@ class TestDeferredLoadingConfigFlag(TestCase):
         config = mock_config()
         config['skills']['use_deferred_loading'] = True
         with patch.dict(Configuration._Configuration__patch, config):
+            Configuration._invalidate_cache()
             skill_manager = SkillManager(self.message_bus_mock)
             self.addCleanup(skill_manager.shutdown)
 
@@ -612,6 +618,7 @@ class TestDeferredLoadingConfigFlag(TestCase):
         config = mock_config()
         config['skills']['use_deferred_loading'] = False  # Explicitly set to False
         with patch.dict(Configuration._Configuration__patch, config):
+            Configuration._invalidate_cache()
             skill_manager = SkillManager(self.message_bus_mock)
             self.addCleanup(skill_manager.shutdown)
 
@@ -638,6 +645,7 @@ class TestDeferredLoadingConfigFlag(TestCase):
         config = mock_config()
         config['skills']['use_deferred_loading'] = True
         with patch.dict(Configuration._Configuration__patch, config):
+            Configuration._invalidate_cache()
             skill_manager = SkillManager(self.message_bus_mock)
             self.addCleanup(skill_manager.shutdown)
 


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5, review and orchestration) with Claude Sonnet 5 (claude-sonnet-5, edits) via Claude Code — NOT human-reviewed. Verify before acting.

CI's build_tests job was red on every open PR because `test/unittests/test_skill_manager.py::TestDeferredLoadingConfigFlag` failed 3 of its 8 tests on a clean `dev` checkout: `test_deferred_loading_enabled_via_config` asserted `_use_deferred_loading` was `False` when the test had set it to `True`, and two other tests failed on the same stale value.

The root cause is an interaction between this test class and a caching change in `ovos-config` 2.3.11a1. `Configuration` now memoizes the merged config in `Configuration._merged_cache` and only invalidates it through class-attribute assignment or the public patch/reload machinery. `TestDeferredLoadingConfigFlag` sets up each test with `patch.dict(Configuration._Configuration__patch, config)`, which mutates the underlying patch dict's contents in place rather than reassigning the class attribute, so the cache-invalidation hook never fires. Whichever value of `use_deferred_loading` gets merged and cached by the first test in the class sticks around for every subsequent test in the same process, regardless of what later tests patch in.

The fix calls `Configuration._invalidate_cache()` immediately after entering each `patch.dict(...)` context in this test class, forcing the merge to rebuild from the freshly patched values before `SkillManager` reads them. No production code changed: the `skill_manager.py` config-read logic (`self.config.get("skills", {}).get("use_deferred_loading", False)`) is already correct, and the deferred-loading feature does not exist in the last stable release (v0.8.5) so there is no back-compat surface to consider.

I reproduced the failure on `dev`, then confirmed fail-before by reverting only the test-file change while keeping it applied against the fix commit's tree: `test_deferred_loading_enabled_via_config`, `test_connectivity_handlers_registered_when_deferred_loading_enabled`, and `test_run_uses_deferred_loading_when_enabled` failed consistently across four repeated runs (`3 failed, 22 passed` each time), reproducing the exact symptom including the `False is not true` assertion. With the fix restored, the same file passes `25 passed` consistently across three repeated runs, and the full `test/unittests` suite passes `456 passed, 6 xfailed` in one run. A separate, pre-existing flake in `TestSkillManager::test_instantiate` shows up intermittently in both the pre-fix and post-fix trees when running the whole file repeatedly; it is unrelated to this defect and was confirmed present on unmodified `dev` as well.
