### PR TITLE
fix: improve unknown pipeline matcher log message

### DIFF
--- a/ovos_core/intent_services/service.py
+++ b/ovos_core/intent_services/service.py
@@ -317,7 +317,7 @@ class IntentService:
         pipe_id = _PIPELINE_RE.sub('', matcher_id)
         plugin = self.pipeline_plugins.get(pipe_id)
         if not plugin:
-            LOG.error(f"Unknown pipeline matcher: {matcher_id}")
+            LOG.error(f"Unknown pipeline matcher '{matcher_id}': no installed plugin provides it. A bare ovos-core install ships no matchers - install ovos-core[plugins] or add the specific plugin to your environment.")
             return None
 
         if isinstance(plugin, ConfidenceMatcherPipeline):

--- a/test/unittests/test_intent_service_extended.py
+++ b/test/unittests/test_intent_service_extended.py
@@ -212,11 +212,17 @@ class TestDisambiguateLang(unittest.TestCase):
 class TestGetPipelineMatcher(unittest.TestCase):
     """Tests for IntentService.get_pipeline_matcher."""
 
-    def test_returns_none_for_unknown_plugin(self):
+    @patch("ovos_core.intent_services.service.LOG")
+    def test_returns_none_for_unknown_plugin(self, mock_log):
         """An unknown matcher_id returns None and logs an error."""
         svc = _make_service()
         result = svc.get_pipeline_matcher("nonexistent-pipeline-plugin")
         self.assertIsNone(result)
+        # Verify error was logged with helpful message
+        self.assertTrue(mock_log.error.called)
+        error_msg = " ".join(str(c) for c in mock_log.error.call_args_list)
+        self.assertIn("nonexistent-pipeline-plugin", error_msg)
+        self.assertIn("no installed plugin provides it", error_msg)
 
     def test_returns_match_high_for_high_suffix(self):
         """A ConfidenceMatcherPipeline plugin with -high suffix returns match_high."""


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Haiku 4.5 via Claude Code — NOT human-reviewed. Verify before acting.

When session.pipeline names a matcher whose plugin isn't installed, the log message now clearly states that no installed plugin provides it and points users to the remedy. The installer already uses the ovos-core[plugins] extra, so this is a diagnosability fix for bare installs in resolver-fresh environments.

- Verified existing test failures before fix (fail-before test included)
- All 85 tests in test_intent_service_extended.py pass
- Commit includes test enhancement to verify log message content