### PR TITLE
fix: back off failed plugin-skill loads and report loaded_new truthfully

### DIFF
--- a/docs/prerelease-quirks.md
+++ b/docs/prerelease-quirks.md
@@ -9,6 +9,22 @@ This file resets at the next stable release. At that point its contents
 become upgrade notes for the `2.1.1 -> next-stable` jump, and a new, empty
 quirks log starts.
 
+## #905 (alpha of 2026-09-01)
+
+`SkillManager._load_plugin_skill`'s `finally` block only tracked a plugin
+skill in `self.plugin_skills` once a `PluginSkillLoader` instance existed;
+if `_get_plugin_skill_loader`/`.load()` raised before that instance was
+bound, the skill was left out of `plugin_skills` while the in-flight marker
+was still cleared, so the next periodic scan (`load_plugin_skills`, every
+30s) saw it as "never attempted" and reloaded it from scratch — reinstating
+the skill and re-registering its intents on every scan, indefinitely.
+Failed loads are now tracked separately with an exponential backoff (30s,
+capped at 15 minutes) before a retry is attempted again; a successful load
+clears the backoff. Separately, `load_plugin_skills` set `loaded_new = True`
+on every load *attempt* rather than on confirmed success, so a skill stuck
+in the retry loop above also re-triggered the `mycroft.skills.train`
+broadcast on every scan; `loaded_new` now reflects the actual load result.
+
 ## 3.0.7a5
 
 `main()` now closes the messagebus client and joins its receiver thread,

--- a/ovos_core/skill_manager.py
+++ b/ovos_core/skill_manager.py
@@ -37,6 +37,14 @@ from ovos_workshop.skills.api import SkillApi
 
 from ovos_plugin_manager.skills import find_skill_plugins
 
+# Backoff schedule for retrying a plugin skill whose load raised before a
+# `PluginSkillLoader` instance existed (eg. an error in the skill's own
+# `__init__`). Without a backoff such a skill is indistinguishable from
+# "never attempted" on the next scan and gets fully re-instantiated - and its
+# intents re-registered - on every 30s scan, forever.
+PLUGIN_SKILL_RETRY_BASE_SECONDS = 30
+PLUGIN_SKILL_RETRY_MAX_SECONDS = 15 * 60
+
 
 def on_started() -> None:
     LOG.info('Skills Manager is starting up.')
@@ -127,6 +135,10 @@ class SkillManager(Thread):
         self.plugin_skills = {}
         self._plugin_skills_lock = threading.RLock()
         self._loading_plugin_skills = set()
+        # skill_id -> (attempt_count, last_attempt_time) for plugin skills whose
+        # load raised before a loader object existed (see _load_plugin_skill).
+        # These are retried with an exponential backoff instead of every scan.
+        self._plugin_skill_failures = {}
         self.num_install_retries = 0
         self.empty_skill_dirs = set()  # Save a record of empty skill dirs.
 
@@ -256,6 +268,28 @@ class SkillManager(Thread):
         with self._plugin_skills_lock:
             self._loading_plugin_skills.discard(skill_id)
 
+    def _should_retry_plugin_skill(self, skill_id: str) -> bool:
+        """Check whether enough time has passed to retry a previously failed load."""
+        with self._plugin_skills_lock:
+            failure = self._plugin_skill_failures.get(skill_id)
+        if failure is None:
+            return True
+        attempts, last_attempt = failure
+        delay = min(PLUGIN_SKILL_RETRY_BASE_SECONDS * (2 ** (attempts - 1)),
+                    PLUGIN_SKILL_RETRY_MAX_SECONDS)
+        return time.time() - last_attempt >= delay
+
+    def _record_plugin_skill_failure(self, skill_id: str) -> None:
+        """Record a failed load attempt, extending the backoff before the next retry."""
+        with self._plugin_skills_lock:
+            attempts, _ = self._plugin_skill_failures.get(skill_id, (0, 0.0))
+            self._plugin_skill_failures[skill_id] = (attempts + 1, time.time())
+
+    def _clear_plugin_skill_failure(self, skill_id: str) -> None:
+        """Clear any recorded backoff once a skill loads successfully."""
+        with self._plugin_skills_lock:
+            self._plugin_skill_failures.pop(skill_id, None)
+
     def _defer_skill_load_until_startup_complete(self):
         """Queue connectivity-triggered skill loads until the intent service is ready."""
         with self._startup_lock:
