### PR TITLE
test: observe named-session activation on the wire and use an Adapt fixture skill

### DIFF
--- a/test/end2end/test_adapt.py
+++ b/test/end2end/test_adapt.py
@@ -18,6 +18,9 @@ from ovos_bus_client.message import Message
 from ovos_bus_client.session import Session
 from ovos_spec_tools import SpecMessage, migration_counterpart
 from ovos_utils.log import LOG
+from ovos_workshop.decorators import intent_handler
+from ovos_workshop.intents import IntentBuilder
+from ovos_workshop.skills import OVOSSkill
 
 from ovoscope import End2EndTest, get_minicroft
 
@@ -44,11 +47,26 @@ NAMESPACE_PATHS = {
 }
 
 
+class AdaptHelloWorldSkill(OVOSSkill):
+    """A minimal Adapt-only fixture skill, kept in-repo so this suite owns
+    its lifecycle shape (10 messages on a match, 4 on a no-match) instead of
+    borrowing it from a plugin skill that can migrate its intents to a
+    different pipeline out from under these tests (see ovos-skill-hello-world
+    0.2.8a2, which moved ``HelloWorldIntent`` to Padatious)."""
+
+    def initialize(self):
+        self.register_vocabulary("hello world", "HelloWorldKeyword")
+
+    @intent_handler(IntentBuilder("HelloWorldIntent").require("HelloWorldKeyword"))
+    def handle_hello_world_intent(self, message):
+        self.speak("Hello world")
+
+
 class TestAdaptIntent(TestCase):
 
     def setUp(self):
         LOG.set_level("DEBUG")
-        self.skill_id = "ovos-skill-hello-world.openvoiceos"
+        self.skill_id = "test-adapt-hello-world.openvoiceos"
 
     def tearDown(self):
         LOG.set_level("CRITICAL")
@@ -56,7 +74,8 @@ class TestAdaptIntent(TestCase):
     def _run_adapt_match(self, namespace):
         modernize, emit_legacy, utt_topic = NAMESPACE_PATHS[namespace]
         minicroft = get_minicroft([self.skill_id], modernize=modernize,
-                                  emit_legacy=emit_legacy)
+                                  emit_legacy=emit_legacy,
+                                  extra_skills={self.skill_id: AdaptHelloWorldSkill})
         try:
 
             session = Session("123")
@@ -101,19 +120,17 @@ class TestAdaptIntent(TestCase):
                             data={"utterance": "hello world", "lang": session.lang},
                             context={"skill_id": self.skill_id}),
                     Message("mycroft.skill.handler.start",
-                            data={"name": "HelloWorldSkill.handle_hello_world_intent"},
+                            data={"name": "AdaptHelloWorldSkill.handle_hello_world_intent"},
                             context={"skill_id": self.skill_id}),
                     Message(SPEC_SPEAK,
                             data={"utterance": "Hello world",
                                   "expect_response": False,
                                   "meta": {
-                                      "dialog": "hello.world",
-                                      "data": {},
                                       "skill": self.skill_id
                                   }},
                             context={"skill_id": self.skill_id}),
                     Message("mycroft.skill.handler.complete",
-                            data={"name": "HelloWorldSkill.handle_hello_world_intent"},
+                            data={"name": "AdaptHelloWorldSkill.handle_hello_world_intent"},
                             context={"skill_id": self.skill_id}),
                 # PIPELINE-1 §8.1: orchestrator emits complete on the handler's
                 # completion, before the end-marker (spec ordering §6.1).
@@ -139,7 +156,8 @@ class TestAdaptIntent(TestCase):
     def _run_skill_blacklist(self, namespace):
         modernize, emit_legacy, utt_topic = NAMESPACE_PATHS[namespace]
         minicroft = get_minicroft([self.skill_id], modernize=modernize,
-                                  emit_legacy=emit_legacy)
+                                  emit_legacy=emit_legacy,
+                                  extra_skills={self.skill_id: AdaptHelloWorldSkill})
         try:
 
             session = Session("123")
