### PR TITLE
fix: take the inbound session at the utterance intake

### DIFF
--- a/docs/prerelease-quirks.md
+++ b/docs/prerelease-quirks.md
@@ -9,6 +9,35 @@ This file resets at the next stable release. At that point its contents
 become upgrade notes for the `2.1.1 -> next-stable` jump, and a new, empty
 quirks log starts.
 
+## #915 (alpha of 2026-09-03)
+
+Floors moved to `ovos-bus-client` 2.11.1a1 and `ovos-spec-tools` 1.10.1a1,
+and core now requires them: `SessionManager.get()` is a pure read there and
+the registry holds only the `default` session, per OVOS-SESSION-2 §2.2.
+
+The inbound session is taken once per utterance, at the intake, via
+`SessionManager.fold_inbound` — the §5.1 arrival, where an omitted field
+leaves the stored value standing and a present one replaces it. Before this,
+a device that declared `intent_context` on one utterance lost it before the
+next, so context-gated skills were unreachable after the first turn.
+
+A named session no longer has a registry entry to look up. The session the
+arrival produces is held for the round in `ovos_core.intent_services.working_session`,
+keyed on the `utterance_id`, and the decay, deactivation-replay, legacy
+context writes and converse write paths all read it from there. Anything
+that reached into `SessionManager.sessions` for a named id needs the same
+treatment; `ovos-workshop`'s `set_context` producer still does.
+
+`ovos.utterance.handled` on the no-match path now carries the decayed
+`intent_context`, which for a named session is the only channel it has.
+`ovos.session.sync` is consumed for its §2.7 whole-session snapshot on
+`Message.data["session"]`, in addition to SessionManager's §5.3
+`intent_context` merge on the same topic.
+
+Core takes one arrival per utterance, but `MessageBusClient` still folds
+every inbound default-session message at the transport layer. Narrowing that
+is a bus-client change.
+
 ## #906 (alpha of 2026-09-02)
 
 `ovos.intent.matched`'s `pipeline_id` field (OVOS-PIPELINE-1 §9.2) carried

--- a/ovos_core/intent_services/converse_service.py
+++ b/ovos_core/intent_services/converse_service.py
@@ -15,6 +15,8 @@ from ovos_utils.log import LOG
 from ovos_plugin_manager.templates.pipeline import PipelinePlugin, IntentHandlerMatch
 from ovos_workshop.permissions import ConverseMode, ConverseActivationMode
 
+from ovos_core.intent_services.working_session import working_session
+
 #: upper bound, seconds, on how long core waits for a skill's
 #: ``skill.converse.response`` before the dispatch lifecycle is declared a
 #: timeout (``mycroft.skill.handler.error``). Generous: converse handlers may
@@ -28,95 +30,22 @@ class ConverseService(PipelinePlugin):
     """Intent Service handling conversational skills."""
 
     @staticmethod
-    def _registry_session_for_write(message: Optional[Message]) -> "Session":
-        """Resolve the session object to mutate for an INCIDENTAL converse
-        write path - one that does NOT echo the resulting session back onto
-        the wire (``message.context["session"] = session.serialize()``) and
-        is not part of a chain that already resolved the session once for
-        this lifecycle-entry call.
+    def _session_for_write(message: Optional[Message]) -> "Session":
+        """Resolve the session object a converse write should mutate.
 
-        FOLD-ORDER CONTRACT (read this before adding a new call site):
+        Converse's write paths are all reached from a bus event a skill emits
+        while its round is in flight — an activation request, a get_response
+        toggle. OVOS-SESSION-2 §2.6 says such a Message does not revise the
+        working session with its own carrier, so the write lands on the
+        session the round is already running on, found by ``utterance_id``.
 