@@ -379,6 +413,8 @@ class SkillManager(Thread):
                 continue
             if self._is_plugin_skill_tracked(skill_id):
                 continue
+            if not self._should_retry_plugin_skill(skill_id):
+                continue
             skill_loader = self._get_plugin_skill_loader(skill_id, init_bus=False,
                                                          skill_class=plug)
             requirements = skill_loader.runtime_requirements
@@ -388,8 +424,8 @@ class SkillManager(Thread):
                 continue
             if not self._reserve_plugin_skill_load(skill_id):
                 continue
-            self._load_plugin_skill(skill_id, plug, reserved=True)
-            loaded_new = True
+            if self._load_plugin_skill(skill_id, plug, reserved=True) is not None:
+                loaded_new = True
         return loaded_new
 
     def _get_internal_skill_bus(self) -> MessageBusClient:
@@ -457,6 +493,15 @@ class SkillManager(Thread):
             if skill_loader is not None:
                 with self._plugin_skills_lock:
                     self.plugin_skills[skill_id] = skill_loader
+                if load_status:
+                    self._clear_plugin_skill_failure(skill_id)
+            else:
+                # `_get_plugin_skill_loader`/`.load()` raised before a loader
+                # object existed - there is nothing to track in
+                # `self.plugin_skills`, so record the failure separately or
+                # this skill would look "never attempted" and get retried
+                # (and its intents re-registered) on every 30s scan forever.
+                self._record_plugin_skill_failure(skill_id)
             self._release_plugin_skill_load(skill_id)
 
         return skill_loader if load_status else None

--- a/test/unittests/test_skill_manager.py
+++ b/test/unittests/test_skill_manager.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 import tempfile
+import time as time_module
 from copy import deepcopy
 from pathlib import Path
 from shutil import rmtree
@@ -25,7 +26,8 @@ from ovos_config import Configuration
 from ovos_config import LocalConf, DEFAULT_CONFIG
 from ovos_bus_client.session import SessionManager
 from ovos_spec_tools import SpecMessage
-from ovos_core.skill_manager import SkillManager
+from ovos_core.skill_manager import (SkillManager, PLUGIN_SKILL_RETRY_BASE_SECONDS,
+                                      PLUGIN_SKILL_RETRY_MAX_SECONDS)
 from ovos_workshop.skill_launcher import SkillLoader
 
 
@@ -449,6 +451,150 @@ class TestSkillManager(TestCase):
         self.assertIsNone(result)
 
 