@@ -177,7 +195,8 @@ class TestAdaptIntent(TestCase):
     def _run_intent_blacklist(self, namespace):
         modernize, emit_legacy, utt_topic = NAMESPACE_PATHS[namespace]
         minicroft = get_minicroft([self.skill_id], modernize=modernize,
-                                  emit_legacy=emit_legacy)
+                                  emit_legacy=emit_legacy,
+                                  extra_skills={self.skill_id: AdaptHelloWorldSkill})
         try:
 
             session = Session("123")
@@ -215,7 +234,8 @@ class TestAdaptIntent(TestCase):
     def _run_padatious_no_match(self, namespace):
         modernize, emit_legacy, utt_topic = NAMESPACE_PATHS[namespace]
         minicroft = get_minicroft([self.skill_id], modernize=modernize,
-                                  emit_legacy=emit_legacy)
+                                  emit_legacy=emit_legacy,
+                                  extra_skills={self.skill_id: AdaptHelloWorldSkill})
         try:
 
             session = Session("123")

--- a/test/end2end/test_stop_legacy_e2e.py
+++ b/test/end2end/test_stop_legacy_e2e.py
@@ -13,11 +13,11 @@ skill_id is the target skill or the pipeline_id). When the bridge is removed
 these tests fail — the legacy topics are gone — which is the intended signal
 that the compatibility unit was dropped.
 """
-import time
+import threading
 from unittest import TestCase
 
 from ovos_bus_client.message import Message
-from ovos_bus_client.session import Session, SessionManager
+from ovos_bus_client.session import Session
 from ovos_spec_tools import SpecMessage
 from ovos_utils import create_daemon
 from ovos_utils.log import LOG
@@ -50,14 +50,37 @@ _IGNORE = [
 ]
 
 
-def _wait_for_active_skill(session_id, skill_id, timeout=10, interval=0.1):
-    deadline = time.time() + timeout
-    while time.time() < deadline:
-        sess = SessionManager.sessions.get(session_id)
-        if sess and sess.is_active(skill_id):
+def _wait_for_active_skill(bus, session_id, skill_id, timeout=10):
+    """Observe a named session's activation on the wire, and return the
+    activated ``Session`` observed there.
+
+    ``SessionManager.sessions`` (ovos-spec-tools >=1.10.1a1, SESSION-2
+    §2.2/§2.3) only ever holds the default session; a named session's state
+    lives in the utterance flow that carries it, not in that registry. The
+    §8.1 ``ovos.intent.handler.start`` dispatch is forwarded from the
+    matched intent's message *after* the orchestrator has stamped the
+    activated session onto its context, so it is the earliest point on the
+    bus where a named session's activation is observable.
+    """
+    activated = threading.Event()
+    observed = {}
+
+    def on_handler_start(message):
+        session = (message.context or {}).get("session") or {}
+        if session.get("session_id") != session_id:
             return
-        time.sleep(interval)
-    raise TimeoutError(f"Skill {skill_id} did not activate within {timeout}s")
+        sess = Session.deserialize(session)
+        if sess.is_active(skill_id):
+            observed["session"] = sess
+            activated.set()
+
+    bus.on(SpecMessage.INTENT_HANDLER_START.value, on_handler_start)
+    try:
+        if not activated.wait(timeout):
+            raise TimeoutError(f"Skill {skill_id} did not activate within {timeout}s")
+    finally:
+        bus.remove(SpecMessage.INTENT_HANDLER_START.value, on_handler_start)
+    return observed["session"]
 
 
 class TestLegacyGlobalStop(TestCase):
@@ -133,9 +156,8 @@ class TestLegacyTargetedStop(TestCase):
                     {"session": session.serialize(), "source": "A", "destination": "B"}))
 
             create_daemon(make_it_count)
-            _wait_for_active_skill(session.session_id, self.skill_id)
+            live = _wait_for_active_skill(minicroft.bus, session.session_id, self.skill_id)
 
-            live = SessionManager.sessions[session.session_id]
             message = Message(SPEC_UTTERANCE,
                               {"utterances": ["stop"], "lang": live.lang},
                               {"session": live.serialize(), "source": "A", "destination": "B"})

--- a/test/end2end/test_stop_spec_e2e.py
+++ b/test/end2end/test_stop_spec_e2e.py
@@ -17,11 +17,11 @@ The un-migrated ``ovos-skill-count`` still subscribes to the legacy
 ``modernize=True, emit_legacy=True`` (the translator active). The global
 scenario needs no skill and runs on the pure spec namespace.
 """
