### PR TITLE
fix: ovos.intent.matched always carries the producing pipeline's bare id

### DIFF
--- a/docs/prerelease-quirks.md
+++ b/docs/prerelease-quirks.md
@@ -9,6 +9,19 @@ This file resets at the next stable release. At that point its contents
 become upgrade notes for the `2.1.1 -> next-stable` jump, and a new, empty
 quirks log starts.
 
+## #906 (alpha of 2026-09-02)
+
+`ovos.intent.matched`'s `pipeline_id` field (OVOS-PIPELINE-1 §9.2) carried
+the raw `session.pipeline` entry that produced the match — a
+confidence-tier matcher id such as `ovos-adapt-pipeline-plugin-high` —
+instead of the plugin's bare `pipeline_id`. Per §3.1, attribution names
+"the plugin's single `pipeline_id` — never an entry-specific string";
+`session.blacklisted_pipelines` (#854) and `_produces_reserved_name`
+already normalized before comparing, but the stamp on
+`context["pipeline_id"]`/`ovos.intent.matched` did not. The stamp is now
+normalized the same way (`_PIPELINE_MIGRATION_MAP` then the
+`-high`/`-medium`/`-low` suffix stripped) before it reaches the bus.
+
 ## #905 (alpha of 2026-09-01)
 
 `SkillManager._load_plugin_skill`'s `finally` block only tracked a plugin

--- a/ovos_core/intent_services/service.py
+++ b/ovos_core/intent_services/service.py
@@ -624,9 +624,15 @@ class IntentService:
             # update Session if modified by pipeline
             reply.context["session"] = sess.serialize()
 
-            # stamp the matching plugin's identity on the dispatch (§3.1, §7.1)
+            # stamp the matching plugin's identity on the dispatch (§3.1, §7.1).
+            # `pipeline_id` here is whatever entry `session.pipeline` used
+            # (e.g. a confidence-tier matcher id like "adapt-high"); §3 requires
+            # attribution to name the plugin's single bare `pipeline_id`, never
+            # an entry-specific string, so it is normalized the same way
+            # `get_pipeline_matcher` resolves it to a plugin.
             if pipeline_id:
-                reply.context["pipeline_id"] = pipeline_id
+                reply.context["pipeline_id"] = _PIPELINE_RE.sub(
+                    '', _PIPELINE_MIGRATION_MAP.get(pipeline_id, pipeline_id))
 
             skill_id = (match.skill_id
                         or (match.match_data or {}).get("skill_id")

--- a/test/unittests/test_dispatcher.py
+++ b/test/unittests/test_dispatcher.py
@@ -297,6 +297,30 @@ class TestDispatchFromMatch(unittest.TestCase):
         self.assertEqual(handled[0].data, {})
         svc.intent_dispatcher.shutdown()
 
+    def test_matched_notification_carries_bare_pipeline_id(self):
+        """OVOS-PIPELINE-1 §9.2/§3.1: ``pipeline_id`` on ``ovos.intent.matched``
+        identifies the plugin, never an entry-specific confidence-tier string
+        such as ``session.pipeline``'s ``-high``/``-medium``/``-low`` matcher
+        id. The loop in ``handle_utterance`` passes whatever ``session.pipeline``
+        entry produced the match; ``_dispatch_match`` must normalize it."""
+        svc, bus = self._make_service()
+        matched = []
+        bus.on(SpecMessage.INTENT_MATCHED.value, lambda m: matched.append(m))
+        self._report_complete(bus)
+
+        match = IntentHandlerMatch(match_type="test.skill:do",
+                                   match_data={}, skill_id="test.skill",
+                                   utterance="hello")
+        msg = Message(SpecMessage.UTTERANCE,
+                      {"utterances": ["hello"]},
+                      {"session": Session("s1").serialize()})
+        svc._dispatch_match(match, msg, "en-US",
+                            pipeline_id="ovos-adapt-pipeline-plugin-high")
+        self.assertEqual(len(matched), 1)
+        self.assertEqual(matched[0].data["pipeline_id"],
+                         "ovos-adapt-pipeline-plugin")
+        svc.intent_dispatcher.shutdown()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Sonnet 5 via Claude Code — NOT human-reviewed. Verify before acting.

OVOS-PIPELINE-1 §3.1 says attribution — the dispatch topic, `Match.skill_id`, the `session.active_handlers` stamp, the introspection topic, and a `blacklisted_pipelines` entry — must all name "the plugin's single `pipeline_id` — never an entry-specific string." §9.2 spells out the same requirement for `ovos.intent.matched`'s `pipeline_id` field: "The `pipeline_id` of the plugin that produced the match."

`IntentService._dispatch_match` in `ovos_core/intent_services/service.py` stamped `context["pipeline_id"]` (and, from there, the `ovos.intent.matched` payload) with whatever raw entry `session.pipeline` used to produce the match — for example `ovos-adapt-pipeline-plugin-high` — rather than the bare plugin id `ovos-adapt-pipeline-plugin`. The same file already normalizes this correctly in two other places: `get_pipeline_matcher` strips the confidence-tier suffix and applies the legacy-name migration map to resolve a plugin, and the `session.blacklisted_pipelines` check (#854) does the same before comparing. The `ovos.intent.matched` stamp was the one place that skipped it, so any consumer keying off the emitted `pipeline_id` field (a config-tier variant vs. the plugin's canonical identity) saw the un-normalized string.

The fix applies the identical normalization — `_PIPELINE_MIGRATION_MAP` lookup, then the `-high`/`-medium`/`-low` suffix strip — at the one remaining stamping site, right before `context["pipeline_id"]` is set and the notification is emitted.

I verified this against the current `dev` source of `ovos-core`, reading OVOS-PIPELINE-1 §3, §3.1 and §9.2 directly rather than relying on a cached description of the defect. I also checked §9.3 (`ovos.intent.unmatched`) for the same requirement — it does not include `pipeline_id` at all, so no corresponding change was needed there.

## Test plan
- Added `test_matched_notification_carries_bare_pipeline_id` in `test/unittests/test_dispatcher.py`, calling `_dispatch_match` with a confidence-tier `pipeline_id` and asserting the emitted `ovos.intent.matched` payload carries the bare plugin id.
- Confirmed the new test fails against the unfixed source (`AssertionError: 'ovos-adapt-pipeline-plugin-high' != 'ovos-adapt-pipeline-plugin'`) via a patch-revert-run-restore cycle, and passes with the fix applied.
- Ran the full `test/unittests` suite on the branch: 471 passed, 6 xfailed (matches the baseline; no regressions).
- `test/end2end` hangs past 60s per-file both on this branch and on unmodified `dev` in the same HOME-isolated sandbox (pre-existing environment issue, unrelated to this change — confirmed by running the identical command against a fresh `dev` clone).