+    def _loader_creation_side_effect(self, error):
+        """Build a `_get_plugin_skill_loader` side_effect that succeeds for the
+        `load_plugin_skills` runtime-requirements probe (init_bus=False) but
+        raises `error` for the real load attempt inside `_load_plugin_skill`
+        (init_bus defaults to True there)."""
+        def side_effect(skill_id, init_bus=True, skill_class=None):
+            if not init_bus:
+                requirements = Mock()
+                requirements.network_before_load = False
+                requirements.internet_before_load = False
+                loader = Mock()
+                loader.runtime_requirements = requirements
+                return loader
+            raise error
+        return side_effect
+
+    @patch('ovos_core.skill_manager.find_skill_plugins')
+    def test_loader_creation_exception_backs_off_before_retry(self, mock_find_skill_plugins):
+        """A skill whose loader raises before an instance exists must not be
+        retried on every 30s scan - only once a backoff window has elapsed."""
+        skill_id = 'test.flaky.loader.skill'
+        mock_find_skill_plugins.return_value = {skill_id: Mock()}
+        self.skill_manager.plugin_skills = {}
+        self.skill_manager._plugin_skill_failures = {}
+        self.skill_manager._get_plugin_skill_loader = Mock(
+            side_effect=self._loader_creation_side_effect(RuntimeError("boom"))
+        )
+
+        fake_now = [1000.0]
+        with patch('ovos_core.skill_manager.time.time', side_effect=lambda: fake_now[0]):
+            loaded_new = self.skill_manager.load_plugin_skills(network=True, internet=True)
+            self.assertFalse(loaded_new)
+            first_attempt_calls = self.skill_manager._get_plugin_skill_loader.call_count
+
+            # Still inside the backoff window: no retry attempted.
+            fake_now[0] += 5
+            self.skill_manager.load_plugin_skills(network=True, internet=True)
+            self.assertEqual(
+                first_attempt_calls, self.skill_manager._get_plugin_skill_loader.call_count,
+                "skill was retried before its backoff window elapsed"
+            )
+
+            # Past the base backoff window: retry happens again.
+            fake_now[0] += PLUGIN_SKILL_RETRY_BASE_SECONDS
+            self.skill_manager.load_plugin_skills(network=True, internet=True)
+            self.assertGreater(
+                self.skill_manager._get_plugin_skill_loader.call_count, first_attempt_calls,
+                "skill was not retried after its backoff window elapsed"
+            )
+
+    @patch('ovos_core.skill_manager.find_skill_plugins')
+    def test_plugin_skill_success_clears_backoff(self, mock_find_skill_plugins):
+        """Once a flaky skill finally loads, its failure record must be
+        cleared so a later unrelated reload is not throttled by stale state."""
+        skill_id = 'test.recovering.skill'
+        mock_plugin = Mock()
+        mock_find_skill_plugins.return_value = {skill_id: mock_plugin}
+        self.skill_manager.plugin_skills = {}
+        self.skill_manager._plugin_skill_failures = {}
+
+        # Record a prior failure directly (mirrors what _load_plugin_skill does).
+        self.skill_manager._record_plugin_skill_failure(skill_id)
+        self.assertIn(skill_id, self.skill_manager._plugin_skill_failures)
+
+        mock_loader = Mock(spec=SkillLoader)
+        mock_loader.skill_id = skill_id
+        mock_loader.load.return_value = True
+        mock_loader.runtime_requirements.network_before_load = False
+        mock_loader.runtime_requirements.internet_before_load = False
+        self.skill_manager._get_plugin_skill_loader = Mock(return_value=mock_loader)
+
+        # Move well past the backoff window so the load is attempted at all.
+        fake_now = [time_module.time() + PLUGIN_SKILL_RETRY_MAX_SECONDS + 1]
+        with patch('ovos_core.skill_manager.time.time', side_effect=lambda: fake_now[0]):
+            loaded_new = self.skill_manager.load_plugin_skills(network=True, internet=True)
+
+        self.assertTrue(loaded_new)
+        self.assertNotIn(skill_id, self.skill_manager._plugin_skill_failures)
+        self.assertIn(skill_id, self.skill_manager.plugin_skills)
+
+    def test_loaded_new_reflects_actual_load_status_not_attempt(self):
+        """`loaded_new`/the train request must only fire on confirmed success,
+        never merely because a load was attempted."""
+        skill_id = 'test.attempt.only.skill'
+        mock_plugin = Mock()
+
+        with patch(self.mock_package + 'find_skill_plugins',
+                    return_value={skill_id: mock_plugin}):
+            self.skill_manager.plugin_skills = {}
+            self.skill_manager._plugin_skill_failures = {}
+            self.skill_manager._get_plugin_skill_loader = Mock(
+                side_effect=self._loader_creation_side_effect(RuntimeError("boom"))
+            )
+            self.message_bus_mock.message_types = []
+            self.skill_manager._use_deferred_loading = False
+
+            # A failed attempt must not request retraining.
+            self.skill_manager._load_new_skills(network=True, internet=True, gui=False)
+            self.assertNotIn('mycroft.skills.train', self.message_bus_mock.message_types)
+
+            # A successful load must request retraining.
+            mock_loader = Mock(spec=SkillLoader)
+            mock_loader.skill_id = skill_id
+            mock_loader.load.return_value = True
+            mock_loader.runtime_requirements.network_before_load = False
+            mock_loader.runtime_requirements.internet_before_load = False
+            self.skill_manager._get_plugin_skill_loader = Mock(return_value=mock_loader)
+            self.skill_manager._plugin_skill_failures = {}
+            self.message_bus_mock.message_types = []
+
+            self.skill_manager._load_new_skills(network=True, internet=True, gui=False)
+            self.assertIn('mycroft.skills.train', self.message_bus_mock.message_types)
+
+    @patch('ovos_core.skill_manager.find_skill_plugins')
+    def test_always_failing_skill_load_attempts_grow_sub_linearly(self, mock_find_skill_plugins):
+        """Field shape of the bug: without backoff a flaky skill is retried
+        once per 30s scan forever; with backoff, N scans over the same span
+        must yield far fewer than N load attempts."""
+        skill_id = 'test.always.failing.skill'
+        mock_find_skill_plugins.return_value = {skill_id: Mock()}
+        self.skill_manager.plugin_skills = {}
+        self.skill_manager._plugin_skill_failures = {}
+        self.skill_manager._get_plugin_skill_loader = Mock(
+            side_effect=self._loader_creation_side_effect(RuntimeError("boom"))
+        )
+
+        cycles = 40
+        fake_now = [2000.0]
+        with patch('ovos_core.skill_manager.time.time', side_effect=lambda: fake_now[0]):
+            for _ in range(cycles):
+                self.skill_manager.load_plugin_skills(network=True, internet=True)
+                fake_now[0] += PLUGIN_SKILL_RETRY_BASE_SECONDS  # one 30s scan tick
+
+        # Each call to `_get_plugin_skill_loader` inside `_load_plugin_skill`
+        # is one real load attempt (the runtime-requirements probe is a
+        # separate, non-retrying call gated out by the backoff check).
+        load_attempts = sum(
+            1 for call in self.skill_manager._get_plugin_skill_loader.call_args_list
+            if call.kwargs.get('init_bus', True)
+        )
+        self.assertLess(load_attempts, cycles,
+                         "load attempts grew linearly with scan cycles - backoff is not applied")
+        self.assertGreater(load_attempts, 0, "skill should still be retried eventually")
+
 class TestDeferredLoadingConfigFlag(TestCase):
     """Test suite for the optional deferred loading config flag."""
 