-import time
+import threading
 from unittest import TestCase
 
 from ovos_bus_client.message import Message
-from ovos_bus_client.session import Session, SessionManager
+from ovos_bus_client.session import Session
 from ovos_spec_tools import SpecMessage
 from ovos_utils import create_daemon
 from ovos_utils.log import LOG
@@ -69,14 +69,40 @@ _IGNORE = [
 ]
 
 
-def _wait_for_active_skill(session_id, skill_id, timeout=10, interval=0.1):
-    deadline = time.time() + timeout
-    while time.time() < deadline:
-        sess = SessionManager.sessions.get(session_id)
-        if sess and sess.is_active(skill_id):
+def _wait_for_active_skill(bus, session_id, skill_id, timeout=10):
+    """Observe a named session's activation on the wire, and return the
+    activated ``Session`` observed there.
+
+    ``SessionManager.sessions`` (ovos-spec-tools >=1.10.1a1, SESSION-2
+    §2.2/§2.3) only ever holds the default session; a named session's state
+    lives in the utterance flow that carries it, not in that registry. The
+    §8.1 ``ovos.intent.handler.start`` dispatch is forwarded from the
+    matched intent's message *after* the orchestrator has stamped the
+    activated session onto its context (see ``IntentService.handle_utterance``:
+    ``sess.activate_skill`` runs, then ``reply.context["session"]`` is set,
+    then the dispatcher forwards from that same message), so it is the
+    earliest point on the bus where a named session's activation is
+    observable.
+    """
+    activated = threading.Event()
+    observed = {}
+
+    def on_handler_start(message):
+        session = (message.context or {}).get("session") or {}
+        if session.get("session_id") != session_id:
             return
-        time.sleep(interval)
-    raise TimeoutError(f"Skill {skill_id} did not activate within {timeout}s")
+        sess = Session.deserialize(session)
+        if sess.is_active(skill_id):
+            observed["session"] = sess
+            activated.set()
+
+    bus.on(SpecMessage.INTENT_HANDLER_START.value, on_handler_start)
+    try:
+        if not activated.wait(timeout):
+            raise TimeoutError(f"Skill {skill_id} did not activate within {timeout}s")
+    finally:
+        bus.remove(SpecMessage.INTENT_HANDLER_START.value, on_handler_start)
+    return observed["session"]
 
 
 class TestGlobalStopSpec(TestCase):
@@ -157,9 +183,8 @@ class TestTargetedStopSpec(TestCase):
                     {"session": session.serialize(), "source": "A", "destination": "B"}))
 
             create_daemon(make_it_count)
-            _wait_for_active_skill(session.session_id, self.skill_id)
+            live = _wait_for_active_skill(minicroft.bus, session.session_id, self.skill_id)
 
-            live = SessionManager.sessions[session.session_id]
             message = Message(SPEC_UTTERANCE,
                               {"utterances": ["stop"], "lang": live.lang},
                               {"session": live.serialize(), "source": "A", "destination": "B"})
@@ -193,11 +218,28 @@ class TestTargetedStopSpec(TestCase):
                             {"skill_id": self.skill_id}),
                 ]
             )
-            test.execute()
+            captured = test.execute()
 