-        ``SessionManager.get(message)`` is NEVER a pure read. It always
-        folds the incoming message's session snapshot onto the live
-        registry entry (``SessionManager._store`` -> ``Session.update_from``,
-        full serialize/deserialize replace, for every session id including
-        ``"default"``) and returns THAT live object. So every call is a
-        write of the message's declared state onto the registry, whether or
-        not the caller goes on to mutate anything itself.
-
-        That fold is *correct and required* at two kinds of site:
-          1. True lifecycle entry (e.g. ``match()``'s own top-level
-             ``SessionManager.get(message)`` call) - SESSION-2 last-writer-
-             wins: the client's freshly-declared fields (lang, blacklist,
-             client-side (de)activations) must apply here.
-          2. Any site that stamps the resolved session back onto the wire
-             via ``message.context["session"] = session.serialize()``
-             (``activate_skill`` / ``deactivate_skill`` below) - bypassing
-             the fold there would silently discard the client's own
-             declarations from the outgoing message, e.g. resurrecting a
-             skill the client had just blacklisted. These sites MUST use
-             plain ``SessionManager.get(message)``, not this helper.
-
-        The fold is *wrong* (and this helper exists to avoid it) only for
-        an INCIDENTAL write with no wire echo, where a STALE message (one
-        that predates state written to the registry earlier in the same
-        session's lifecycle, e.g. by a prior ``get_response.enable`` call)
-        would otherwise wipe that state via the full-replace fold before
-        this handler's own write lands. ``get_response.enable/disable``
-        below are the load-bearing example: they only ``SessionManager.sync``
-        for the default session, so a named session's write was being
-        wiped on every subsequent fold with no recovery.
-
-        RESIDUAL (not fixed by this helper, tracked as a known gap): a
-        case-2 wire-echo site (``activate_skill`` / ``deactivate_skill``)
-        still full-replaces the registry entry when it folds. So a
-        case-3 write this helper protects (e.g. ``get_response.enable``)
-        only survives until the NEXT stale ``activate_skill`` /
-        ``deactivate_skill`` call for that same session - executed proof:
-        enable get_response for a named session, then drive a stale
-        ``activate_skill`` call for the same session id, and
-        ``utterance_states`` is wiped back to empty. This is pre-existing
-        on ``dev`` (``activate_skill``/``deactivate_skill`` already used
-        plain ``SessionManager.get(message)`` before this PR) and is
-        unchanged by this PR - this helper narrows the window, it does not
-        close it. Fixing it for real needs case-2 sites to fold
-        per-field (client wins only on fields it actually declares) rather
-        than full-replace; out of scope here.
-
-        A THIRD case - repeated folding within a single synchronous call
-        chain sharing one message (``match()`` -> ``_collect_converse_skills``
-        / ``get_active_skills``) - is neither of the above: fold once at
-        the top (case 1) and THREAD that resolved ``session`` object
-        through the rest of the chain via an explicit parameter; do not
-        call ``SessionManager.get(message)``/this helper again per
-        sub-step, each additional call re-folds the same stale message and
-        undoes whatever the previous step in the chain just wrote. Note
-        ``_check_converse_timeout`` does NOT need this treatment: verified
-        by mutation testing, it sits between two folds of the identical
-        message with no intervening write, so re-folding there is
-        idempotent - see its own docstring.
-
-        This mirrors ``IntentService._registry_session_for_context_write``
-        (#857, ``ovos_core/intent_services/service.py``) exactly for case-3
-        incidental writes, but is a deliberately separate copy: the
-        intent-context handlers and these converse write paths are
-        different call sites landing in different PRs. Do not delete this
-        helper assuming #857 covers it - when both PRs are merged, consider
-        consolidating the two into one shared helper, but until then each
-        pairs with its own call sites.
-
-        Resolution: resolve session_id off the message and, if the registry
-        already holds a live entry for it, mutate that object directly - no
-        fold. Fall back to ``SessionManager.get(message)`` (today's
-        behavior) only when no registry entry exists yet, e.g.
-        out-of-registry/test callers or a message with no session context.
+        With no round open the write is out-of-band. The default session is
+        the device's store and remains writable at any time (§5); a named
+        session resolves to a throwaway built from the carrier, because §2.2
+        leaves the orchestrator holding nothing for it between utterances and
+        there is no session here for the write to reach.
         """
-        session_data = message.context.get("session") if message and message.context else None
-        session_id = session_data.get("session_id") if isinstance(session_data, dict) else None
-        if session_id and session_id in SessionManager.sessions:
-            return SessionManager.sessions[session_id]
-        return SessionManager.get(message)
+        return working_session(message) or SessionManager.get(message)
 
     def __init__(self, bus: Optional[Union[MessageBusClient, FakeBus]] = None,
                  config: Optional[Dict] = None) -> None:
@@ -154,8 +83,8 @@ class ConverseService(PipelinePlugin):
         def _resolve_complete(msg: Message) -> None:
             if msg.data.get("skill_id") and msg.data.get("skill_id") != skill_id:
                 return  # ack from a different skill, ignore
-            # no fold here; see IntentService._registry_session_for_context_write
-            # (SESSION-2 §2.6) — only peek at the ack's session id.
+            # only peek at the ack's session id; an incidental Message does
+            # not revise the working session (SESSION-2 §2.6).
             ack_sess = Session.from_message(msg) if "session" in msg.context else None
             if ack_sess and ack_sess.session_id != session_id:
                 return  # ack from a different session, ignore
@@ -205,11 +134,9 @@ class ConverseService(PipelinePlugin):
             message: bus message to resolve a session from when ``session``
                      is not already known (standalone/incidental callers).
             session: an already-resolved session to read from directly -
-                     pass this when called as part of a chain that already
-                     folded once for this lifecycle entry (see
-                     ``_registry_session_for_write``'s fold-order contract);
-                     re-resolving via ``message`` here would re-fold and can
-                     undo a write an earlier step in the same chain made.
+                     pass this when the caller is a step in a chain that
+                     already resolved it, so every step reads the one object
+                     the round is mutating.
 
         Returns:
             active_skills (list): ordered list of skill_ids
@@ -235,11 +162,7 @@ class ConverseService(PipelinePlugin):
         source_skill = source_skill or skill_id
         if self._deactivate_allowed(skill_id, source_skill):
             message = message or Message("")
-            # this session gets stamped back onto the outgoing wire message
-            # below, so the fold must apply here (see the fold-order
-            # contract on _registry_session_for_write): the client's own
-            # declarations must win, not be silently bypassed.
-            session = SessionManager.get(message)
+            session = self._session_for_write(message)
             if session.is_active(skill_id):
                 # update converse session
                 session.deactivate_skill(skill_id)
@@ -270,11 +193,7 @@ class ConverseService(PipelinePlugin):
         source_skill = source_skill or skill_id
         if self._activate_allowed(skill_id, source_skill):
             message = message or Message("")
-            # this session gets stamped back onto the outgoing wire message
-            # below, so the fold must apply here (see the fold-order
-            # contract on _registry_session_for_write): the client's own
-            # declarations must win, not be silently bypassed.
-            session = SessionManager.get(message)
+            session = self._session_for_write(message)
             session.activate_skill(skill_id)
 
             # keep message.context
@@ -396,16 +315,14 @@ class ConverseService(PipelinePlugin):
         Args:
             message: the bus message driving this converse attempt.
             session: an already-resolved session to use instead of
-                     re-folding ``message`` (see ``match()``, which folds
-                     once and threads the result through this whole call
-                     chain - see the fold-order contract on
-                     ``_registry_session_for_write``). Falls back to a
-                     fresh ``SessionManager.get(message)`` fold for
-                     standalone callers.
+                     resolving ``message`` again - ``match()`` resolves once
+                     and threads the result through this whole call chain, so
+                     every step reads and writes the one object the round is
+                     running on. Standalone callers may omit it.
         """
         answered = []  # candidates whose first valid pong already landed
         claimed = set()  # candidates whose first valid pong was a claim
-        session = session or SessionManager.get(message)
+        session = session or self._session_for_write(message)
 
         # note: this is sorted by priority already
         active_skills = [skill_id for skill_id in self.get_active_skills(message, session=session)
@@ -500,25 +417,15 @@ class ConverseService(PipelinePlugin):
         return [skill_id for skill_id in active_skills if skill_id in claimed]
 
     def _check_converse_timeout(self, message: Message):
-        """ filter active skill list based on timestamps
+        """Drop active handlers whose converse window has expired.
 
-        Note: unlike ``_collect_converse_skills``/``get_active_skills``,
-        this method does NOT accept a threaded ``session`` param. Verified
-        by mutation testing (reverting both the param and a
-        registry-first-helper fallback here left the full converse test
-        suite green): ``match()``'s own top-level ``SessionManager.get(message)``
-        fold and a fresh fold here resolve to the identity-same live
-        registry object with no intervening write between the two calls in
-        this synchronous frame, so re-folding here is idempotent - unlike
-        the fold immediately after this call inside ``_collect_converse_skills``,
-        which WOULD wipe the active_skills filter this method just wrote if
-        it re-folded instead of using the threaded object. Keep this site
-        plain (YAGNI); do not add the param back without a red test proving
-        it does something.
+        The filter is a write, so it goes on the round's own session; resolved
+        from the message rather than threaded because every caller sits in the
+        same round and gets the same object either way.
         """
         timeouts = self.config.get("skill_timeouts") or {}
         def_timeout = self.config.get("timeout", 300)
-        session = SessionManager.get(message)
+        session = self._session_for_write(message)
         session.active_handlers = [
             h for h in session.active_handlers
             if time.time() - h["activated_at"] <= timeouts.get(h["skill_id"], def_timeout)]
@@ -549,14 +456,11 @@ class ConverseService(PipelinePlugin):
             - Attempts conversation with each eligible skill
         """
         lang = standardize_lang(lang)
-        # this is the lifecycle-entry fold for this pipeline's turn at the
-        # utterance (SESSION-2 last-writer-wins is correct here) - `session`
-        # is threaded through every sub-call in this method instead of each
-        # one re-resolving via `message`, which would re-fold the same
-        # message repeatedly and undo whatever the previous sub-call just
-        # wrote (see the fold-order contract on
-        # `_registry_session_for_write`).
-        session = SessionManager.get(message)
+        # the round's session, threaded through every sub-call below so
+        # each step reads what the previous one wrote. The arrival already
+        # happened at the orchestrator's lifecycle entry (SESSION-2 §5.1);
+        # this pipeline does not fold again (§2.6).
+        session = self._session_for_write(message)
 
         # we call flatten in case someone is sending the old style list of tuples
         utterances = flatten_list(utterances)
@@ -602,7 +506,7 @@ class ConverseService(PipelinePlugin):
     @staticmethod
     def handle_get_response_enable(message: Message):
         skill_id = message.data["skill_id"]
-        session = ConverseService._registry_session_for_write(message)
+        session = ConverseService._session_for_write(message)
         session.enable_response_mode(skill_id)
         if session.session_id == "default":
             SessionManager.sync(message)
@@ -610,7 +514,7 @@ class ConverseService(PipelinePlugin):
     @staticmethod
     def handle_get_response_disable(message: Message):
         skill_id = message.data["skill_id"]
-        session = ConverseService._registry_session_for_write(message)
+        session = ConverseService._session_for_write(message)
         session.disable_response_mode(skill_id)
         if session.session_id == "default":
             SessionManager.sync(message)

--- a/ovos_core/intent_services/service.py
+++ b/ovos_core/intent_services/service.py
@@ -23,12 +23,13 @@ from typing import Optional, Tuple, Callable, List
 
 import requests
 from ovos_bus_client.message import Message
-from ovos_bus_client.session import SessionManager, _CONTEXT_LOCK
+from ovos_bus_client.session import SessionManager, Session, _CONTEXT_LOCK
 from ovos_bus_client.util import get_message_lang
 from ovos_config.config import Configuration
 from ovos_config.locale import get_valid_languages
 from ovos_spec_tools import closest_lang, standardize_lang, SpecMessage
 from ovos_spec_tools.context import resolve_key
+from ovos_spec_tools.session import merge_carrier
 from ovos_utils.log import LOG
 from ovos_utils.metrics import Stopwatch
 from ovos_utils.process_utils import ProcessStatus, StatusCallbackMap
@@ -37,6 +38,9 @@ from ovos_utils.thread_utils import create_daemon
 from ovos_core.transformers import MetadataTransformersService, UtteranceTransformersService, IntentTransformersService
 from ovos_core.intent_services.dispatcher import IntentDispatcher, DEFAULT_HANDLER_TIMEOUT
 from ovos_core.intent_services.manifest import IntentManifest
+from ovos_core.intent_services.working_session import (
+    close_round, open_round, working_session,
+)
 from ovos_core.version import OVOS_VERSION_STR
 from ovos_plugin_manager.pipeline import OVOSPipelineFactory
 from ovos_plugin_manager.templates.pipeline import IntentHandlerMatch, ConfidenceMatcherPipeline
@@ -199,8 +203,10 @@ class IntentService:
 
         self.bus.on(SpecMessage.UTTERANCE, self.handle_utterance)
 
-        # OVOS-CONTEXT-1 §5.3: intent_context is owned by SessionManager,
-        # not subscribed to here.
+        # OVOS-SESSION-2 §6.2: honour a synced session snapshot. The §5.3
+        # intent_context half of this topic is SessionManager's and is already
+        # subscribed there; this handler takes the whole-session snapshot.
+        self.bus.on(SpecMessage.SESSION_SYNC, self.handle_session_sync)
 
         # Context related handlers
         self.bus.on('add_context', self.handle_add_context)
@@ -218,6 +224,32 @@ class IntentService:
         self.status.set_alive()
         if preload_pipelines:
             self.bus.emit(Message('intent.service.pipelines.reload'))
+
+    def handle_session_sync(self, message: Message):
+        """OVOS-SESSION-2 §2.7 — take a synced session snapshot into the
+        session it is for.
+
+        §2.7 puts the snapshot in ``Message.data["session"]`` and leaves
+        ``Message.context["session"]`` as the ambient carrier saying *which*
+        session the sync is about, so the content comes from the data and the
+        identity from the context. The merge is §5.1's: a field the snapshot
+        carries replaces, a field it omits leaves the current value alone.
+
+        For the default session the merge lands in the store, which
+        ``SessionManager`` owns. For a named session there is no store (§2.2)
+        and §2.7 directs the update at the session of the utterance in
+        progress — so it applies while that round is open, and a sync arriving
+        outside one has no session to revise and is dropped.
+        """
+        payload = message.data.get("session") or {}
+        if not payload:
+            return
+        sess = working_session(message)
+        if sess is not None and not sess.is_default:
+            sess.update_from(
+                Session.deserialize(merge_carrier(sess, payload)))
+            return
+        SessionManager.handle_sync(message)
 
     def handle_reload_pipelines(self, message: Message):
         pipeline_plugins = OVOSPipelineFactory.get_installed_pipeline_ids()
@@ -373,10 +405,20 @@ class IntentService:
 
     @staticmethod
     def _validate_session(message, lang):
-        # get session
+        """Take the inbound utterance into session state and return the session
+        to run it on.
+
+        This is the arrival OVOS-SESSION-2 §5.1 describes, and the only one:
+        ``fold_inbound`` merges the raw carrier into the default-session store
+        field by field, or builds a named session from its carrier alone since
+        the orchestrator holds no state for one (§2.2). Nowhere else in the
+        utterance flow may fold a carrier — §2.6 makes an incidental Message
+        arriving mid-round unable to revise the working session, and a second
+        fold of a stale snapshot is exactly that revision.
+        """
         lang = standardize_lang(lang)
-        sess = SessionManager.get(message)
-        if sess.session_id == "default":
+        sess = SessionManager.fold_inbound(message)
+        if sess.is_default:
             updated = False
             # Default session, check if it needs to be (re)-created
             if sess.expired():
@@ -390,7 +432,6 @@ class IntentService:
                 SessionManager.sync(message)
         else:
             sess.lang = lang
-            SessionManager.update(sess)
         sess.touch()
         return sess
 
@@ -414,14 +455,13 @@ class IntentService:
         emit their own end-marker inline; together they give exactly one per
         utterance."""
         msg = dispatch_msg.forward(SpecMessage.UTTERANCE_HANDLED, {})
-        # no fold here; see _registry_session_for_context_write (SESSION-2 §2.6).
-        # Re-apply the tracked deactivations to the live session and stamp it
-        # on the end-marker so the utterance terminates with the state the
-        # handler actually requested, not the dispatch message's stale snapshot.
-        sid = (dispatch_msg.context.get("session") or {}).get("session_id")
-        live = SessionManager.sessions.get(sid) if sid else None
+        # No fold here (SESSION-2 §2.6): the dispatch message is a snapshot the
+        # round has since moved past. Re-apply the tracked deactivations to the
+        # working session and stamp that on the end-marker, so the utterance
+        # terminates with the state the handler actually requested.
+        live = close_round(dispatch_msg)
         if live is not None:
-            for skill_id in self._deactivations.get(sid) or []:
+            for skill_id in self._deactivations.pop(live.session_id, None) or []:
                 if live.is_active(skill_id):
                     live.deactivate_skill(skill_id)
             msg.context["session"] = live.serialize()
@@ -496,32 +536,24 @@ class IntentService:
         )
 
     @staticmethod
-    def _apply_post_match_decay(session_id: str, pre_match_entries: dict):
-        """OVOS-CONTEXT-1 §4/§4.1: decrement turns_remaining on the managed
-        session, skipping keys refreshed since ``pre_match_entries`` was
-        snapshotted (compared by value, not identity, since reply/forward
+    def _apply_post_match_decay(sess: "Session", pre_match_entries: dict):
+        """OVOS-CONTEXT-1 §4/§4.1: decrement turns_remaining on the session the
+        round is running on, skipping keys refreshed since ``pre_match_entries``
+        was snapshotted (compared by value, not identity, since reply/forward
         round-trips entries through serialize/deserialize).
 
         Must run before the dispatch reaches the IntentDispatcher / before
         any §9.3/§9.5 terminal is emitted (see ``_dispatch_match``).
 
-        An unregistered ``session_id`` is a no-op: decaying the DEFAULT
-        session with another session's pre-match snapshot would corrupt an
-        unrelated conversation.
+        The caller passes the working session rather than an id to look up:
+        OVOS-SESSION-2 §2.2 keeps the orchestrator stateless for named
+        sessions, so there is no registry entry to find one by, and a lookup
+        that missed would silently stop decaying every session but the
+        device's.
 
         Returns:
-            Optional[Session]: the decayed session, or ``None`` when the id
-                is unknown and nothing was touched.
+            Session: the decayed session.
         """
-        default_sess = SessionManager.get_default_session()
-        sess = SessionManager.sessions.get(session_id)
-        if sess is None:
-            if session_id != default_sess.session_id:
-                LOG.warning(f"skipping intent_context decay: session "
-                            f"'{session_id}' is not registered (decaying the "
-                            f"default session here would corrupt it)")
-                return None
-            sess = default_sess
         post_ctx = dict(sess.intent_context or {})
         unchanged_keys = {k for k in pre_match_entries
                           if k in post_ctx and post_ctx[k] == pre_match_entries[k]}
@@ -539,9 +571,8 @@ class IntentService:
         the OVOS-CONTEXT-1 §4.2 decrement, and ``context['pipeline_id']``
         stamping (§7.1); emits §9.2 ``ovos.intent.matched``; hands the
         dispatch Message to the IntentDispatcher (§7/§8). The §4.2 decrement
-        must run before the dispatch is put on the bus, or a later fold (see
-        _registry_session_for_context_write, SESSION-2 §2.6) would re-stamp
-        the pre-decrement map onto the registry.
+        must run before the dispatch is put on the bus, or the pre-decrement
+        map would be what the dispatch's consumers see.
 
         Args:
             match (IntentHandlerMatch): The matched intent (utterance, match_type,
@@ -559,11 +590,16 @@ class IntentService:
             LOG.exception("_dispatch_match failed")
 
         reply = None
-        # no fold here; see _registry_session_for_context_write (SESSION-2 §2.6).
-        sid = (message.context.get("session") or {}).get("session_id")
-        sess = (match.updated_session
-                or (sid and SessionManager.sessions.get(sid))
-                or SessionManager.get(message))
+        # §5.1: a committed ``Match.updated_session`` replaces the working
+        # session wholesale; otherwise the round continues on the session it
+        # was folded onto at entry. No fold here (§2.6).
+        sess = match.updated_session or working_session(message) or \
+            SessionManager.get(message)
+        if match.updated_session is not None:
+            # ``update`` returns the store for the default session, so the
+            # round carries on the one object every co-located view holds.
+            sess = SessionManager.update(sess)
+            open_round(message, sess)
         sess.lang = lang  # ensure it is updated
 
         # Launch intent handler
@@ -616,10 +652,7 @@ class IntentService:
             self._apply_context_slots(match, sess, reply)
 
             # OVOS-CONTEXT-1 §4.2: decrement before dispatch (see docstring)
-            decayed = self._apply_post_match_decay(sess.session_id,
-                                                   pre_match_entries or {})
-            if decayed is not None:
-                sess = decayed
+            sess = self._apply_post_match_decay(sess, pre_match_entries or {})
 
             # update Session if modified by pipeline
             reply.context["session"] = sess.serialize()
@@ -804,8 +837,12 @@ class IntentService:
 
         stopwatch = Stopwatch()
 
-        # get session
+        # get session: the single arrival of the round (SESSION-2 §5.1)
         sess = self._validate_session(message, lang)
+        # §2.2's utterance-scoped cache. Every Message derived from this round
+        # can now reach the session the round is running on, which for a named
+        # session is the only place it lives.
+        open_round(message, sess)
 
         # OVOS-CONTEXT-1 §4 (pre-match): prune dead entries so every matcher
         # this round sees the same gating snapshot
@@ -899,9 +936,14 @@ class IntentService:
         # OVOS-CONTEXT-1 §4.2 no-match path (matched path decrements in
         # _dispatch_match)
         if no_match_lang is not None:
-            self._apply_post_match_decay(sess.session_id, pre_match_entries)
+            self._apply_post_match_decay(sess, pre_match_entries)
             message.data["lang"] = no_match_lang
+            # §9.5 wants the end-marker to carry the round's final session,
+            # and the decay just changed it. For a named session this stamp is
+            # the only way the decayed context reaches the client (§2.2).
+            message.context["session"] = sess.serialize()
             self.send_complete_intent_failure(message)
+            close_round(message)
 
         # sync any changes made to the default session, eg by ConverseService
         if sess.session_id == "default":
@@ -951,28 +993,24 @@ class IntentService:
             LOG.debug(f"context-supplied slots (§7): {supplied}")
 
     @staticmethod
-    def _registry_session_for_context_write(message: Message) -> "Session":
-        """Resolve the session object to mutate for an in-lifecycle context write.
+    def _session_for_context_write(message: Message) -> "Session":
+        """Resolve the session object a legacy context write should mutate.
 
-        FOLD LAW: a message's session snapshot folds onto the live registry
-        session only at lifecycle entry; an incidental message arriving
-        mid-lifecycle (a skill reply, a follow-up handler frame) must never
-        fold its stale snapshot onto the registry, or it silently overwrites
-        whatever the registry has accumulated since — including named-session
-        ``update_from`` full-replaces and the same-shaped bug on the
-        ``"default"`` session. Writes belong on the registry session object
-        itself, never on a fresh fold of the message. See SESSION-2 §2.6.
+        A context write belongs to the round it was emitted from, so it lands
+        on that round's working session (SESSION-2 §2.6: a mutation happens at
+        a lifecycle boundary the writer participates in, and an incidental
+        Message may not revise the working session with its own snapshot). The
+        working session is looked up by ``utterance_id``, which the skill's
+        handler frame carries for free.
 
-        This resolves the session_id off the message and, if the registry
-        already holds a live entry for it, returns that object directly - no
-        fold. Falls back to ``SessionManager.get(message)`` only when no
-        registry entry exists yet, e.g. out-of-registry/test callers.
+        With no round open there is no lifecycle to write into. The default
+        session is still the device's store and a write to it is meaningful at
+        any time (§5), so that case resolves to the store; a named session
+        resolves to a throwaway built from the carrier and the write goes
+        nowhere, which is what §2.2 leaves available — the orchestrator holds
+        no named session between utterances to write into.
         """
-        session_data = message.context.get("session") if message and message.context else None
-        session_id = session_data.get("session_id") if isinstance(session_data, dict) else None
-        if session_id and session_id in SessionManager.sessions:
-            return SessionManager.sessions[session_id]
-        return SessionManager.get(message)
+        return working_session(message) or SessionManager.get(message)
 
     @staticmethod
     def handle_add_context(message: Message):
@@ -1012,7 +1050,7 @@ class IntentService:
         entity['match'] = word
         entity['key'] = word
         entity['origin'] = origin
-        sess = IntentService._registry_session_for_context_write(message)
+        sess = IntentService._session_for_context_write(message)
         # Finding 30a: `sess.context.inject_context()` folds its own write
         # into `intent_context` under `ovos_bus_client.session._CONTEXT_LOCK`
         # (the same lock guarding `Session.set_intent_context` /
@@ -1081,7 +1119,7 @@ class IntentService:
         """
         context = message.data.get('context')
         if context:
-            sess = IntentService._registry_session_for_context_write(message)
+            sess = IntentService._session_for_context_write(message)
             # Finding 30a: same atomicity requirement as `handle_add_context`
             # - hold `_CONTEXT_LOCK` across the `remove_context`-style fold
             # AND the copy-modify-assign below, so a concurrent skill-side
@@ -1106,7 +1144,7 @@ class IntentService:
     @staticmethod
     def handle_clear_context(message: Message):
         """Clears all keywords from context """
-        sess = IntentService._registry_session_for_context_write(message)
+        sess = IntentService._session_for_context_write(message)
         # Finding 30a: same atomicity requirement as `handle_add_context`.
         with _CONTEXT_LOCK:
             sess.context.clear_context()

--- a/ovos_core/intent_services/working_session.py
+++ b/ovos_core/intent_services/working_session.py
@@ -1,0 +1,72 @@
+"""The session an utterance is being processed on, for as long as that utterance lasts.
+
+OVOS-SESSION-2 §2.2 lets the orchestrator keep a transient cache of the
+session it is currently processing and forbids anything from treating such a
+cache as durable state. This module is that cache, and the whole of it.
+
+The working session is registered when an utterance enters the lifecycle
+(OVOS-PIPELINE-1 §6) and dropped when the lifecycle terminates. It is keyed on
+the §9.1.1 ``utterance_id``, which every Message derived from the utterance
+carries, so a handler frame or a legacy context write arriving mid-round finds
+the same object the pipeline is working on, and nothing survives its round.
+
+Named sessions are why this exists. The orchestrator holds no state for them
+between utterances (§2.2), so ``SessionManager.sessions`` never contains one
+and a lookup there answers ``None``; the round's session lives here instead.
+For the default session the working session *is* the store (§5), so a lookup
+here and ``SessionManager.get_default_session()`` return the same object and
+either answer is correct.
+
+A message with no ``utterance_id`` belongs to no lifecycle. There is no
+working session for it — per §2.6 an out-of-lifecycle write has nowhere
+legitimate to land — and callers get ``None``.
+"""
+from collections import OrderedDict
+from threading import RLock
+from typing import Optional
+
+from ovos_bus_client.message import Message
+from ovos_bus_client.session import Session
+
+#: An utterance whose dispatch never reaches a terminal is never closed, so the
+#: oldest round is evicted once this many are open at once. Reaching the bound
+#: means terminals are going missing; the eviction only stops that leaking.
+_MAX_OPEN_ROUNDS = 32
+
+_LOCK = RLock()
+_OPEN_ROUNDS: "OrderedDict[str, Session]" = OrderedDict()
+
+
+def _utterance_id(message: Optional[Message]) -> Optional[str]:
+    ctx = getattr(message, "context", None) or {}
+    return ctx.get("utterance_id")
+
+
+def open_round(message: Message, session: Session) -> None:
+    """Register ``session`` as the working session of ``message``'s lifecycle."""
+    uid = _utterance_id(message)
+    if not uid:
+        return
+    with _LOCK:
+        _OPEN_ROUNDS[uid] = session
+        _OPEN_ROUNDS.move_to_end(uid)
+        while len(_OPEN_ROUNDS) > _MAX_OPEN_ROUNDS:
+            _OPEN_ROUNDS.popitem(last=False)
+
+
+def working_session(message: Optional[Message]) -> Optional[Session]:
+    """The working session of ``message``'s lifecycle, if one is open."""
+    uid = _utterance_id(message)
+    if not uid:
+        return None
+    with _LOCK:
+        return _OPEN_ROUNDS.get(uid)
+
+
+def close_round(message: Optional[Message]) -> Optional[Session]:
+    """Drop and return the working session of ``message``'s lifecycle."""
+    uid = _utterance_id(message)
+    if not uid:
+        return None
+    with _LOCK:
+        return _OPEN_ROUNDS.pop(uid, None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,13 +16,13 @@ dependencies = [
     "python-dateutil>=2.6, <3.0",
     "combo-lock>=0.2.2, <0.4",
     "ovos-utils>=0.13.9a1,<1.0.0",
-    # OVOS-CONTEXT-1 §5.3: SessionManager intent_context field (bus-client #239)
-    "ovos_bus_client>=2.7.1a1,<3.0.0",
+    # OVOS-SESSION-2 §5.1 arrival merge: SessionManager.fold_inbound / handle_sync
+    "ovos_bus_client>=2.11.1a1,<3.0.0",
     "ovos-plugin-manager>=2.11.1a1,<3.0.0",
     "ovos-config>=2.1.4a5,<4.0.0",
     "ovos-workshop>=9.3.11a1,<10.0.0",
     "rapidfuzz>=3.6,<4.0",
-    "ovos-spec-tools[langcodes]>=1.6.1a1,<2.0.0",
+    "ovos-spec-tools[langcodes]>=1.10.1a1,<2.0.0",
 ]
 
 [project.urls]

--- a/test/end2end/test_context1_reachability.py
+++ b/test/end2end/test_context1_reachability.py
@@ -54,6 +54,7 @@ from ovos_utils.fakebus import FakeBus
 from ovos_spec_tools.context import gate_satisfied
 
 from ovos_core.intent_services.service import IntentService
+from ovos_core.intent_services.working_session import close_round, open_round
 from ovos_workshop.skills.ovos import OVOSSkill
 
 SKILL_ID = "my.skill"
@@ -72,13 +73,14 @@ class TestContext1EndToEndReachability(TestCase):
         self.requires = [CONTEXT_KEY]
         self.excludes = []
 
-        # Register a REAL named session in the shared singleton registry -
-        # nothing is mocked here by default. This is what
-        # SessionManager.get(message) would fold onto for any message
-        # declaring session_id=SESSION_ID.
         self._saved_sessions = dict(SessionManager.sessions)
         SessionManager.sessions.clear()
         self.session = Session(SESSION_ID)
+        # OVOS-SESSION-2 §2.2 keeps the orchestrator stateless for a named
+        # session, so core resolves one through the round's working session.
+        # ovos-workshop's producer still resolves through the registry, so the
+        # same object is planted there too and both halves write the one
+        # session a real round would be running on.
         SessionManager.sessions[SESSION_ID] = self.session
 
         self.bus.on("add_context", IntentService.handle_add_context)
@@ -93,10 +95,9 @@ class TestContext1EndToEndReachability(TestCase):
         SessionManager.sessions.update(self._saved_sessions)
 
     def _live_intent_context(self) -> dict:
-        """What ``ovos.utterance.handled`` would serialize (SESSION-1/SESSION-2:
-        the terminal event carries the live registry session, not a private
-        reference) - read directly off the singleton, never off a variable
-        the test happens to still be holding."""
+        """What ``ovos.utterance.handled`` would serialize: the session the
+        round is running on, read through the working-session registry rather
+        than off a variable the test happens to still be holding."""
         return SessionManager.sessions[SESSION_ID].intent_context or {}
 
     def _gate_open(self) -> bool:
@@ -173,15 +174,14 @@ class TestContext1EndToEndReachability(TestCase):
                 SessionManager.sessions.pop(DEFAULT_SESSION_ID, None)
 
     def test_named_session_context_survives_a_second_stale_client_message(self):
-        """Without the registry-first fold discipline, this assertion fails:
-        a stale second message wipes a NAMED session's context before it
-        ever reaches the terminal event.
+        """A stale second message must not wipe a NAMED session's context
+        before it reaches the terminal event.
 
         Step 1 drives the REAL producer (``OVOSSkill.set_context``) over the
         bus, in-handler (so ``dig_for_message`` finds the driving message),
         exactly like the repro above, but on an explicit NAMED session
-        registered in the real ``SessionManager.sessions`` registry. This
-        opens the gate and moves the registry forward.
+        on an explicit NAMED session. This opens the gate and moves the
+        round's session forward.
 
         ``Message.forward()`` (used internally by the workshop producer)
         self-heals staleness for messages derived *within this same
@@ -201,10 +201,11 @@ class TestContext1EndToEndReachability(TestCase):
         ``MessageBusClient`` hands a deserialized wire message to the
         registered handler.
 
-        Without the fix, ``handle_add_context`` folds this stale snapshot
-        onto the registry entry before writing to it - for a NAMED session
-        that fold is full-replace, wiping step 1's entry - so the
-        ``"kitchen" entry present`` assertion below fails.
+        The frame belongs to the round, so it carries the round's
+        ``utterance_id`` and reaches the working session that way
+        (OVOS-SESSION-2 §2.6). What it must NOT do is adopt its own stale
+        snapshot: that would full-replace the named session and wipe step 1's
+        entry, so the ``"kitchen" entry present`` assertion below fails.
         """
         # Step 1: real producer, real consumer, over the bus, in-handler.
         stale_snapshot = self.session.serialize()  # captured BEFORE any write
@@ -216,7 +217,10 @@ class TestContext1EndToEndReachability(TestCase):
         inbound = Message("recognizer_loop:utterance",
                           {"utterances": ["irrelevant"]},
                           {"session": self.session.serialize(),
-                           "skill_id": SKILL_ID})
+                           "skill_id": SKILL_ID,
+                           "utterance_id": "uid-ctx1-e2e"})
+        open_round(inbound, self.session)
+        self.addCleanup(close_round, inbound)
         self.bus.on("recognizer_loop:utterance", _handler)
         self._emit_and_wait("ovos.utterance.handled",
                             lambda: self.bus.emit(inbound))
@@ -235,7 +239,8 @@ class TestContext1EndToEndReachability(TestCase):
             "add_context",
             {"context": "my_skillother", "word": "other", "origin": "",
              "key": "other"},
-            {"session": stale_snapshot, "skill_id": SKILL_ID})
+            {"session": stale_snapshot, "skill_id": SKILL_ID,
+             "utterance_id": "uid-ctx1-e2e"})
         IntentService.handle_add_context(stale_second_message)
 
         ctx = self._live_intent_context()

--- a/test/unittests/test_converse_service.py
+++ b/test/unittests/test_converse_service.py
@@ -24,6 +24,23 @@ from ovos_utils.fakebus import FakeBus
 from ovos_workshop.permissions import ConverseMode, ConverseActivationMode
 
 from ovos_core.intent_services.converse_service import ConverseService
+from ovos_core.intent_services.working_session import close_round, open_round
+
+
+def _round(msg_type: str, data: dict, session: Session,
+           carrier: Session = None) -> Message:
+    """A Message inside an open utterance round whose working session is
+    ``session``.
+
+    ``carrier`` is what the Message itself declares in
+    ``context["session"]`` — pass a stale snapshot to prove the round's
+    session is what gets written, per OVOS-SESSION-2 §2.6.
+    """
+    msg = Message(msg_type, data=data,
+                  context={"session": (carrier or session).serialize(),
+                           "utterance_id": f"uid-{session.session_id}"})
+    open_round(msg, session)
+    return msg
 
 
 def _make_service() -> ConverseService:
@@ -643,24 +660,22 @@ class TestMatchFoldChainSurvival(unittest.TestCase):
         svc = _make_service()
         now = time.time()
         sess = Session("named-match-1")
-        # client declares both skills as active; skill_old is long expired
+        # both skills are active on the round; skill_old is long expired
         sess.active_skills = [("skill_old", now - 400), ("skill_new", now - 1)]
-        SessionManager.sessions[sess.session_id] = sess
 
-        msg = Message("recognizer_loop:utterance",
-                      data={"utterances": ["hello"]},
-                      context={"session": sess.serialize()})
+        msg = _round("recognizer_loop:utterance",
+                     {"utterances": ["hello"]}, sess)
 
         # no skill is listening on skill.converse.pong, so _collect_converse_skills
         # will time out its 0.5s wait with an empty want_converse - match()
-        # returns None, which is fine, we only care about the registry's
-        # active_skills state afterward.
+        # returns None, which is fine, we only care about the working
+        # session's active_skills state afterward.
         svc.match(["hello"], "en-US", msg)
 
-        live = SessionManager.sessions[sess.session_id]
-        remaining = [s[0] for s in live.active_skills]
+        remaining = [s[0] for s in sess.active_skills]
         self.assertNotIn("skill_old", remaining)
         self.assertIn("skill_new", remaining)
+        close_round(msg)
 
 
 # ---------------------------------------------------------------------------
@@ -763,53 +778,42 @@ class TestActivateDeactivateSkillRequestHandlers(unittest.TestCase):
 class TestGetResponseHandlers(unittest.TestCase):
     """Tests for the get_response enable/disable bus handlers.
 
-    These tests exercise the REAL SessionManager.sessions registry (no
-    mocking of SessionManager.get), mirroring
-    test_intent_service_extended.py's registry-first test shape for #857.
-    setUp/tearDown save+clear the real registry so a session id reused
-    across tests in this module (e.g. "s") can never leak state between
-    them and can never accidentally satisfy the registry-first lookup
-    with a stale entry left by an earlier test.
+    A get_response toggle is a bus event a skill emits while its round is in
+    flight, so the write belongs on that round's working session
+    (OVOS-SESSION-2 §2.6). These tests drive the real handlers inside a real
+    open round and assert on the session object the round is running on.
     """
-
-    def setUp(self):
-        self._saved_sessions = dict(SessionManager.sessions)
-        SessionManager.sessions.clear()
 
     def tearDown(self):
         SessionManager.sessions.clear()
-        SessionManager.sessions.update(self._saved_sessions)
+        SessionManager.reset_default_session()
 
     def test_handle_get_response_enable_sets_response_state(self):
         """enable handler puts the skill into RESPONSE utterance state."""
         sess = Session("s")
         sess.activate_skill("skill_a")
-        SessionManager.sessions[sess.session_id] = sess
-        msg = Message("skill.converse.get_response.enable",
-                      data={"skill_id": "skill_a"},
-                      context={"session": sess.serialize()})
+        msg = _round("skill.converse.get_response.enable",
+                     {"skill_id": "skill_a"}, sess)
 
-        with patch("ovos_core.intent_services.converse_service.SessionManager.sync"):
-            ConverseService.handle_get_response_enable(msg)
+        ConverseService.handle_get_response_enable(msg)
 
-        live = SessionManager.sessions[sess.session_id]
-        self.assertEqual(live.utterance_states.get("skill_a"), UtteranceState.RESPONSE)
+        self.assertEqual(sess.utterance_states.get("skill_a"),
+                         UtteranceState.RESPONSE)
+        close_round(msg)
 
     def test_handle_get_response_disable_restores_intent_state(self):
         """disable handler removes the skill from RESPONSE state."""
         sess = Session("s")
         sess.activate_skill("skill_a")
         sess.enable_response_mode("skill_a")
-        SessionManager.sessions[sess.session_id] = sess
-        msg = Message("skill.converse.get_response.disable",
-                      data={"skill_id": "skill_a"},
-                      context={"session": sess.serialize()})
+        msg = _round("skill.converse.get_response.disable",
+                     {"skill_id": "skill_a"}, sess)
 
-        with patch("ovos_core.intent_services.converse_service.SessionManager.sync"):
-            ConverseService.handle_get_response_disable(msg)
+        ConverseService.handle_get_response_disable(msg)
 
-        live = SessionManager.sessions[sess.session_id]
-        self.assertNotEqual(live.utterance_states.get("skill_a"), UtteranceState.RESPONSE)
+        self.assertNotEqual(sess.utterance_states.get("skill_a"),
+                            UtteranceState.RESPONSE)
+        close_round(msg)
 
     def test_handle_get_response_enable_syncs_default_session(self):
         """enable handler calls SessionManager.sync for the default session."""
@@ -841,135 +845,99 @@ class TestGetResponseHandlers(unittest.TestCase):
         mock_sync.assert_called_once()
 
     def test_get_response_enable_survives_stale_named_session_snapshot(self):
-        """Wave-3 regression (converse write-path counterpart to #857):
-        a NAMED session's get_response state written by
-        handle_get_response_enable must land on the LIVE registry entry,
-        not a copy folded from a stale client message snapshot. Before the
-        registry-first fix, `SessionManager.get(message)` folds the
-        message's stale snapshot onto the registry entry first
-        (full-replace for named sessions via `update_from`), then the
-        handler's `enable_response_mode` write lands on that folded copy -
-        the write is visible on the return value but is never actually
-        durable proof of a *registry* write when `.get` is mocked, which is
-        exactly how the pre-fix bug hid in the two tests above. Here we
-        register a live entry, drive the handler with an intentionally
-        STALE message snapshot (unaware of the live entry's other state),
-        and assert the live registry entry itself picked up the write."""
+        """A named session's get_response write lands on the round's working
+        session, and the stale snapshot the Message happens to carry does not
+        revise it (OVOS-SESSION-2 §2.6).
+
+        The Message declares a snapshot unaware of skill_b's activation. If
+        the handler wrote to a session folded from that carrier, skill_b's
+        activation would be gone and the write would land on a throwaway the
+        round never sees again — a named session has no registry entry to
+        fall back on (§2.2)."""
         sess = Session("named-converse-1")
         sess.activate_skill("skill_a")
-        sess.activate_skill("skill_b")  # pre-existing state the stale snapshot doesn't know about
-        SessionManager.sessions[sess.session_id] = sess
+        sess.activate_skill("skill_b")  # state the stale snapshot doesn't know about
 
         stale = Session(sess.session_id)  # unaware of skill_b's activation
-        msg = Message("skill.converse.get_response.enable",
-                      data={"skill_id": "skill_a"},
-                      context={"session": stale.serialize()})
+        msg = _round("skill.converse.get_response.enable",
+                     {"skill_id": "skill_a"}, sess, carrier=stale)
 
-        with patch("ovos_core.intent_services.converse_service.SessionManager.sync"):
-            ConverseService.handle_get_response_enable(msg)
+        ConverseService.handle_get_response_enable(msg)
 
-        live = SessionManager.sessions[sess.session_id]
-        self.assertEqual(live.utterance_states.get("skill_a"), UtteranceState.RESPONSE)
-        # the registry entry's pre-existing state must not have been wiped
-        # by the stale snapshot fold
-        self.assertTrue(live.is_active("skill_b"))
+        self.assertEqual(sess.utterance_states.get("skill_a"),
+                         UtteranceState.RESPONSE)
+        self.assertTrue(sess.is_active("skill_b"))
+        close_round(msg)
 
     def test_get_response_disable_survives_stale_named_session_snapshot(self):
-        """Same regression as
+        """Same as
         `test_get_response_enable_survives_stale_named_session_snapshot`,
-        for `handle_get_response_disable` (adversarial review finding F4:
-        this site's registry-first fix had no test that actually drove a
-        stale snapshot, so it could regress silently - the previous test
-        registered a session and serialized THAT SAME session for the
-        message context, which the fold cannot distinguish from a correct
-        write since there was nothing else on the registry entry for the
-        fold to wipe)."""
+        for `handle_get_response_disable`."""
         sess = Session("named-converse-4")
         sess.activate_skill("skill_a")
         sess.enable_response_mode("skill_a")
-        sess.activate_skill("skill_b")  # pre-existing state the stale snapshot doesn't know about
-        SessionManager.sessions[sess.session_id] = sess
+        sess.activate_skill("skill_b")  # state the stale snapshot doesn't know about
 
         stale = Session(sess.session_id)  # unaware of skill_b's activation
-        msg = Message("skill.converse.get_response.disable",
-                      data={"skill_id": "skill_a"},
-                      context={"session": stale.serialize()})
+        msg = _round("skill.converse.get_response.disable",
+                     {"skill_id": "skill_a"}, sess, carrier=stale)
 
-        with patch("ovos_core.intent_services.converse_service.SessionManager.sync"):
-            ConverseService.handle_get_response_disable(msg)
+        ConverseService.handle_get_response_disable(msg)
 
-        live = SessionManager.sessions[sess.session_id]
-        self.assertNotEqual(live.utterance_states.get("skill_a"), UtteranceState.RESPONSE)
-        # the registry entry's pre-existing state must not have been wiped
-        # by the stale snapshot fold
-        self.assertTrue(live.is_active("skill_b"))
+        self.assertNotEqual(sess.utterance_states.get("skill_a"),
+                            UtteranceState.RESPONSE)
+        self.assertTrue(sess.is_active("skill_b"))
+        close_round(msg)
 
-    def test_activate_skill_folds_client_blacklist_and_applies_write(self):
-        """Fold-order contract regression (adversarial review finding F1):
-        `activate_skill`/`deactivate_skill` stamp the resolved session back
-        onto the outgoing wire message (`message.context["session"] =
-        session.serialize()`), so - unlike the incidental get_response
-        handlers - they must NOT bypass the fold. The client's own
-        declarations (here, a freshly-declared blacklist entry the registry
-        doesn't know about yet) must win per SESSION-2 last-writer-wins,
-        and the activation write must still land on top of that fold.
+    def test_activate_skill_writes_the_working_session(self):
+        """`activate_skill` writes the round's working session and stamps that
+        session onto the outgoing wire message.
 
-        Before this was corrected (an earlier revision of this branch
-        wrongly applied the registry-first bypass here), the client's
-        blacklist declaration would be silently discarded and stamped out
-        of the outgoing message - a client-blacklisted skill could read as
-        not-blacklisted downstream."""
+        The activation request carries a snapshot of its own. Per
+        OVOS-SESSION-2 §2.6 that snapshot does not revise the working
+        session, so a blacklist the request declares does not reach the round
+        — the round's own blacklist, arrived at the §5.1 intake, is what the
+        outgoing message carries."""
         bus = FakeBus()
         svc = ConverseService(bus=bus, config={})
         sess = Session("named-converse-2")
-        SessionManager.sessions[sess.session_id] = sess
+        sess.blacklisted_skills = ["skill_y"]
 
-        # client's message declares a blacklist entry the registry entry
-        # does not have yet
         declaring = Session(sess.session_id)
         declaring.blacklisted_skills = ["skill_x"]
-        msg = Message("intent.service.skills.activate",
-                      data={"skill_id": "skill_a"},
-                      context={"session": declaring.serialize()})
+        msg = _round("intent.service.skills.activate",
+                     {"skill_id": "skill_a"}, sess, carrier=declaring)
 
         svc.activate_skill("skill_a", "skill_a", msg)
 
-        live = SessionManager.sessions[sess.session_id]
-        # the write applied on top of the fold
-        self.assertTrue(live.is_active("skill_a"))
-        # the client's declaration folded onto the registry entry
-        self.assertIn("skill_x", live.blacklisted_skills)
-        # and was NOT stamped out of the outgoing wire message
-        self.assertIn("skill_x", msg.context["session"]["blacklisted_skills"])
+        self.assertTrue(sess.is_active("skill_a"))
+        self.assertEqual(msg.context["session"]["blacklisted_skills"],
+                         ["skill_y"])
+        close_round(msg)
 
-    def test_deactivate_skill_folds_client_blacklist_and_applies_write(self):
-        """Same fold-order contract as above, for `deactivate_skill`.
+    def test_deactivate_skill_writes_the_working_session(self):
+        """Same as above for `deactivate_skill`.
 
-        `declaring` must itself declare skill_a as active - otherwise the
-        fold makes `session.is_active(skill_id)` False and
-        `deactivate_skill`'s write branch (and its
-        `message.context["session"] = ...` re-stamp) never executes at
-        all; the assertions would then pass trivially off `declaring`'s
-        own pre-serialized context rather than off the actual write."""
+        The working session must itself have skill_a active, or the write
+        branch (and its wire re-stamp) never runs and the assertions would
+        pass off the carrier rather than off an actual write."""
         bus = FakeBus()
         svc = ConverseService(bus=bus, config={})
         sess = Session("named-converse-3")
         sess.activate_skill("skill_a")
-        SessionManager.sessions[sess.session_id] = sess
+        sess.blacklisted_skills = ["skill_y"]
 
         declaring = Session(sess.session_id)
-        declaring.activate_skill("skill_a")  # must fold in as active for the write branch to run
         declaring.blacklisted_skills = ["skill_x"]
-        msg = Message("intent.service.skills.deactivate",
-                      data={"skill_id": "skill_a"},
-                      context={"session": declaring.serialize()})
+        msg = _round("intent.service.skills.deactivate",
+                     {"skill_id": "skill_a"}, sess, carrier=declaring)
 
         svc.deactivate_skill("skill_a", "skill_a", msg)
 
-        live = SessionManager.sessions[sess.session_id]
-        self.assertFalse(live.is_active("skill_a"))
-        self.assertIn("skill_x", live.blacklisted_skills)
-        self.assertIn("skill_x", msg.context["session"]["blacklisted_skills"])
+        self.assertFalse(sess.is_active("skill_a"))
+        self.assertEqual(msg.context["session"]["blacklisted_skills"],
+                         ["skill_y"])
+        close_round(msg)
 
 
 # ---------------------------------------------------------------------------

--- a/test/unittests/test_intent_context.py
+++ b/test/unittests/test_intent_context.py
@@ -23,7 +23,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from ovos_bus_client.message import Message
-from ovos_bus_client.session import Session, SessionManager
+from ovos_bus_client.session import DEFAULT_SESSION_ID, Session, SessionManager
 from ovos_utils.fakebus import FakeBus
 
 from ovos_spec_tools.context import (
@@ -262,35 +262,39 @@ class TestLiveSessionManagerSync(unittest.TestCase):
         self.assertIn("tea.skill:confirming_milk", merged)
         self.assertNotIn("keep", merged)
 
-    def test_orchestrator_decays_managed_session(self):
+    def test_orchestrator_decays_a_named_session_over_the_wire(self):
+        """§4.2 decay on a named session, which the orchestrator holds no
+        state for between utterances (SESSION-2 §2.2) — each turn's decayed
+        session comes back on the wire and the client sends it on the next."""
         bus = FakeBus()
         SessionManager.connect_to_bus(bus)
         svc = _make_service()
         svc.bus = bus
 
-        sess = Session("turn-sess")
-        sess.intent_context = {"tea.skill:flag": {"value": None,
-                                                  "turns_remaining": 1}}
-        SessionManager.update(sess)
+        carrier = Session("turn-sess")
+        carrier.intent_context = {"tea.skill:flag": {"value": None,
+                                                     "turns_remaining": 1}}
 
-        def _drive():
+        def _drive(snapshot):
+            handled = []
+            bus.on("ovos.utterance.handled", handled.append)
             msg = Message("recognizer_loop:utterance",
                           data={"utterances": ["hello"]},
-                          context={"session":
-                                   SessionManager.sessions["turn-sess"].serialize()})
+                          context={"session": snapshot})
             # no pipelines loaded -> no match, decay still runs
             svc.handle_utterance(msg)
+            bus.remove("ovos.utterance.handled", handled.append)
+            self.assertEqual(len(handled), 1)
+            return handled[0].context["session"]
 
         # turn 1: flag is live during the round, decremented to 0 after
-        _drive()
+        turn1 = _drive(carrier.serialize())
         self.assertEqual(
-            SessionManager.sessions["turn-sess"].intent_context["tea.skill:flag"]["turns_remaining"],
-            0)
+            turn1[INTENT_CONTEXT_FIELD]["tea.skill:flag"]["turns_remaining"], 0)
         # turn 2: pre-match prune removes the now-dead flag
-        _drive()
-        self.assertNotIn(
-            "tea.skill:flag",
-            SessionManager.sessions["turn-sess"].intent_context or {})
+        turn2 = _drive(turn1)
+        self.assertNotIn("tea.skill:flag",
+                         turn2.get(INTENT_CONTEXT_FIELD) or {})
 
     @pytest.mark.xfail(strict=True, reason=_NEEDS_BUS_CLIENT_278)
     def test_midispatch_sync_survives_decay(self):
@@ -376,11 +380,15 @@ class TestSessionSyncCarrier(unittest.TestCase):
 
     def test_legacy_context_carrier_is_still_honoured(self):
         """§2.7 fallback: the legacy ``context['session']`` shape must keep
-        working for one major. This passes on bus-client dev today."""
-        sess = self._tracked("carrier-ctx")
+        working for one major.
+
+        Driven on the default session, the only one the orchestrator holds
+        state for (§2.3/§5) and so the only one a sync arriving outside an
+        utterance has somewhere to land."""
+        sess = self._tracked(DEFAULT_SESSION_ID)
         snap = self._snap(sess, {"from.ctx": {"value": "ctx"}})
         SessionManager.handle_session_sync(_sync_msg(snap, carrier="context"))
-        merged = SessionManager.sessions["carrier-ctx"].intent_context
+        merged = SessionManager.get_default_session().intent_context
         self.assertEqual(merged.get("from.ctx"), {"value": "ctx"})
 
     @pytest.mark.xfail(strict=True, reason=_NEEDS_BUS_CLIENT_278)
@@ -417,33 +425,30 @@ class TestDecayIgnoresUnknownSession(unittest.TestCase):
 
     tearDown = setUp
 
-    def test_unregistered_session_id_leaves_default_untouched(self):
+    def test_named_session_decay_leaves_default_untouched(self):
         default = SessionManager.get_default_session()
         default.intent_context = {"person": {"value": "Bob",
                                              "turns_remaining": 3}}
         before = copy.deepcopy(default.intent_context)
 
+        sess = Session("foreign-session")
+        sess.intent_context = {"person": {"value": "Bob", "turns_remaining": 3}}
         svc = _make_service()
-        # a foreign session's pre-match snapshot, for an id nobody registered
-        result = svc._apply_post_match_decay(
-            "ghost-session", {"person": {"value": "Bob", "turns_remaining": 3}})
+        svc._apply_post_match_decay(
+            sess, {"person": {"value": "Bob", "turns_remaining": 3}})
 
-        self.assertIsNone(result, "unknown session must be a no-op")
+        self.assertEqual(sess.intent_context["person"]["turns_remaining"], 2)
         self.assertEqual(
             SessionManager.get_default_session().intent_context, before,
             "the default session's intent_context must be untouched")
 
-    def test_registered_session_still_decays(self):
-        # guard: the no-op branch must not have disabled decay outright
+    def test_named_session_decays(self):
         sess = Session("real-session")
         sess.intent_context = {"person": {"value": "Bob", "turns_remaining": 3}}
-        SessionManager.update(sess)
         svc = _make_service()
         svc._apply_post_match_decay(
-            "real-session", {"person": {"value": "Bob", "turns_remaining": 3}})
-        self.assertEqual(
-            SessionManager.sessions["real-session"]
-            .intent_context["person"]["turns_remaining"], 2)
+            sess, {"person": {"value": "Bob", "turns_remaining": 3}})
+        self.assertEqual(sess.intent_context["person"]["turns_remaining"], 2)
 
 
 
@@ -660,9 +665,9 @@ class TestDecayPropagatesToTerminalEmissions(unittest.TestCase):
     def test_decrement_actually_runs(self):
         sess = Session("decay-sanity")
         sess.intent_context = {"person": {"value": "Bob", "turns_remaining": 3}}
-        self._run_full_dispatch(sess)
-        managed = SessionManager.sessions["decay-sanity"].intent_context
-        self.assertEqual(managed["person"]["turns_remaining"], 2)
+        handled_frames, _ = self._run_full_dispatch(sess)
+        decayed = handled_frames[0].context["session"][INTENT_CONTEXT_FIELD]
+        self.assertEqual(decayed["person"]["turns_remaining"], 2)
 
     def test_terminal_emissions_carry_decayed_context(self):
         sess = Session("wire-sess")

--- a/test/unittests/test_intent_service.py
+++ b/test/unittests/test_intent_service.py
@@ -27,9 +27,8 @@ from ovos_config import LocalConf, DEFAULT_CONFIG
 from ovos_config.locale import setup_locale
 from ovos_core.intent_services import IntentService
 from ovos_core.intent_services import service as intent_service_module
-from ovos_utils.fakebus import FakeBus
+from ovos_core.intent_services.working_session import close_round, open_round
 from ovos_workshop.intents import IntentBuilder
-from ovos_workshop.skills.ovos import OVOSSkill
 
 # Setup configurations to use with default language tests
 BASE_CONF = deepcopy(LocalConf(DEFAULT_CONFIG))
@@ -90,10 +89,10 @@ class TestContextWriteLockRace(TestCase):
     """Finding 30a: `IntentService.handle_add_context` copy-modify-assigns
     `Session.intent_context` (`ctx = dict(sess.intent_context); ...;
     sess.intent_context = ctx`) OUTSIDE `ovos_bus_client.session._CONTEXT_LOCK`,
-    while a concurrent skill-side write (`ovos-workshop` >=9.3.13a1's
-    registry-first `set_context`/`remove_context`, calling
-    `Session.set_intent_context`/`remove_intent_context` directly) mutates the
-    SAME map under that lock. If the skill's write lands between core's
+    while a concurrent skill-side write (`OVOSSkill.set_context` /
+    `remove_context`, which call `Session.set_intent_context` /
+    `remove_intent_context` on the round's session) mutates the SAME map
+    under that lock. If the skill's write lands between core's
     snapshot read and its write-back, the stale snapshot silently overwrites
     it - the skill's write is lost with no error and no trace.
 
@@ -102,34 +101,32 @@ class TestContextWriteLockRace(TestCase):
     `handle_add_context` right after it snapshots `sess.intent_context` and
     right before it writes the result back - signals readiness and then
     blocks, giving the "skill" thread a bounded window to run its own
-    registry write before core's write-back proceeds.
+    write before core's write-back proceeds.
     """
 
     def setUp(self):
-        self.bus = FakeBus()
-        self.skill = OVOSSkill(bus=self.bus, skill_id="race.skill")
         self.sess = Session(session_id="s-race-lock-test")
-        SessionManager.update(self.sess)
         # seed a live layer0 entry, as if an earlier turn set it
         self.sess.set_intent_context("layer0", "1", scope="private",
                                      owner_id="race.skill")
+        # both frames belong to the same in-flight round, so both resolve to
+        # the one working session (OVOS-SESSION-2 §2.2/§2.6)
+        self.ctx = {"skill_id": "race.skill",
+                    "session": self.sess.serialize(),
+                    "utterance_id": "uid-s-race-lock-test"}
 
     def tearDown(self):
-        SessionManager.sessions.pop("s-race-lock-test", None)
+        close_round(Message("", {}, self.ctx))
 
     def test_concurrent_skill_write_survives_core_add_context(self):
-        skill_msg = Message("some.intent", {}, {
-            "skill_id": "race.skill",
-            "session": SessionManager.sessions["s-race-lock-test"].serialize()})
         # core processing a (possibly stale/duplicate) add_context for the
         # skill's OWN previously-set key, concurrently with the skill moving
         # on to a new context layer
         core_msg = Message("add_context",
                            {"context": "racskilllayer0", "word": "1",
                             "key": "layer0"},
-                           {"skill_id": "race.skill",
-                            "session": SessionManager.sessions[
-                                "s-race-lock-test"].serialize()})
+                           dict(self.ctx))
+        open_round(core_msg, self.sess)
 
         core_ready = threading.Event()
         skill_done = threading.Event()
@@ -142,13 +139,14 @@ class TestContextWriteLockRace(TestCase):
             skill_done.wait(timeout=5)
             return orig_resolve_key(*args, **kwargs)
 
-        def skill_turn(triggering_msg):
-            # `triggering_msg` is a positional arg on THIS frame so
-            # `dig_for_message()` (walked internally by
-            # `skill.remove_context`/`set_context`) resolves the right
-            # session - mirroring a real skill handler.
-            self.skill.remove_context("layer0")  # tombstone layer0
-            self.skill.set_context("layer1", "1")
+        def skill_turn():
+            # the skill-side write a co-located `OVOSSkill.set_context` /
+            # `remove_context` performs on the round's session, under
+            # `_CONTEXT_LOCK`
+            self.sess.remove_intent_context("layer0", scope="private",
+                                            owner_id="race.skill")
+            self.sess.set_intent_context("layer1", "1", scope="private",
+                                         owner_id="race.skill")
 
         core_thread = threading.Thread(
             target=IntentService.handle_add_context, args=(core_msg,))
@@ -157,7 +155,7 @@ class TestContextWriteLockRace(TestCase):
             core_thread.start()
             self.assertTrue(core_ready.wait(timeout=5),
                             "core thread never reached the snapshot window")
-            skill_turn(skill_msg)
+            skill_turn()
             skill_done.set()
             core_thread.join(timeout=5)
             self.assertFalse(core_thread.is_alive(),
@@ -165,7 +163,7 @@ class TestContextWriteLockRace(TestCase):
         finally:
             intent_service_module.resolve_key = orig_resolve_key
 
-        final_ctx = SessionManager.sessions["s-race-lock-test"].intent_context
+        final_ctx = self.sess.intent_context
         # the skill's new write (layer1) must not be silently dropped
         self.assertIn("race.skill:layer1", final_ctx)
         self.assertEqual(final_ctx["race.skill:layer1"]["value"], "1")

--- a/test/unittests/test_intent_service_extended.py
+++ b/test/unittests/test_intent_service_extended.py
@@ -30,6 +30,7 @@ from ovos_spec_tools import SpecMessage
 from ovos_core.intent_services.service import IntentService
 from ovos_core.intent_services.dispatcher import IntentDispatcher
 from ovos_core.intent_services.manifest import IntentManifest
+from ovos_core.intent_services.working_session import close_round, open_round
 
 
 def _make_service(config=None) -> IntentService:
@@ -457,7 +458,7 @@ class TestContextHandlers(unittest.TestCase):
     """Tests for the context management static methods."""
 
     def setUp(self):
-        # The handlers resolve registry-first (_registry_session_for_context_write),
+        # The handlers resolve the round's working session,
         # so a leftover real SessionManager.sessions["s"] entry from
         # `Session.touch()`'s self-registration (triggered internally by
         # intent_context writes) would otherwise shadow this test's
@@ -890,18 +891,13 @@ class TestContextHandlers(unittest.TestCase):
 
 
 class TestContextHandlersLiveRegistry(unittest.TestCase):
-    """FOLD LAW (see IntentService._registry_session_for_context_write,
-    SESSION-2 §2.6): a message's session snapshot folds onto the live
-    registry session only at lifecycle entry, never on an incidental
-    mid-lifecycle message. `SessionManager.get(message)` folds unconditionally,
-    and for NAMED sessions that fold is full-replace (`update_from`), so an
-    incidental fold wipes the registry entry's intent_context with a stale
-    snapshot - a named session's context can never survive to the terminal
-    event.
+    """A legacy context write lands on the working session of the round it
+    came from, and the snapshot the incidental Message happens to carry does
+    not revise that session (OVOS-SESSION-2 §2.6).
 
-    These tests exercise the REAL SessionManager.sessions registry (no
-    mocking of SessionManager.get) so they fail against an unconditional
-    every-call fold.
+    Named sessions are the load-bearing case: the orchestrator holds no state
+    for one between utterances (§2.2), so a write that resolved through the
+    carrier would land on a throwaway and be gone by the terminal event.
     """
 
     def setUp(self):
@@ -912,48 +908,46 @@ class TestContextHandlersLiveRegistry(unittest.TestCase):
         SessionManager.sessions.clear()
         SessionManager.sessions.update(self._saved_sessions)
 
+    @staticmethod
+    def _in_round(session, data, carrier=None):
+        msg = Message("add_context", data=data,
+                      context={"session": (carrier or session).serialize(),
+                               "utterance_id": f"uid-{session.session_id}"})
+        open_round(msg, session)
+        return msg
+
     def test_add_context_survives_stale_message_snapshot_fold(self):
-        """A registry entry's pre-existing intent_context must survive a
-        handle_add_context call driven by a message carrying a STALE
-        session snapshot (no knowledge of the pre-existing entry) - the
-        write must land on the LIVE registry object, not a folded copy."""
+        """The round's pre-existing intent_context survives a
+        handle_add_context driven by a Message carrying a stale snapshot."""
         sess = Session("named-r4")
         sess.intent_context = {"Existing": {"value": "existing"}}
-        SessionManager.sessions[sess.session_id] = sess
 
         stale = Session(sess.session_id)  # unaware of "Existing"
-        msg = Message("add_context",
-                      data={"context": "New", "word": "newword"},
-                      context={"session": stale.serialize()})
+        msg = self._in_round(sess, {"context": "New", "word": "newword"},
+                             carrier=stale)
 
         IntentService.handle_add_context(msg)
 
-        live = SessionManager.sessions[sess.session_id]
-        self.assertIn("Existing", live.intent_context)
-        self.assertIn("New", live.intent_context)
+        self.assertIn("Existing", sess.intent_context)
+        self.assertIn("New", sess.intent_context)
+        close_round(msg)
 
     def test_add_context_accumulates_across_two_stale_calls(self):
-        """Two handle_add_context calls, each driven by a message with its
-        own stale snapshot (mirroring successive mid-lifecycle frames),
-        must both survive on the live registry entry."""
+        """Two handle_add_context calls in the same round, each carrying its
+        own stale snapshot, both survive."""
         sess = Session("named-r4-2")
-        SessionManager.sessions[sess.session_id] = sess
 
-        stale1 = Session(sess.session_id)
-        msg1 = Message("add_context",
-                       data={"context": "First", "word": "one"},
-                       context={"session": stale1.serialize()})
+        msg1 = self._in_round(sess, {"context": "First", "word": "one"},
+                              carrier=Session(sess.session_id))
         IntentService.handle_add_context(msg1)
 
-        stale2 = Session(sess.session_id)
-        msg2 = Message("add_context",
-                       data={"context": "Second", "word": "two"},
-                       context={"session": stale2.serialize()})
+        msg2 = self._in_round(sess, {"context": "Second", "word": "two"},
+                              carrier=Session(sess.session_id))
         IntentService.handle_add_context(msg2)
 
-        live = SessionManager.sessions[sess.session_id]
-        self.assertIn("First", live.intent_context)
-        self.assertIn("Second", live.intent_context)
+        self.assertIn("First", sess.intent_context)
+        self.assertIn("Second", sess.intent_context)
+        close_round(msg2)
 
     def test_add_context_survives_stale_default_session_snapshot_fold(self):
         """The registry-first fix is load-bearing for the DEVICE-LOCAL

--- a/test/unittests/test_session2_intake.py
+++ b/test/unittests/test_session2_intake.py
@@ -1,0 +1,290 @@
+"""OVOS-SESSION-2 intake: where an inbound session enters the orchestrator.
+
+§5.1 merges an inbound default-session carrier into the store, §2.6 forbids
+any later Message from revising the working session with its own snapshot,
+§2.7 defines the sync merge, and §2.2 leaves the orchestrator holding nothing
+for a named session between utterances. These tests drive the real
+IntentService over a FakeBus for each of those.
+"""
+import unittest
+from collections import defaultdict
+from unittest.mock import MagicMock
+
+from ovos_bus_client.message import Message
+from ovos_bus_client.session import DEFAULT_SESSION_ID, Session, SessionManager
+from ovos_plugin_manager.templates.pipeline import IntentHandlerMatch
+from ovos_spec_tools import SpecMessage
+from ovos_utils.fakebus import FakeBus
+
+from ovos_core.intent_services.dispatcher import IntentDispatcher
+from ovos_core.intent_services.manifest import IntentManifest
+from ovos_core.intent_services.service import IntentService
+
+INTENT_CONTEXT_FIELD = "intent_context"
+
+
+def _make_service(bus, match=None) -> IntentService:
+    """A real IntentService wired to ``bus``, with the plugin machinery stubbed
+    and a single pipeline that returns ``match`` (or never matches)."""
+    svc = IntentService.__new__(IntentService)
+    svc.bus = bus
+    svc.config = {}
+    svc.pipeline_plugins = {}
+    svc._deactivations = defaultdict(list)
+    svc.status = MagicMock()
+
+    for attr, transform in (("utterance_plugins", lambda utt, ctx: (utt, ctx)),
+                            ("metadata_plugins", lambda ctx: ctx),
+                            ("intent_plugins", lambda intent: intent)):
+        plugins = MagicMock()
+        plugins.transform.side_effect = transform
+        setattr(svc, attr, plugins)
+
+    svc.disambiguate_lang = lambda m: "en-US"
+    svc.intent_manifest = IntentManifest(bus)
+    svc.intent_dispatcher = IntentDispatcher(
+        bus, timeout=0, on_terminal=svc._emit_utterance_handled)
+    svc.get_pipeline = lambda session: (
+        [("fake-high", lambda utts, lang, msg: match)] if match else [])
+    return svc
+
+
+def _utterance(session_snapshot=None, utterance="hello") -> Message:
+    context = {} if session_snapshot is None else {"session": session_snapshot}
+    return Message("recognizer_loop:utterance",
+                   data={"utterances": [utterance]}, context=context)
+
+
+class SessionIntakeTestCase(unittest.TestCase):
+    def setUp(self):
+        self.bus = FakeBus()
+        SessionManager.sessions.clear()
+        SessionManager.reset_default_session()
+        SessionManager.bus = None
+
+    tearDown = setUp
+
+    def drive(self, svc, message):
+        """Run one utterance and return the session on its end-marker."""
+        handled = []
+        self.bus.on(SpecMessage.UTTERANCE_HANDLED, handled.append)
+        svc.handle_utterance(message)
+        self.bus.remove(SpecMessage.UTTERANCE_HANDLED, handled.append)
+        self.assertEqual(len(handled), 1,
+                         "expected exactly one ovos.utterance.handled")
+        return handled[0].context["session"]
+
+
+class TestDefaultSessionArrival(SessionIntakeTestCase):
+    """§5.1 first bullet — an inbound default-session carrier is merged into
+    the store as part of the utterance lifecycle."""
+
+    def test_context_declared_on_one_utterance_gates_the_next(self):
+        """The device declares an intent_context gate on its utterance; the
+        next utterance, which declares nothing, still sees the gate.
+
+        This is the whole point of the store. The device may omit its session
+        entirely (§6.5) precisely because the orchestrator holds it, so a
+        carrier that arrives and is not merged leaves every context-gated
+        skill unreachable from the second turn onwards.
+        """
+        svc = _make_service(self.bus)
+
+        declared = Session(DEFAULT_SESSION_ID)
+        declared.intent_context = {"naptime.skill:awake": {"value": "yes"}}
+        self.drive(svc, _utterance(declared.serialize()))
+
+        # a bare follow-up: no session carrier at all, as §6.5 permits
+        second = self.drive(svc, _utterance())
+        self.assertIn("naptime.skill:awake",
+                      second.get(INTENT_CONTEXT_FIELD) or {})
+
+    def test_omitted_field_keeps_the_stored_value(self):
+        """§5.1 merge semantics: a field the carrier omits is not cleared."""
+        svc = _make_service(self.bus)
+
+        declared = Session(DEFAULT_SESSION_ID)
+        declared.blacklisted_intents = ["skill_x"]
+        self.drive(svc, _utterance(declared.serialize()))
+
+        second = self.drive(svc, _utterance(Session(DEFAULT_SESSION_ID).serialize()))
+        self.assertEqual(second.get("blacklisted_intents"), ["skill_x"])
+
+    def test_present_field_replaces_the_stored_value(self):
+        """§5.1 merge semantics: a field the carrier sends does replace."""
+        svc = _make_service(self.bus)
+
+        first = Session(DEFAULT_SESSION_ID)
+        first.blacklisted_intents = ["skill_x"]
+        self.drive(svc, _utterance(first.serialize()))
+
+        second = Session(DEFAULT_SESSION_ID)
+        second.blacklisted_intents = ["skill_y"]
+        result = self.drive(svc, _utterance(second.serialize()))
+        self.assertEqual(result.get("blacklisted_intents"), ["skill_y"])
+
+
+class TestArrivalHappensOnceAnUtterance(SessionIntakeTestCase):
+    """§5.1 — the orchestrator takes an arrival exactly once per utterance,
+    at the lifecycle entry, and its own write paths never take another."""
+
+    def test_one_arrival_per_utterance(self):
+        svc = _make_service(self.bus)
+        arrivals = []
+        real_fold = SessionManager.fold_inbound
+        SessionManager.fold_inbound = classmethod(
+            lambda cls, message: arrivals.append(message) or real_fold(message))
+        try:
+            self.drive(svc, _utterance(Session(DEFAULT_SESSION_ID).serialize()))
+            self.assertEqual(len(arrivals), 1)
+
+            # a legacy context write and a converse toggle arrive on their own
+            # Messages mid-round; neither is an arrival (§2.6)
+            frame = Message("add_context", {"context": "Kitchen"},
+                            dict(arrivals[0].context))
+            IntentService.handle_add_context(frame)
+            self.assertEqual(len(arrivals), 1)
+
+            self.drive(svc, _utterance())
+            self.assertEqual(len(arrivals), 2)
+        finally:
+            SessionManager.fold_inbound = real_fold
+
+    def test_a_context_write_does_not_adopt_the_frames_carrier(self):
+        """§2.6: a mid-round frame's own snapshot does not revise the working
+        session, so a stale one cannot wipe what the round accumulated."""
+        svc = _make_service(self.bus)
+
+        declared = Session(DEFAULT_SESSION_ID)
+        declared.intent_context = {"naptime.skill:awake": {"value": "yes"}}
+        message = _utterance(declared.serialize())
+        svc.handle_utterance(message)
+
+        stale = Message("add_context", {"context": "Kitchen"},
+                        {"session": Session(DEFAULT_SESSION_ID).serialize(),
+                         "utterance_id": message.context["utterance_id"]})
+        IntentService.handle_add_context(stale)
+
+        stored = SessionManager.get_default_session()
+        self.assertIn("naptime.skill:awake", stored.intent_context or {})
+        self.assertIn("Kitchen", stored.intent_context or {})
+
+
+class TestSessionSyncConsumer(SessionIntakeTestCase):
+    """§2.7 / §6.2 — ``ovos.session.sync`` carries a snapshot in
+    ``Message.data["session"]`` and the orchestrator honours it."""
+
+    def _sync(self, snapshot, carrier=None):
+        context = {} if carrier is None else {"session": carrier}
+        return Message(SpecMessage.SESSION_SYNC, {"session": snapshot}, context)
+
+    def test_sync_merges_the_data_carrier_into_the_store(self):
+        svc = _make_service(self.bus)
+        stored = SessionManager.get_default_session()
+        stored.blacklisted_intents = ["skill_x"]
+
+        synced = Session(DEFAULT_SESSION_ID)
+        synced.intent_context = {"tea.skill:brewing": {"value": "yes"}}
+        svc.handle_session_sync(self._sync(synced.serialize()))
+
+        stored = SessionManager.get_default_session()
+        self.assertIn("tea.skill:brewing", stored.intent_context or {})
+        # §5.1: what the snapshot omits keeps its stored value
+        self.assertEqual(stored.blacklisted_intents, ["skill_x"])
+
+    def test_sync_for_an_unknown_named_session_is_dropped(self):
+        """§2.2: no round is open for it, so there is nothing to revise — and
+        certainly not the default store."""
+        svc = _make_service(self.bus)
+
+        synced = Session("nobody-here")
+        synced.intent_context = {"tea.skill:brewing": {"value": "yes"}}
+        svc.handle_session_sync(
+            self._sync(synced.serialize(), carrier=synced.serialize()))
+
+        self.assertEqual(SessionManager.sessions.get("nobody-here"), None)
+        self.assertEqual(
+            SessionManager.get_default_session().intent_context or {}, {})
+
+    def test_sync_reaches_the_named_session_of_an_open_round(self):
+        """§2.7 directs a named-session sync at the utterance in progress."""
+        received = []
+        self.bus.on("lights.skill:on", received.append)
+        match = IntentHandlerMatch(match_type="lights.skill:on",
+                                   match_data={"conf": 1.0},
+                                   skill_id="lights.skill", utterance="turn on")
+        svc = _make_service(self.bus, match=match)
+
+        carrier = Session("client-1")
+        message = _utterance(carrier.serialize(), utterance="turn on")
+        handled = []
+        self.bus.on(SpecMessage.UTTERANCE_HANDLED, handled.append)
+        svc.handle_utterance(message)
+        self.assertEqual(len(received), 1, "handler was never dispatched")
+
+        # the skill syncs a context entry mid-round, on its own dispatch frame
+        synced = Session("client-1")
+        synced.intent_context = {"lights.skill:room": {"value": "kitchen"}}
+        svc.handle_session_sync(
+            Message(SpecMessage.SESSION_SYNC, {"session": synced.serialize()},
+                    dict(received[0].context)))
+
+        self.bus.emit(Message("mycroft.skill.handler.complete", {},
+                              {"skill_id": "lights.skill",
+                               "session": received[0].context.get("session")}))
+        self.assertEqual(len(handled), 1)
+        self.assertIn("lights.skill:room",
+                      handled[0].context["session"].get(INTENT_CONTEXT_FIELD) or {})
+
+
+class TestNamedSessionThreading(SessionIntakeTestCase):
+    """§2.2 — the orchestrator holds no named session between utterances, so
+    the round's own session is what every step reads and writes."""
+
+    def _dispatch_named(self, svc, session_id="client-1"):
+        received = []
+        self.bus.on("lights.skill:on", received.append)
+        carrier = Session(session_id)
+        message = _utterance(carrier.serialize(), utterance="turn on")
+        handled = []
+        self.bus.on(SpecMessage.UTTERANCE_HANDLED, handled.append)
+        svc.handle_utterance(message)
+        self.assertEqual(len(received), 1, "handler was never dispatched")
+        return received[0], handled
+
+    def test_tracked_deactivation_is_replayed_onto_the_end_marker(self):
+        """A skill that deactivated itself mid-dispatch must not be active on
+        the §9.5 end-marker of a named session's round."""
+        match = IntentHandlerMatch(match_type="lights.skill:on",
+                                   match_data={"conf": 1.0},
+                                   skill_id="lights.skill", utterance="turn on")
+        svc = _make_service(self.bus, match=match)
+        dispatch, handled = self._dispatch_named(svc)
+
+        svc._handle_deactivate(
+            Message("intent.service.skills.deactivate",
+                    {"skill_id": "lights.skill"}, dict(dispatch.context)))
+
+        self.bus.emit(Message("mycroft.skill.handler.complete", {},
+                              {"skill_id": "lights.skill",
+                               "session": dispatch.context.get("session")}))
+
+        self.assertEqual(len(handled), 1)
+        end_session = Session.deserialize(handled[0].context["session"])
+        self.assertFalse(end_session.is_active("lights.skill"))
+
+    def test_decay_ticks_on_a_named_session(self):
+        """§4.2 decay reaches a named session's context and rides the wire
+        back, which is the only channel it has (§2.2)."""
+        svc = _make_service(self.bus)
+
+        carrier = Session("client-2")
+        carrier.intent_context = {"person": {"value": "Bob",
+                                             "turns_remaining": 3}}
+        end_session = self.drive(svc, _utterance(carrier.serialize()))
+        self.assertEqual(
+            end_session[INTENT_CONTEXT_FIELD]["person"]["turns_remaining"], 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unittests/test_skill_manager.py
+++ b/test/unittests/test_skill_manager.py
@@ -42,16 +42,19 @@ class MessageBusMock:
         self.message_types = []
         self.message_data = []
         self.event_handlers = []
+        self.handlers = []
 
     def emit(self, message):
         self.message_types.append(message.msg_type)
         self.message_data.append(message.data)
 
-    def on(self, event, _):
+    def on(self, event, handler):
         self.event_handlers.append(event)
+        self.handlers.append((event, handler))
 
-    def once(self, event, _):
+    def once(self, event, handler):
         self.event_handlers.append(event)
+        self.handlers.append((event, handler))
 
     def wait_for_response(self, message):
         self.emit(message)
@@ -845,9 +848,13 @@ class TestSkillManagerSessionManagerBus(TestCase):
         constructing IntentService, and IntentService.__init__ used to call
         SessionManager.connect_to_bus() unconditionally. Same bus object on
         both call sites means every standard monolith boot registered all
-        five SessionManager bus handlers twice. Assert exactly one handler
-        per topic is registered, regardless of which subsystem connects
-        first.
+        five SessionManager bus handlers twice. Assert exactly one
+        SessionManager-owned handler per topic is registered, regardless of
+        which subsystem connects first.
+
+        Counted by handler owner, not by topic: ``ovos.session.sync`` also
+        carries IntentService's own OVOS-SESSION-2 §2.7 subscriber, which is
+        a different handler doing a different job on the same topic.
         """
         bus = MessageBusMock()
         SkillManager(bus, enable_intent_service=True, enable_file_watcher=False)
@@ -860,9 +867,12 @@ class TestSkillManagerSessionManagerBus(TestCase):
             "recognizer_loop:audio_output_end",
             SpecMessage.SESSION_SYNC,
         ):
+            owned = [h for t, h in bus.handlers
+                     if t == topic
+                     and getattr(h, "__self__", None) is SessionManager]
             self.assertEqual(
-                bus.event_handlers.count(topic), 1,
-                f"expected exactly one handler for {topic}, got "
-                f"{bus.event_handlers.count(topic)}"
+                len(owned), 1,
+                f"expected exactly one SessionManager handler for {topic}, "
+                f"got {len(owned)}"
             )
 


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 5 (claude-opus-5) via Claude Code — NOT human-reviewed. Verify before acting.

`ovos-bus-client` 2.11.1a1 made `SessionManager.get()` a pure read and stopped the registry from holding named sessions, which is what OVOS-SESSION-2 §2.2 asks for. Core was still written against the old contract, where every `get()` folded the message's snapshot onto a registry entry. The result is that nothing merged an inbound carrier into the default-session store, and every named-session registry lookup quietly missed.

The visible break is on the device's own session: a client that declared `intent_context` on one utterance lost it before the next, because `_validate_session` read the store rather than merging the carrier into it. Every context-gated skill became unreachable from the second turn onward. On a named session the symptoms were different but the cause was the same — the OVOS-CONTEXT-1 §4.2 decay stopped without ever ticking, the tracked-deactivation replay never reached `ovos.utterance.handled`, and the converse timeout filter and get_response toggles wrote to objects nobody would read again.

`_validate_session` now calls `SessionManager.fold_inbound`. That is the §5.1 arrival and the only one core takes: an omitted field leaves the stored value standing, a present one replaces it, and a named session is built from its carrier alone. The session the arrival produces is registered as the round's working session in a new `working_session` module, keyed on the §9.1.1 `utterance_id` that every derived Message already carries. The five sites that used to consult `SessionManager.sessions` for a named id read it from there instead, and the round is dropped at its terminal — §2.2 permits exactly this cache and forbids anything durable. `ovos.session.sync` gains its §2.7 consumer alongside SessionManager's existing §5.3 one: the snapshot on `Message.data["session"]` merges into the store for the default session, and into the working session of an open round for a named one.

Two things are worth a reviewer's attention. First, the arrival is once per utterance *in core*, but `MessageBusClient._take_inbound_session` still folds every inbound default-session message at the transport layer, and `ovos_utils.fakebus.FakeBus.on_message` does the same with a full `update`. Narrowing that is a bus-client and ovos-utils change, not one core can make, so the once-per-utterance test here asserts what core itself does. Second, `ovos-workshop`'s producer still resolves a named session through `SessionManager.sessions` (`intents.py:86`); the end-to-end reachability test plants the round's session there so both halves write the same object, and that lookup wants the same treatment in a follow-up. The deprecated `SessionManager.sync` broadcast is left alone here — §2.7 says there is no push topic, but removing it is a behaviour change with its own tests and belongs in its own PR.

Floors move to `ovos-bus-client>=2.11.1a1` and `ovos-spec-tools>=1.10.1a1`. This change requires the new API and carries no feature-detect shim.

Ten new tests in `test/unittests/test_session2_intake.py` cover the arrival merge, the once-per-utterance property, the §2.7 sync and the named-session threading; all ten fail against the unfixed source. The existing tests that encoded the registry-holds-named-sessions contract are rewritten to the working-session one. The unit suite is 481 passed on this branch against 461 passed and 10 failed on `dev` with the same dependency set. The end-to-end suite is flaky on `dev` with this dependency set and its failure set shifts between identical runs — `test_intent_pipeline` and `test_activate` gave 6 failed then 2 failed across two consecutive `dev` runs of the same files. The failures stable across every run on both sides are `test_adapt`'s two tests (both namespaces) and the two targeted-stop e2e tests; none of them are touched by this diff. `test_context1_reachability` needed updating, because it read a named session back out of `SessionManager.sessions`, and it passes here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved session handling across multi-turn interactions, including named sessions and session synchronization.
  - Preserved the active session consistently throughout each utterance round.
  - Improved context updates, expiration, and no-match responses to reflect the active session accurately.
- **Documentation**
  - Added prerelease notes describing the updated session-management behavior.
- **Bug Fixes**
  - Fixed stale session data being used during ongoing interactions.
  - Improved handling of session updates and context changes received during a conversation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->