### PR TITLE
feat(telemetry): report whether the intent match came from the default session

### DIFF
--- a/ovos_core/intent_services/service.py
+++ b/ovos_core/intent_services/service.py
@@ -579,7 +579,8 @@ class IntentService:
                                                         match.match_type,
                                                         lang,
                                                         match.match_data,
-                                                        sess.pipeline))
+                                                        sess.pipeline,
+                                                        sess.session_id == "default"))
 
         if reply is not None:
             reply.data["utterance"] = match.utterance
@@ -649,16 +650,24 @@ class IntentService:
                                                         "complete_intent_failure",
                                                         lang,
                                                         match.match_data,
-                                                        sess.pipeline))
+                                                        sess.pipeline,
+                                                        sess.session_id == "default"))
 
     @staticmethod
-    def _upload_match_data(utterance: str, intent: str, lang: str, match_data: dict, pipeline: List[str]):
+    def _upload_match_data(utterance: str, intent: str, lang: str, match_data: dict, pipeline: List[str],
+                            session_default: bool):
         """if enabled upload the intent match data to a server, allowing users and developers
         to collect metrics/datasets to improve the pipeline plugins and skills.
 
         There isn't a default server to upload things too, users needs to explicitly configure one
 
         https://github.com/OpenVoiceOS/ovos-opendata-server
+
+        ``session_default`` is True when the match came from the "default" session
+        (ie. a local client). It is a privacy-preserving proxy for counting remote
+        (HiveMind) clients by exclusion: remote clients always carry a non-default
+        session id, so no session id or other identifier is ever uploaded, only
+        this boolean.
         """
         config = Configuration().get("open_data", {})
         endpoints: List[str] = config.get("intent_urls", [])  # eg. "http://localhost:8000/intents"
@@ -674,7 +683,8 @@ class IntentService:
             "lang": lang,
             "match_data": json.dumps(match_data, ensure_ascii=False),
             "pipeline": "|".join(pipeline),
-            "core_version": OVOS_VERSION_STR
+            "core_version": OVOS_VERSION_STR,
+            "session_default": session_default
         }
         for url in endpoints:
             try:

--- a/test/unittests/test_intent_service_extended.py
+++ b/test/unittests/test_intent_service_extended.py
@@ -1558,7 +1558,7 @@ class TestBlacklistedPipelines(unittest.TestCase):
 class TestUploadMatchData(unittest.TestCase):
     """The intent-metrics payload carries the session pipeline and core version."""
 
-    def _post_payload(self, pipeline):
+    def _post_payload(self, pipeline, session_default=False):
         captured = {}
 
         def _fake_post(url, data=None, headers=None, timeout=None):
@@ -1572,17 +1572,27 @@ class TestUploadMatchData(unittest.TestCase):
                       side_effect=_fake_post):
             IntentService._upload_match_data(
                 "turn on the lights", "test:intent", "en-US",
-                {"skill_id": "test.skill"}, pipeline)
+                {"skill_id": "test.skill"}, pipeline, session_default)
         return captured
 
     def test_pipeline_joined_into_payload(self):
-        captured = self._post_payload(["adapt_high", "padatious_high"])
+        captured = self._post_payload(["adapt_high", "padatious_high"], False)
         self.assertEqual(captured["pipeline"], "adapt_high|padatious_high")
 
     def test_core_version_in_payload(self):
         from ovos_core.version import OVOS_VERSION_STR
-        captured = self._post_payload(["adapt_high"])
+        captured = self._post_payload(["adapt_high"], False)
         self.assertEqual(captured["core_version"], OVOS_VERSION_STR)
+
+    def test_default_session_reported_true(self):
+        """A match from the "default" session is flagged so remote (HiveMind)
+        clients can be counted, by exclusion, without uploading any session id."""
+        captured = self._post_payload(["adapt_high"], True)
+        self.assertIs(captured["session_default"], True)
+
+    def test_non_default_session_reported_false(self):
+        captured = self._post_payload(["adapt_high"], False)
+        self.assertIs(captured["session_default"], False)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

This adds a `session_default` boolean field to the intent-metrics payload that `_upload_match_data` POSTs to any configured `open_data.intent_urls` endpoint. It is derived from the same session the intent match was dispatched against (no new session lookup is introduced) and is simply `sess.session_id == "default"`.

The motivation is a privacy-respecting way to estimate how many users reach a core over HiveMind. A message carries the "default" session id only when it originates locally; any remote client (HiveMind satellite, voice-remote, etc.) is always assigned a non-default session id by the orchestrator. So `session_default: false` in the uploaded metrics is, by construction, a remote hit, and operators can tally remote-vs-local traffic without the payload ever containing a session id, device id, or any other identifier — just the one boolean.

No existing payload fields change. The upload remains entirely opt-in: nothing is sent unless the deployer configures `open_data.intent_urls` themselves, and there is no default endpoint.

Tests extend the existing `TestUploadMatchData` suite in `test/unittests/test_intent_service_extended.py` with two new cases: a default-session match asserting `session_default` is `True` in the captured payload, and a non-default-session match asserting `False`. Both new cases (and the two pre-existing ones, whose call site also needed the new positional argument) failed with `TypeError: _upload_match_data() takes 5 positional arguments but 6 were given` against the unfixed source, and all four pass after the fix. The touched test files (`test_intent_service_extended.py` and `test_intent_service.py`, 92 tests total) pass in full.