### PR TITLE
fix: allow ovos-config 3.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     # OVOS-CONTEXT-1 §5.3: SessionManager intent_context field (bus-client #239)
     "ovos_bus_client>=2.7.1a1,<3.0.0",
     "ovos-plugin-manager>=2.11.1a1,<3.0.0",
-    "ovos-config>=2.1.4a5,<3.0.0",
+    "ovos-config>=2.1.4a5,<4.0.0",
     "ovos-workshop>=9.3.11a1,<10.0.0",
     "rapidfuzz>=3.6,<4.0",
     "ovos-spec-tools[langcodes]>=1.6.1a1,<2.0.0",


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5, review and orchestration) with Claude Sonnet 5 (claude-sonnet-5, edits) via Claude Code — NOT human-reviewed. Verify before acting.

ovos-config 3.0.0a1 is a breaking release that introduces AssistantConfig and removes the remote-config APIs. An adversarial sweep of this repo found no use of any API that was removed in that release, so the `<3.0.0` upper bound on the `ovos-config` dependency only blocks a compatible upgrade without protecting against any real incompatibility.

This raises the cap to `<4.0.0`, keeping the existing floor. Normal resolution still lands on ovos-config 2.x because the PyPI release of ovos-bus-client still caps ovos-config below 3.0.0 (that cap-lift is a separate draft PR). Forcing `ovos-config==3.0.1a1` and running the full suite against it gives 503 passed and 6 xfailed, with no failures.

Merge after ovos-config 3.0.1a1: 3.0.0a1 is missing follow-up hardening that ships in 3.0.1a1.