### PR TITLE
fix: bind the round's working session to the dispatch message at intake

### DIFF
--- a/ovos_core/intent_services/service.py
+++ b/ovos_core/intent_services/service.py
@@ -593,13 +593,27 @@ class IntentService:
         # §5.1: a committed ``Match.updated_session`` replaces the working
         # session wholesale; otherwise the round continues on the session it
         # was folded onto at entry. No fold here (§2.6).
-        sess = match.updated_session or working_session(message) or \
-            SessionManager.get(message)
+        sess = working_session(message) or SessionManager.get(message)
         if match.updated_session is not None:
-            # ``update`` returns the store for the default session, so the
-            # round carries on the one object every co-located view holds.
-            sess = SessionManager.update(sess)
-            open_round(message, sess)
+            updated = match.updated_session
+            if updated.resolved_session_id() != sess.resolved_session_id():
+                # §5.1/§4.2: updated_session is defined as the ROUND's session,
+                # updated — never a different session. A pipeline plugin
+                # returning one for a different id is a plugin bug, and a
+                # plugin bug must not kill the utterance: log it and keep
+                # dispatching on the round's own working session.
+                LOG.error(
+                    f"pipeline '{pipeline_id}' returned an updated_session "
+                    f"for '{updated.resolved_session_id()}' but the round is "
+                    f"running on '{sess.resolved_session_id()}'; ignoring "
+                    f"the updated_session and continuing on the round's own "
+                    f"session")
+            else:
+                # ``update`` returns the store for the default session, so the
+                # round carries on the one object every co-located view holds.
+                sess = SessionManager.update(updated)
+                open_round(message, sess)
+                SessionManager.bind(message, sess)
         sess.lang = lang  # ensure it is updated
 
         # Launch intent handler
@@ -843,6 +857,11 @@ class IntentService:
         # can now reach the session the round is running on, which for a named
         # session is the only place it lives.
         open_round(message, sess)
+        # Bind the working session as the message's own session: every
+        # ``SessionManager.get(message)`` this round and every derivation's
+        # ``stamp_derived`` must see this exact object, mutations included,
+        # rather than rebuilding one from the (now stale) carrier.
+        SessionManager.bind(message, sess)
 
         # OVOS-CONTEXT-1 §4 (pre-match): prune dead entries so every matcher
         # this round sees the same gating snapshot

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "ovos-config>=2.1.4a5,<4.0.0",
     "ovos-workshop>=9.3.11a1,<10.0.0",
     "rapidfuzz>=3.6,<4.0",
-    "ovos-spec-tools[langcodes]>=1.10.1a1,<2.0.0",
+    "ovos-spec-tools[langcodes]>=1.10.4a1,<2.0.0",
 ]
 
 [project.urls]

--- a/test/unittests/test_intent_context.py
+++ b/test/unittests/test_intent_context.py
@@ -296,6 +296,57 @@ class TestLiveSessionManagerSync(unittest.TestCase):
         self.assertNotIn("tea.skill:flag",
                          turn2.get(INTENT_CONTEXT_FIELD) or {})
 
+    def test_intake_binds_the_working_session_to_the_message_named(self):
+        """The round must run on ONE session object: mid-round, the
+        message's bound session (what every ``SessionManager.get(message)``
+        and derivation sees) must be the exact working session object the
+        orchestrator opened the round with, for a named carrier."""
+        from ovos_core.intent_services.working_session import working_session
+        bus = FakeBus()
+        SessionManager.connect_to_bus(bus)
+        svc = _make_service()
+        svc.bus = bus
+
+        seen = {}
+
+        def _capture(utts, lang, message):
+            seen["bound"] = SessionManager.get(message)
+            seen["working"] = working_session(message)
+            return None
+
+        svc.get_pipeline = lambda session: [("fake", _capture)]
+
+        carrier = Session("bind-check-sess")
+        msg = Message("recognizer_loop:utterance",
+                      data={"utterances": ["hello"]},
+                      context={"session": carrier.serialize()})
+        svc.handle_utterance(msg)
+        self.assertIs(seen["bound"], seen["working"])
+
+    def test_intake_binds_the_working_session_to_the_message_default(self):
+        """Same invariant for the default carrier: the object bound must be
+        the registry's own default-session store, not a copy, since
+        ``SessionManager.bind`` refuses anything else for a default-shaped
+        session."""
+        bus = FakeBus()
+        SessionManager.connect_to_bus(bus)
+        svc = _make_service()
+        svc.bus = bus
+
+        seen = {}
+
+        def _capture(utts, lang, message):
+            seen["bound"] = SessionManager.get(message)
+            return None
+
+        svc.get_pipeline = lambda session: [("fake", _capture)]
+
+        msg = Message("recognizer_loop:utterance",
+                      data={"utterances": ["hello"]},
+                      context={})
+        svc.handle_utterance(msg)
+        self.assertIs(seen["bound"], SessionManager.get_default_session())
+
     @pytest.mark.xfail(strict=True, reason=_NEEDS_BUS_CLIENT_278)
     def test_midispatch_sync_survives_decay(self):
         # §4.1: a mid-dispatch entry is not decremented by the round it arrived in