@@ -719,3 +865,4 @@ class TestSkillManagerSessionManagerBus(TestCase):
                 f"expected exactly one handler for {topic}, got "
                 f"{bus.event_handlers.count(topic)}"
             )
+


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (orchestration) with edits by Claude Sonnet 5 via Claude Code — NOT human-reviewed. Verify before acting.

This started from an investigation into a reported field incident of periodic intent re-registration. The primary journal data from that boot does not actually show the retry pattern this PR addresses — every skill in that log loaded exactly once, with no failure/retry evidence — so this PR does not claim to explain that specific incident. What the investigation did surface, and what this PR fixes, are two defects verified directly against current `dev` source in `ovos_core/skill_manager.py` that would produce exactly this failure chain if a plugin skill ever hit them.

`SkillManager` runs a periodic scan every 30 seconds (`load_plugin_skills`) that skips any skill already present in `self.plugin_skills`. `_load_plugin_skill`'s `finally` block only added the skill to that dict when a `PluginSkillLoader` instance actually existed, but it always cleared the in-flight "currently loading" marker regardless. If `_get_plugin_skill_loader` or the loader's own `.load()` raised before that instance was bound, the skill ended up in neither bucket: not tracked as loaded, not marked as loading. The next 30-second scan then saw it as never-attempted and reloaded it from scratch, which fully re-instantiates the skill class and re-runs `initialize()` — the code path where `register_intent`/`register_intent_file` live — so every retry re-emitted the same intent registrations to whichever pipeline consumes them (e.g. padatious), forever, for exactly the one flaky skill.

Compounding that, `load_plugin_skills` set `loaded_new = True` the moment `_load_plugin_skill` was *called*, not when it actually succeeded. A skill caught in the loop above therefore also re-triggered the `mycroft.skills.train` broadcast on every scan, even though nothing had actually finished loading and no other skill's set had changed.

The fix tracks failed load attempts in a separate dict (`skill_id -> (attempt_count, last_attempt_time)`) instead of conflating "failed" with "untracked." A failed attempt is retried with exponential backoff — 30 seconds, doubling, capped at 15 minutes — rather than every single scan, and a successful load clears the record so recovery is not permanently blocked. `loaded_new` now reflects whether `_load_plugin_skill` actually returned a loader, not merely whether it was invoked.

Four regression tests were added to `test/unittests/test_skill_manager.py`, and each was verified to produce a real assertion failure (not just an import error) against a partial revert that kept the new constants/helpers defined but restored the old tracking/`loaded_new` wiring: a loader-creation exception is retried only after its backoff window elapses, a subsequent success clears that backoff, a failed attempt does not fire the `mycroft.skills.train` emit while a successful one does, and repeated scans of an always-failing skill produce load attempts that grow sub-linearly with scan count rather than one per scan. The full `test/unittests` suite passes at 470 tests (plus 6 pre-existing xfails) against this branch, versus 466 passing on a clean `origin/dev` checkout with the same interpreter — no regressions, four new tests.