-            # §6.2: the stopped skill is drained from active_handlers.
-            drained = SessionManager.sessions[session.session_id]
-            self.assertNotIn(self.skill_id,
-                             [s[0] for s in drained.active_skills])
+            # §6.2: the stopped skill is drained from active_handlers. Read
+            # the drained state off the stop dispatch's own §9.5 terminal —
+            # the first ``ovos.utterance.handled`` following the
+            # ``{skill_id}:stop`` dispatch — not the registry (a named
+            # session never lands in ``SessionManager.sessions``) and not
+            # just any later message: the interrupted count intent's own
+            # (aborted) handler completes afterwards from an earlier,
+            # un-drained snapshot of this named session's flow, since only
+            # the default session gets re-stamped from a shared store.
+            stop_topic = f"{self.skill_id}:stop"
+            drained = None
+            seen_stop = False
+            for m in captured:
+                if m.msg_type == stop_topic:
+                    seen_stop = True
+                    continue
+                if seen_stop and m.msg_type == SpecMessage.UTTERANCE_HANDLED.value:
+                    drained = Session.deserialize(m.context["session"])
+                    break
+            self.assertIsNotNone(drained, "no utterance.handled terminal followed the stop dispatch")
+            self.assertFalse(drained.is_active(self.skill_id))
         finally:
             minicroft.stop()


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

`test_stop_spec_e2e.py::TestTargetedStopSpec` and both scenarios in `test_stop_legacy_e2e.py` were red on `dev` (bisected against ovos-core commit b80743f, the last-green commit, which fails identically with today's sibling versions — so this is not a core regression). Both polled `SessionManager.sessions.get("123")` waiting for a named session's skill to become active. ovos-spec-tools 1.10.4a1 (SESSION-2 §2.2/§2.3, `ovos_spec_tools/session.py` ~:926-930) keeps only the default session in that registry; a named session's state now lives solely in the utterance flow that carries it, so the poll ran out its full 10s timeout every time and the harness reported it as a handler timeout.

The fix observes the same activation on the wire instead of in that registry. `ovos.intent.handler.start` is the earliest bus message forwarded from the matched-intent message after `IntentService.handle_utterance` has stamped the activated session onto its context, so both tests now subscribe to it and read the session straight off the message that satisfies the wait. The §6.2 drain assertion in the spec test (which used to re-read the same registry after the stop dispatch) now reads the drained session off the stop dispatch's own `ovos.utterance.handled` terminal in the list `End2EndTest.execute()` returns, rather than any later message in that captured list — a later message on this named session's own flow can still carry an earlier, un-drained snapshot, because only the default session gets re-stamped from a shared store before being forwarded.

Separately, `test_adapt.py` used `ovos-skill-hello-world` as its Adapt fixture, and hello-world 0.2.8a2 moved `HelloWorldIntent` to Padatious (an `@intent_handler(...)` file-intent plus locale vocab), so the Adapt-lifecycle assertion (10 messages) and the padatious-no-match assertion (4 messages) no longer held against it — the utterance now matches on a different pipeline than the one under test. The fix adds a small in-repo `AdaptHelloWorldSkill` fixture, one `IntentBuilder`-based intent with a vocabulary registered directly in `initialize()` (no locale files needed), loaded through `get_minicroft`'s `extra_skills`, following the same in-file-fixture pattern `test_activate.py` already uses. The suite now owns the pipeline its own fixture runs on, instead of borrowing one from a plugin skill that can migrate intents to a different pipeline out from under it.

Versions in the venv used to reproduce and verify: `ovos-spec-tools==1.10.4a1`, `ovos-skill-hello-world==0.2.8a2`, `ovoscope==1.6.20a1`, `ovos-workshop==9.6.5a1`, `ovos-core` at this branch's tip (3.2.3a1). `test_adapt.py`, `test_stop_spec_e2e.py`, `test_stop_legacy_e2e.py`, `test_padatious.py`, `test_intent_pipeline.py`, and `test_converse.py` all pass (17 tests, 26 subtests). The full `test/end2end` suite passes: 37 tests, 48 subtests. `test/unittests` has one pre-existing failure, `test_intent_context.py::TestLiveSessionManagerSync::test_orchestrator_decays_a_named_session_over_the_wire`, in a file this change never touches — a separate, unrelated bug in intent-context decay over the wire, not something this PR introduces or fixes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test reliability by using an in-repository Hello World skill fixture.
  * Updated intent and speech event expectations for the revised test skill.
  * Improved STOP scenario coverage for named sessions using event-based session tracking.
  * Updated targeted-stop assertions to verify the session associated with the handled utterance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->