@@ -355,6 +406,53 @@ class TestLiveSessionManagerSync(unittest.TestCase):
         ctx = SessionManager.sessions["refresh-sess"].intent_context
         self.assertEqual(ctx["tea.skill:flag"]["turns_remaining"], 5)
         self.assertEqual(ctx["tea.skill:flag"]["value"], "b")
+
+
+class TestDispatchMatchRejectsMismatchedUpdatedSession(unittest.TestCase):
+    """OVOS-PIPELINE-1 §4.2 / OVOS-SESSION-2 §5.1: ``updated_session`` is
+    defined as the ROUND's own session, updated — never a different
+    session. A pipeline plugin handing back one for a different id is a
+    plugin bug, and a plugin bug must not kill the utterance."""
+
+    def setUp(self):
+        SessionManager.sessions = {"default": Session("default")}
+        SessionManager.default_session = SessionManager.sessions["default"]
+        SessionManager.bus = None
+
+    tearDown = setUp
+
+    def test_mismatched_updated_session_id_is_rejected_not_fatal(self):
+        bus = FakeBus()
+        SessionManager.connect_to_bus(bus)
+        svc = _make_service()
+        svc.bus = bus
+        svc.intent_dispatcher = MagicMock()
+
+        carrier = Session("sat-1")
+        mismatched = Session("sat-2")
+        bad_match = IntentHandlerMatch(
+            match_type="test:intent", match_data={}, skill_id=None,
+            utterance="hello", updated_session=mismatched)
+        svc.get_pipeline = lambda session: [
+            ("fake-high", lambda utts, lang, msg: bad_match)]
+
+        msg = Message("recognizer_loop:utterance",
+                      data={"utterances": ["hello"]},
+                      context={"session": carrier.serialize()})
+
+        from ovos_core.intent_services import service as service_module
+        with patch.object(service_module.LOG, "error") as mock_error:
+            svc.handle_utterance(msg)
+
+        mock_error.assert_called_once()
+        logged = mock_error.call_args[0][0]
+        self.assertIn("sat-1", logged)
+        self.assertIn("sat-2", logged)
+        # dispatch proceeded on the round's own session, not the rejected one
+        svc.intent_dispatcher.dispatch.assert_called_once()
+        dispatched_reply = svc.intent_dispatcher.dispatch.call_args[0][0]
+        self.assertEqual(
+            dispatched_reply.context["session"]["session_id"], "sat-1")
 
 
 class TestSessionSyncCarrier(unittest.TestCase):

--- a/test/unittests/test_intent_service_extended.py
+++ b/test/unittests/test_intent_service_extended.py
@@ -1227,18 +1227,19 @@ class TestHandleUtterance(unittest.TestCase):
         sess.blacklisted_intents = ["skill_a:stop"]
         before = list(sess.active_handlers)
 
