### PR TITLE
fix: make skill_manager tests hermetic against config cache state

### DIFF
--- a/test/unittests/test_skill_manager.py
+++ b/test/unittests/test_skill_manager.py
@@ -111,6 +111,7 @@ class TestSkillManager(TestCase):
         config['skills']['use_deferred_loading'] = False
         SessionManager.bus = None
         with patch.dict(Configuration._Configuration__patch, config):
+            Configuration._invalidate_cache()
             bus_mock = MessageBusMock()
             skill_manager = SkillManager(bus_mock)
             try:


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5, review and orchestration) with Claude Sonnet 5 (claude-sonnet-5, edits) via Claude Code — NOT human-reviewed. Verify before acting.

Every PR against `dev` — including docs-only ones — has been showing scattered `build_tests` reds on one or two of the Python-version jobs, with a different version failing each run. The failing job was `TestSkillManager::test_instantiate` in `test/unittests/test_skill_manager.py`, comparing the list of message-bus handlers `SkillManager` registers against an expected list that assumes deferred loading is disabled. The failure list carried extra `mycroft.network.connected`, `mycroft.internet.connected`, `mycroft.gui.available` and related connectivity handlers, which only get registered when deferred loading is enabled.

`test_instantiate` patches `Configuration._Configuration__patch` with `use_deferred_loading` explicitly set to `False` before constructing `SkillManager`, but it never calls `Configuration._invalidate_cache()` inside that patch context. Every other `patch.dict(Configuration._Configuration__patch, ...)` site in this file does call it, following the pattern introduced by a prior fix (#892) once `ovos-config` 2.3.11a1 added a memoized merge cache that only refreshes through that public API. When a different test in the same process — `TestDeferredLoadingConfigFlag`'s `use_deferred_loading=True` cases — runs first and leaves the merge cache populated with the deferred-loading config, `test_instantiate`'s own patch has no effect on what `Configuration()` returns, because the cache is never invalidated to pick it up. `SkillManager` then registers the connectivity handlers the test does not expect. Because `pytest-randomly` shuffles test order on every run, the leak only shows up when the ordering happens to put the contaminating test first, which explains why it manifested as a different Python version failing on each CI run.

The fix adds the missing `Configuration._invalidate_cache()` call right after entering the patch context in `test_instantiate`, matching the idiom already used everywhere else in the file.

Reproduction: looping `pytest test/unittests/test_skill_manager.py` unseeded failed once in 8 runs on unmodified `dev`. Pinning `pytest-randomly` to seed 9 reproduces the failure deterministically, with the assertion showing the extra connectivity handlers. After the fix, seed 9 passes, and 10 consecutive unseeded runs of the file all pass (25 passed each time). The full `test/unittests` suite was run twice after the fix: 456 passed, 6 xfailed, both times, with no other test affected.