+        # the carrier must name session "s" too: the round's own working
+        # session (what blacklisted_intents gating reads) now comes from
+        # the intake carrier fold, not from the ``SessionManager.get`` patch
+        # below (which only satisfies StopService's own lookups).
         msg = Message("recognizer_loop:utterance",
                       data={"utterances": ["stop"]},
-                      context={})
+                      context={"session": sess.serialize()})
 
         with patch.object(svc, "get_pipeline",
                           return_value=[("ovos-stop-pipeline-plugin", stop_svc.match_high)]), \
              patch.object(stop_svc, "_collect_stop_skills", return_value=["skill_a"]), \
              patch("ovos_core.intent_services.service.SessionManager.get",
                    return_value=sess), \
-             patch("ovos_core.intent_services.service.SessionManager.reset_default_session",
-                   return_value=sess), \
-             patch("ovos_core.intent_services.service.SessionManager.update"), \
              patch("ovos_core.intent_services.service.SessionManager.sync"), \
              patch("ovos_core.intent_services.service.get_message_lang",
                    return_value="en-US"), \


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

ovos-spec-tools 1.10.4a1 (merging PR #123) exposed a regression in how the orchestrator hands a round's working session to the rest of the dispatch: `open_round(message, sess)` puts the round's session into the utterance-scoped cache, but `message.reply`/`message.forward` derivations stamp whatever `SessionManager` resolves as the message's session from its carrier, which was a *different* object than the one `open_round` installed. Pre-match decay (`_apply_post_match_decay`) mutates the working session, but that mutation never reaches the wire because the reply/forward derivations never saw it. `test_orchestrator_decays_a_named_session_over_the_wire` catches this directly: a context flag's `turns_remaining` stays at 0 instead of being pruned from the outbound session snapshot on the following turn.

The fix uses the new public `SessionManager.bind(message, session)` from spec-tools to make the working session the message's own binding right after each `open_round(message, sess)` call (intake, and the `updated_session` commit path in `_dispatch_match`). With that, every `SessionManager.get(message)` and every derivation's `stamp_derived` in the round agree on the same object, so the round runs on exactly one session end to end. The pyproject floor pin for `ovos-spec-tools` is bumped to `1.10.4a1`, the first published version that contains the merged `bind()` API.

Neither spec states an explicit id-equality rule for `updated_session`, but both model a round as one continuous working session: OVOS-PIPELINE-1 §6.1 retrieves the session once per round, and OVOS-SESSION-2 §2.6 treats it as a single object throughout. Neither contemplates a mid-round switch to a different session id, so a pipeline plugin returning an `updated_session` for a different id than the round's own is a plugin bug, not a supported case. Binding it unconditionally meant that bug would make `bind()` raise, and `_dispatch_match`'s exception handler silently turned that into a no-match, dropping the utterance with no visible error. A plugin bug must not be able to kill the utterance, so the commit site now compares the resolved session ids first: on a mismatch it logs an error naming the offending pipeline and both ids and keeps dispatching on the round's own working session, only adopting the plugin's `updated_session` when the ids agree.

Verification: reverting only the source hunk while keeping the new tests reproduces the original decay failure (`AssertionError: 'tea.skill:flag' unexpectedly found in {'turns_remaining': 0}`), and reapplying it passes; the same patch-revert check on the rejection-rule hunk reproduces the raw `ValueError` from `bind()` before the guard exists. Two new regression tests assert `SessionManager.get(message)` is the exact working-session object mid-round (named and default carriers), and a third drives a stub pipeline match with a mismatched `updated_session` through the real `_dispatch_match`, asserting dispatch proceeds, the round keeps its own session, and the mismatch is logged rather than raised. One pre-existing test was passing only by accident — its message never carried the session id its own `SessionManager.get` patch assumed, so the previous unconditional `bind()` crash happened to fall through to the same no-match path the test expected; the message now carries that session on its context so the intended blacklist gate is what actually discards the match. Full `test/unittests`: 484 passed, 6 xfailed (481 baseline + 3 new/updated tests, no other regressions). Session-relevant `test/end2end` files (context1 reachability, intent pipeline, activate, converse, fallback): 12 passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved session handling during utterance processing by consistently using the active working session.
  - Rejects mismatched session updates safely while allowing dispatch to continue with the correct session.
  - Ensures session context remains available for related intent and stop-processing behavior.

- **Tests**
  - Added coverage for named and default session binding.
  - Added regression coverage for mismatched session updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->