### PR TITLE
fix: sync the round's working session with the handler's mutations at completion (OVOS-SESSION-2 §2.6)

### DIFF
--- a/ovos_core/intent_services/dispatcher.py
+++ b/ovos_core/intent_services/dispatcher.py
@@ -60,9 +60,20 @@ class IntentDispatcher:
     """
 
     def __init__(self, bus, timeout: Optional[float] = DEFAULT_HANDLER_TIMEOUT,
-                 on_terminal: Optional[Callable[[Message], None]] = None):
+                 on_terminal: Optional[Callable[[Message], None]] = None,
+                 on_done_signal: Optional[Callable[[Message, Message], None]] = None):
         self.bus = bus
         self.timeout = timeout
+        # Called with (done-signal Message, dispatch Message) before the §8
+        # terminal is emitted. The done-signal is forwarded from the handler's
+        # own copy of the dispatch, so its session carries whatever the handler
+        # wrote; OVOS-SESSION-2 §2.6 has the orchestrator sync the round's
+        # working session with those writes at this point, so that the terminal
+        # and everything after it carry the synced session. Which fields sync
+        # and how is session semantics and belongs to the orchestrator, not
+        # here. There is no handler session on the §8.3 timeout path — the
+        # handler never reported — so this is not called for it.
+        self.on_done_signal = on_done_signal
         # Called synchronously with the dispatch Message immediately AFTER each §8
         # terminal (complete/error/timeout) is emitted, so the orchestrator can emit
         # its §9.5 ovos.utterance.handled end-marker. Doing this in the same step
@@ -139,6 +150,21 @@ class IntentDispatcher:
         session, preserved unchanged via MSG-1 §5.1 ``forward``)."""
         self.bus.emit(dispatch_msg.forward(topic, data))
 
+    def _sync_handler_session(self, done_msg: Message, dispatch_msg: Message):
+        """Hand the done-signal to the orchestrator's §2.6 completion sync.
+
+        Runs before the §8 terminal is emitted so the terminal — and the §9.5
+        end-marker after it — carry the synced session. A sync that raises is a
+        bug in the orchestrator's callback, not a reason to lose the terminal.
+        """
+        if self.on_done_signal is None:
+            return
+        try:
+            self.on_done_signal(done_msg, dispatch_msg)
+        except Exception:
+            LOG.exception("handler-completion session sync failed; "
+                          "emitting the terminal with the dispatch session")
+
     def _notify_terminal(self, dispatch_msg: Message):
         """Tell the orchestrator a §8 terminal just fired so it can emit its §9.5
         end-marker. Called after the terminal is on the bus, so the terminal is
@@ -196,6 +222,7 @@ class IntentDispatcher:
                           message.data.get("intent_name"))
         if entry is None:
             return
+        self._sync_handler_session(message, entry.dispatch_msg)
         try:
             self._emit(SpecMessage.INTENT_HANDLER_COMPLETE, entry.dispatch_msg,
                        {"skill_id": entry.skill_id, "intent_name": entry.intent_name})
@@ -208,6 +235,7 @@ class IntentDispatcher:
                           message.data.get("intent_name"))
         if entry is None:
             return
+        self._sync_handler_session(message, entry.dispatch_msg)
         exception = (message.data.get("exception")
                      or message.data.get("error")
                      or "handler raised an exception")

--- a/ovos_core/intent_services/service.py
+++ b/ovos_core/intent_services/service.py
@@ -23,13 +23,14 @@ from typing import Optional, Tuple, Callable, List
 
 import requests
 from ovos_bus_client.message import Message
-from ovos_bus_client.session import SessionManager, Session, _CONTEXT_LOCK
+from ovos_bus_client.session import (SessionManager, Session, MalformedSession,
+                                     session_carrier, _CONTEXT_LOCK)
 from ovos_bus_client.util import get_message_lang
 from ovos_config.config import Configuration
 from ovos_config.locale import get_valid_languages
 from ovos_spec_tools import closest_lang, standardize_lang, SpecMessage
 from ovos_spec_tools.context import resolve_key
-from ovos_spec_tools.session import merge_carrier
+from ovos_spec_tools.session import merge_carrier, resolve_session_id
 from ovos_utils.log import LOG
 from ovos_utils.metrics import Stopwatch
 from ovos_utils.process_utils import ProcessStatus, StatusCallbackMap
@@ -39,7 +40,7 @@ from ovos_core.transformers import MetadataTransformersService, UtteranceTransfo
 from ovos_core.intent_services.dispatcher import IntentDispatcher, DEFAULT_HANDLER_TIMEOUT
 from ovos_core.intent_services.manifest import IntentManifest
 from ovos_core.intent_services.working_session import (
-    close_round, open_round, working_session,
+    close_round, open_round, pruned_entries, record_pruned, working_session,
 )
 from ovos_core.version import OVOS_VERSION_STR
 from ovos_plugin_manager.pipeline import OVOSPipelineFactory
@@ -185,7 +186,8 @@ class IntentService:
 
         handler_timeout = self.config.get("handler_timeout", DEFAULT_HANDLER_TIMEOUT)
         self.intent_dispatcher: IntentDispatcher = IntentDispatcher(
-            bus, timeout=handler_timeout, on_terminal=self._emit_utterance_handled)
+            bus, timeout=handler_timeout, on_terminal=self._emit_utterance_handled,
+            on_done_signal=self._sync_handler_mutations)
 
         # INTENT-4 §10 manifest — indexes registration broadcasts and serves
         # ovos.intent.list / ovos.intent.describe pull-queries.
@@ -444,6 +446,91 @@ class IntentService:
         sess = SessionManager.get(message)
         skill_id = message.data.get("skill_id")
         self._deactivations[sess.session_id].append(skill_id)
+
+    def _sync_handler_mutations(self, done_msg: Message, dispatch_msg: Message):
+        """OVOS-SESSION-2 §2.6 — sync the round's working session with the
+        handler's mutations, at handler completion.
+
+        The handler runs in its own process and mutates its own copy of the
+        dispatch session, so the writes come back on the framework done-signal,
+        which ovos-workshop forwards from the very Message the handler was
+        given. Reading that carrier here is how the orchestrator learns of the
+        mutation; §2.6 fixes what happens to it, not how it arrives.
+
+        Only fields the handler owns are taken: ``intent_context``, merged
+        entry-by-entry per OVOS-CONTEXT-1 §5.3 through the same
+        ``SessionManager`` helper an inbound sync goes through;
+        ``response_mode``; and removals from ``active_handlers``, the one
+        write OVOS-STOP-1 §4.4 prescribes there. Everything else — ``lang``,
+        ``pipeline``, ``site_id``, the rest of the registry — stays as the
+        round has it, because a handler writing those is forbidden by §2.6 and
+        an orchestrator that applied the write anyway would make the
+        prohibition unenforced.
+
+        What is taken is the *difference* against the dispatch snapshot, not
+        the carrier wholesale, so a handler that touched nothing changes
+        nothing and two handlers on one session cannot clobber each other with
+        their stale halves. The round's decay outranks the carrier either way:
+        an entry the pre-match prune dropped (see ``handle_utterance``) is
+        never put back, however stale the copy the handler answered with. That
+        is about the *entry*, not the key — a handler re-arming the same key
+        with a fresh entry, which is what a skill asking the same follow-up
+        question twice does, is writing, not echoing, and its write lands.
+
+        For the default session the working session *is* the store (§5.1), so
+        merging into it here is the store merge §2.6 asks for.
+        """
+        try:
+            carrier = session_carrier(done_msg)
+        except MalformedSession:
+            LOG.error("done-signal carries a malformed session; skipping the "
+                      "OVOS-SESSION-2 §2.6 completion sync")
+            return
+        if not carrier:
+            return
+
+        live = working_session(dispatch_msg) or SessionManager.get(dispatch_msg)
+        carried_id = resolve_session_id(carrier)
+        if carried_id != live.resolved_session_id():
+            # §2.6 scopes the sync to the round's own session; a done-signal
+            # naming another one is a handler or transport fault, and folding
+            # it would write one session's state into another.
+            LOG.error(f"done-signal for the round on "
+                      f"'{live.resolved_session_id()}' carries session "
+                      f"'{carried_id}'; not syncing it")
+            return
+
+        baseline = dispatch_msg.context.get("session") or {}
+        base_ctx = baseline.get("intent_context") or {}
+        new_ctx = carrier.get("intent_context") or {}
+        payload = {k: v for k, v in new_ctx.items() if base_ctx.get(k) != v}
+        payload.update({k: None for k in base_ctx if k not in new_ctx})
+        for key, dropped in pruned_entries(dispatch_msg).items():
+            # only the stale carry-over of a pruned entry is beaten by the
+            # decay; the same key re-armed with a different entry is a fresh
+            # handler write and lands like any other.
+            if payload.get(key) == dropped:
+                payload.pop(key)
+        if payload:
+            with _CONTEXT_LOCK:
+                ctx = dict(live.intent_context or {})
+                SessionManager.merge_intent_context(ctx, payload)
+                _replace_intent_context(live, ctx)
+
+        if carrier.get("response_mode") != baseline.get("response_mode"):
+            live.response_mode = carrier.get("response_mode")
+
+        def handler_ids(session_dict):
+            return {h.get("skill_id") for h in session_dict.get("active_handlers") or []}
+
+        for skill_id in handler_ids(baseline) - handler_ids(carrier):
+            live.remove_active_handler(skill_id)
+
+        SessionManager.update(live)
+        # The §8 terminal and the §9.5 end-marker are both forwarded from the
+        # dispatch Message, so re-stamping it here is what makes them carry the
+        # synced session instead of the snapshot the round has moved past.
+        dispatch_msg.context["session"] = live.serialize()
 
     def _emit_utterance_handled(self, dispatch_msg: Message):
         """OVOS-PIPELINE-1 §9.5 — emit the universal ``ovos.utterance.handled``
@@ -867,6 +954,11 @@ class IntentService:
         # this round sees the same gating snapshot
         intent_ctx = dict(sess.intent_context or {})
         prune_intent_context(intent_ctx)
+        # SESSION-2 §2.6: what the prune removed here is authoritative for the
+        # round, so remember it — the completion sync must not let a handler
+        # holding a pre-prune copy of the session put any of it back.
+        record_pruned(message, {k: v for k, v in (sess.intent_context or {}).items()
+                                if k not in intent_ctx})
         # §4.1: snapshot entry *value* (not identity, which reply/forward
         # round-tripping churns) so a mid-dispatch refresh is exempted below.
         # Deep, so an in-place mutation of a nested entry value later in the

--- a/ovos_core/intent_services/working_session.py
+++ b/ovos_core/intent_services/working_session.py
@@ -22,8 +22,9 @@ working session for it — per §2.6 an out-of-lifecycle write has nowhere
 legitimate to land — and callers get ``None``.
 """
 from collections import OrderedDict
+from copy import deepcopy
 from threading import RLock
-from typing import Optional
+from typing import Dict, Optional
 
 from ovos_bus_client.message import Message
 from ovos_bus_client.session import Session
@@ -35,6 +36,9 @@ _MAX_OPEN_ROUNDS = 32
 
 _LOCK = RLock()
 _OPEN_ROUNDS: "OrderedDict[str, Session]" = OrderedDict()
+#: intent-context entries the round's pre-match prune removed, per open
+#: round, as key -> the entry the prune dropped.
+_PRUNED_ENTRIES: "OrderedDict[str, Dict[str, dict]]" = OrderedDict()
 
 
 def _utterance_id(message: Optional[Message]) -> Optional[str]:
@@ -51,7 +55,34 @@ def open_round(message: Message, session: Session) -> None:
         _OPEN_ROUNDS[uid] = session
         _OPEN_ROUNDS.move_to_end(uid)
         while len(_OPEN_ROUNDS) > _MAX_OPEN_ROUNDS:
-            _OPEN_ROUNDS.popitem(last=False)
+            evicted, _ = _OPEN_ROUNDS.popitem(last=False)
+            _PRUNED_ENTRIES.pop(evicted, None)
+
+
+def record_pruned(message: Message, entries: Dict[str, dict]) -> None:
+    """Record the intent-context entries this round's pre-match prune removed.
+
+    OVOS-SESSION-2 §2.6 makes the round's decay authoritative over what a
+    handler carries back: an entry the prune dropped stays dropped even when
+    the handler's copy of the session predates the prune and still holds it.
+    The dropped *entry* is kept, not just its key, so that a handler re-arming
+    the same key with a fresh entry is told apart from one echoing the stale
+    one — only the echo is beaten by the decay.
+    """
+    uid = _utterance_id(message)
+    if not uid:
+        return
+    with _LOCK:
+        _PRUNED_ENTRIES[uid] = deepcopy(entries)
+
+
+def pruned_entries(message: Optional[Message]) -> Dict[str, dict]:
+    """The intent-context entries this round's pre-match prune removed."""
+    uid = _utterance_id(message)
+    if not uid:
+        return {}
+    with _LOCK:
+        return deepcopy(_PRUNED_ENTRIES.get(uid) or {})
 
 
 def working_session(message: Optional[Message]) -> Optional[Session]:
@@ -69,4 +100,5 @@ def close_round(message: Optional[Message]) -> Optional[Session]:
     if not uid:
         return None
     with _LOCK:
+        _PRUNED_ENTRIES.pop(uid, None)
         return _OPEN_ROUNDS.pop(uid, None)

--- a/test/end2end/test_completion_sync_e2e.py
+++ b/test/end2end/test_completion_sync_e2e.py
@@ -1,0 +1,164 @@
+"""End-to-end proof of the OVOS-SESSION-2 §2.6 completion sync.
+
+A real ovos-workshop skill running under MiniCroft speaks and then writes an
+intent-context entry, exactly as a skill setting up a follow-up question does.
+The skill's session object is not core's — the dispatch crosses the bus and the
+skill mutates its own copy — so the entry reaches the orchestrator only if the
+round's working session is synced with the handler's mutations at completion.
+
+The first test asserts the entry rides the round's canonical end-marker,
+``ovos.utterance.handled``, which is what a client adopts (§3.3). The second
+follows the consequence through: the client re-declares the session it adopted,
+and a ``requires_context`` intent that was ungated on the first turn matches on
+the second.
+"""
+import time
+from threading import Event
+from unittest import TestCase
+
+from ovos_bus_client.message import Message
+from ovos_bus_client.session import Session, SessionManager
+from ovos_spec_tools import SpecMessage
+from ovos_utils.log import LOG
+from ovos_workshop.decorators import intent_handler
+from ovos_workshop.intents import IntentBuilder
+from ovos_workshop.skills import OVOSSkill
+
+from ovoscope import get_minicroft
+
+SKILL_ID = "test-completion-sync.openvoiceos"
+CONTEXT_KEY = "confirming"
+STORED_KEY = f"{SKILL_ID}:{CONTEXT_KEY}"
+REARM_KEY = "rearming"
+STORED_REARM_KEY = f"{SKILL_ID}:{REARM_KEY}"
+#: short enough that the entry is dead by the next turn, so that turn's
+#: pre-match prune removes it while the handler re-arms it again
+REARM_TTL = 1.0
+UTTERANCE_HANDLED = SpecMessage.UTTERANCE_HANDLED.value
+
+
+class ContextWritingSkill(OVOSSkill):
+    """Asks a question, then arms the follow-up with an intent-context entry.
+
+    The write goes straight into ``session.intent_context`` — the only context
+    write path OVOS-CONTEXT-1 §5.0 defines — on the session the skill received
+    with its dispatch, which is the §5.3 handler pathway.
+    """
+
+    def initialize(self):
+        self.register_vocabulary("delete everything", "DeleteKeyword")
+        self.register_vocabulary("yes", "YesKeyword")
+        self.register_vocabulary("clear the queue", "RearmKeyword")
+        self.register_vocabulary("go ahead", "GoAheadKeyword")
+
+    @intent_handler(IntentBuilder("DeleteIntent").require("DeleteKeyword"))
+    def handle_delete(self, message):
+        self.speak("are you sure?")
+        SessionManager.get(message).set_intent_context(
+            CONTEXT_KEY, True, owner_id=self.skill_id)
+
+    @intent_handler(IntentBuilder("ConfirmIntent").require("YesKeyword"),
+                    requires_context=[CONTEXT_KEY])
+    def handle_confirm(self, message):
+        self.speak("deleted")
+
+    @intent_handler(IntentBuilder("RearmIntent").require("RearmKeyword"))
+    def handle_rearm(self, message):
+        """Arms a short-lived confirmation window on every invocation — the
+        shape of any skill that asks the same follow-up question twice."""
+        self.speak("are you sure?")
+        SessionManager.get(message).set_intent_context(
+            REARM_KEY, time.time(), owner_id=self.skill_id,
+            expires_at=time.time() + REARM_TTL)
+
+    @intent_handler(IntentBuilder("RearmConfirmIntent").require("GoAheadKeyword"),
+                    requires_context=[REARM_KEY])
+    def handle_rearm_confirm(self, message):
+        self.speak("queue cleared")
+
+
+class TestCompletionSyncE2E(TestCase):
+
+    def setUp(self):
+        LOG.set_level("DEBUG")
+        self.minicroft = get_minicroft(
+            [SKILL_ID], extra_skills={SKILL_ID: ContextWritingSkill})
+        self.bus = self.minicroft.bus
+
+    def tearDown(self):
+        if self.minicroft:
+            self.minicroft.stop()
+        LOG.set_level("CRITICAL")
+
+    def _session(self) -> Session:
+        session = Session("client-1")
+        session.lang = "en-US"
+        session.pipeline = ["ovos-adapt-pipeline-plugin-high"]
+        return session
+
+    def _say(self, utterance: str, session: Session) -> Session:
+        """Run one utterance and return the session the end-marker carried."""
+        done = Event()
+        captured = []
+
+        def on_handled(message: Message):
+            captured.append(message.context.get("session") or {})
+            done.set()
+
+        self.bus.on(UTTERANCE_HANDLED, on_handled)
+        try:
+            self.bus.emit(Message(
+                "recognizer_loop:utterance",
+                {"utterances": [utterance], "lang": session.lang},
+                {"session": session.serialize(),
+                 "source": "A", "destination": "B"}))
+            self.assertTrue(done.wait(timeout=20),
+                            f"no ovos.utterance.handled for '{utterance}'")
+        finally:
+            self.bus.remove(UTTERANCE_HANDLED, on_handled)
+        return Session.deserialize(captured[0])
+
+    def test_handler_context_write_rides_the_end_marker(self):
+        adopted = self._say("delete everything", self._session())
+        self.assertIn(STORED_KEY, adopted.intent_context or {},
+                      "the entry the skill wrote during its handler never "
+                      "reached ovos.utterance.handled")
+
+    def test_the_follow_up_turn_resolves_the_requires_context_gate(self):
+        adopted = self._say("delete everything", self._session())
+        # a conformant client re-declares the session it adopted (§3)
+        adopted.pipeline = ["ovos-adapt-pipeline-plugin-high"]
+        spoken = []
+        self.bus.on(SpecMessage.SPEAK.value,
+                    lambda m: spoken.append(m.data.get("utterance")))
+
+        self._say("yes", adopted)
+
+        self.assertIn("deleted", spoken,
+                      "the context-gated follow-up intent did not match, so "
+                      "the entry never survived the first round")
+
+    def test_a_rearmed_entry_survives_the_prune_of_its_own_predecessor(self):
+        """The decay beats a stale carry-over, not a fresh write.
+
+        The entry armed on the first turn is dead by the second, so the second
+        turn's pre-match prune removes it — and the handler arms it again in
+        the same round. That write is the handler's, not an echo of what the
+        prune dropped, so it must reach the end marker and gate the third turn.
+        """
+        first = self._say("clear the queue", self._session())
+        self.assertIn(STORED_REARM_KEY, first.intent_context or {})
+        time.sleep(REARM_TTL + 0.5)
+
+        second = self._say("clear the queue", first)
+        self.assertIn(STORED_REARM_KEY, second.intent_context or {},
+                      "the handler re-armed a key this round's pre-match "
+                      "prune had removed; the write was dropped")
+
+        spoken = []
+        self.bus.on(SpecMessage.SPEAK.value,
+                    lambda m: spoken.append(m.data.get("utterance")))
+        second.pipeline = ["ovos-adapt-pipeline-plugin-high"]
+        self._say("go ahead", second)
+        self.assertIn("queue cleared", spoken,
+                      "the re-armed gate did not match on the next turn")

--- a/test/unittests/test_session2_completion_sync.py
+++ b/test/unittests/test_session2_completion_sync.py
@@ -1,0 +1,362 @@
+"""OVOS-SESSION-2 §2.6 — the completion sync.
+
+The session a handler receives on its dispatch is the round's single working
+session, and at handler completion the orchestrator syncs that working session
+with whatever the handler wrote. The handler runs in another process, so its
+writes come back on the framework done-signal, which ovos-workshop forwards
+from the handler's own copy of the dispatch Message.
+
+These tests drive the real IntentService and IntentDispatcher over a FakeBus,
+simulating the process boundary the way the bus does it: the "skill" reads a
+serialize/deserialize round trip of the dispatch, mutates that copy's session,
+and answers with a done-signal forwarded from it. They assert what §2.6 fixes:
+the §8 terminal and the §9.5 end-marker carry the synced session, the default
+store is merged the same way an intake merges, the round's pre-match prune
+outranks a stale handler copy, and a write to a field the handler does not own
+never lands.
+"""
+import unittest
+from collections import defaultdict
+from copy import deepcopy
+from unittest.mock import MagicMock, patch
+
+from ovos_bus_client.message import Message
+from ovos_bus_client.session import DEFAULT_SESSION_ID, Session, SessionManager
+from ovos_plugin_manager.templates.pipeline import IntentHandlerMatch
+from ovos_spec_tools import SpecMessage
+from ovos_utils.fakebus import FakeBus
+
+from ovos_core.intent_services.dispatcher import IntentDispatcher
+from ovos_core.intent_services.manifest import IntentManifest
+from ovos_core.intent_services.service import IntentService
+
+SKILL_ID = "lights.skill"
+INTENT = "on"
+DISPATCH_TOPIC = f"{SKILL_ID}:{INTENT}"
+
+
+def _make_service(bus, match) -> IntentService:
+    """A real IntentService wired to ``bus`` with one pipeline returning
+    ``match``, and the real IntentDispatcher wired to both its callbacks."""
+    svc = IntentService.__new__(IntentService)
+    svc.bus = bus
+    svc.config = {}
+    svc.pipeline_plugins = {}
+    svc._deactivations = defaultdict(list)
+    svc.status = MagicMock()
+
+    for attr, transform in (("utterance_plugins", lambda utt, ctx: (utt, ctx)),
+                            ("metadata_plugins", lambda ctx: ctx),
+                            ("intent_plugins", lambda intent: intent)):
+        plugins = MagicMock()
+        plugins.transform.side_effect = transform
+        setattr(svc, attr, plugins)
+
+    svc.disambiguate_lang = lambda m: "en-US"
+    svc.intent_manifest = IntentManifest(bus)
+    svc.intent_dispatcher = IntentDispatcher(
+        bus, timeout=0, on_terminal=svc._emit_utterance_handled,
+        on_done_signal=svc._sync_handler_mutations)
+    svc.get_pipeline = lambda session: [
+        ("fake-high", lambda utts, lang, msg: match)]
+    return svc
+
+
+def _match() -> IntentHandlerMatch:
+    return IntentHandlerMatch(match_type=DISPATCH_TOPIC,
+                              match_data={"conf": 1.0},
+                              skill_id=SKILL_ID, utterance="turn on")
+
+
+def _entry(value):
+    return {"value": value}
+
+
+class CompletionSyncTestCase(unittest.TestCase):
+    """Drives one utterance with a scripted handler and collects the round's
+    terminal events."""
+
+    def setUp(self):
+        self.bus = FakeBus()
+        SessionManager.sessions.clear()
+        SessionManager.reset_default_session()
+        SessionManager.bus = None
+        self.svc = _make_service(self.bus, _match())
+        self.complete = []
+        self.errored = []
+        self.handled = []
+        self.bus.on(SpecMessage.INTENT_HANDLER_COMPLETE, self.complete.append)
+        self.bus.on(SpecMessage.INTENT_HANDLER_ERROR, self.errored.append)
+        self.bus.on(SpecMessage.UTTERANCE_HANDLED, self.handled.append)
+
+    def tearDown(self):
+        self.svc.intent_dispatcher.shutdown()
+        SessionManager.sessions.clear()
+        SessionManager.reset_default_session()
+        SessionManager.bus = None
+
+    def run_utterance(self, handler, carrier=None, done_topic=None,
+                      done_from=None):
+        """Run one utterance; ``handler`` plays the skill on its own copy of
+        the dispatch and returns the Message the done-signal is forwarded from.
+
+        ``handler`` receives the deserialized dispatch — the object a skill in
+        another process would get off the bus, never core's own instance.
+        """
+        signal = done_topic or "mycroft.skill.handler.complete"
+
+        def on_dispatch(dispatch: Message):
+            # the process boundary: what the skill sees is a wire round trip
+            skill_copy = Message.deserialize(dispatch.serialize())
+            handler(skill_copy)
+            source = done_from(skill_copy) if done_from else skill_copy
+            done = source.forward(signal, {})
+            done.context["skill_id"] = SKILL_ID
+            self.bus.emit(done)
+
+        self.bus.on(DISPATCH_TOPIC, on_dispatch)
+        context = {} if carrier is None else {"session": carrier}
+        self.svc.handle_utterance(
+            Message("recognizer_loop:utterance",
+                    {"utterances": ["turn on"]}, context))
+        self.bus.remove(DISPATCH_TOPIC, on_dispatch)
+
+    @staticmethod
+    def detached(mutate):
+        """A handler playing on a session DETACHED from the orchestrator's.
+
+        A skill runs in another process, so the session it writes to is only
+        ever a copy. For the default session that distinction is the whole
+        test: ``SessionManager.get`` would hand an in-process handler the
+        store itself, and a write through it would land whether or not the
+        completion sync exists.
+        """
+        def handler(dispatch: Message):
+            sess = Session.deserialize(dispatch.context["session"])
+            mutate(sess)
+            dispatch.context["session"] = sess.serialize()
+        return handler
+
+    @staticmethod
+    def plain_done(skill_copy: Message) -> Message:
+        """The done-signal as the other process builds it — carrying that
+        process's own session, not one re-stamped from the local store."""
+        return Message("done", {}, deepcopy(skill_copy.context))
+
+    def end_session(self) -> dict:
+        self.assertEqual(len(self.handled), 1,
+                         "expected exactly one ovos.utterance.handled")
+        return self.handled[0].context["session"]
+
+    def complete_session(self) -> dict:
+        self.assertEqual(len(self.complete), 1,
+                         "expected exactly one ovos.intent.handler.complete")
+        return self.complete[0].context["session"]
+
+
+class TestNamedSession(CompletionSyncTestCase):
+    """§2.6 — the terminal and the end-marker carry the synced session."""
+
+    def test_handler_write_reaches_the_terminal_and_the_end_marker(self):
+        def handler(dispatch):
+            # a real handler speaks first; the speak derives its own Message
+            # and is not what carries the mutation back
+            self.bus.emit(dispatch.forward("speak", {"utterance": "ok"}))
+            SessionManager.get(dispatch).set_intent_context(
+                "kitchen", _entry(True), owner_id=SKILL_ID)
+
+        self.run_utterance(handler, carrier=Session("client-1").serialize())
+
+        key = f"{SKILL_ID}:kitchen"
+        self.assertIn(key, self.complete_session()["intent_context"],
+                      "ovos.intent.handler.complete carries the dispatch "
+                      "snapshot, not the session synced at completion")
+        self.assertIn(key, self.end_session()["intent_context"])
+
+    def test_error_terminal_carries_the_synced_session(self):
+        def handler(dispatch):
+            SessionManager.get(dispatch).set_intent_context(
+                "kitchen", _entry(True), owner_id=SKILL_ID)
+
+        self.run_utterance(handler, carrier=Session("client-1").serialize(),
+                           done_topic="mycroft.skill.handler.error")
+
+        key = f"{SKILL_ID}:kitchen"
+        self.assertEqual(len(self.errored), 1)
+        self.assertIn(key, self.errored[0].context["session"]["intent_context"])
+        self.assertIn(key, self.end_session()["intent_context"])
+
+    def test_removal_propagates(self):
+        carrier = Session("client-1")
+        key = f"{SKILL_ID}:kitchen"
+        carrier.intent_context = {key: _entry(True)}
+
+        def handler(dispatch):
+            SessionManager.get(dispatch).remove_intent_context(
+                "kitchen", owner_id=SKILL_ID)
+
+        self.run_utterance(handler, carrier=carrier.serialize())
+
+        self.assertNotIn(key, self.complete_session().get("intent_context") or {})
+        self.assertNotIn(key, self.end_session().get("intent_context") or {})
+
+    def test_a_field_the_handler_does_not_own_is_not_applied(self):
+        def handler(dispatch):
+            SessionManager.get(dispatch).lang = "pt-PT"
+
+        self.run_utterance(handler, carrier=Session("client-1").serialize())
+
+        self.assertEqual(self.end_session()["lang"], "en-US",
+                         "a handler write to lang is forbidden by §2.6 and "
+                         "must not be synced onto the round")
+
+    def test_self_removal_from_active_handlers_is_applied(self):
+        carrier = Session("client-1")
+        carrier.add_active_handler(SKILL_ID)
+
+        def handler(dispatch):
+            SessionManager.get(dispatch).remove_active_handler(SKILL_ID)
+
+        self.run_utterance(handler, carrier=carrier.serialize())
+
+        active = {h["skill_id"]
+                  for h in self.end_session().get("active_handlers") or []}
+        self.assertNotIn(SKILL_ID, active)
+
+
+class TestDefaultSession(CompletionSyncTestCase):
+    """§2.6 / §5.1 — the write also merges into the default-session store.
+
+    These assert the end state, not the sync in isolation: ovos-bus-client
+    writes a default-shaped ``Session`` through to the store whatever object
+    holds it, so an in-process handler reaches the store on its own. The
+    named-session cases above are where the sync is isolated.
+    """
+
+    def test_store_reflects_the_handler_write(self):
+        handler = self.detached(lambda s: s.set_intent_context(
+            "kitchen", _entry(True), owner_id=SKILL_ID))
+
+        self.run_utterance(handler,
+                           carrier=Session(DEFAULT_SESSION_ID).serialize(),
+                           done_from=self.plain_done)
+
+        key = f"{SKILL_ID}:kitchen"
+        self.assertIn(key, self.end_session()["intent_context"])
+        self.assertIn(key, SessionManager.get_default_session().intent_context,
+                      "the default-session store did not receive the "
+                      "handler's §5.1 merge")
+
+    def test_removal_reaches_the_store(self):
+        key = f"{SKILL_ID}:kitchen"
+        stored = SessionManager.get_default_session()
+        stored.intent_context = {key: _entry(True)}
+
+        handler = self.detached(lambda s: s.remove_intent_context(
+            "kitchen", owner_id=SKILL_ID))
+
+        self.run_utterance(handler,
+                           carrier=Session(DEFAULT_SESSION_ID).serialize(),
+                           done_from=self.plain_done)
+
+        self.assertNotIn(key, SessionManager.get_default_session().intent_context)
+
+
+class TestDecayAuthority(CompletionSyncTestCase):
+    """§2.6 — the synced map is authoritative for the round's decay: an entry
+    the pre-match prune removed is not resurrected by the handler's copy."""
+
+    def test_a_pruned_entry_is_not_resurrected_by_a_stale_handler_copy(self):
+        key = f"{SKILL_ID}:expired"
+        stored = SessionManager.get_default_session()
+        # dead on arrival: the pre-match prune of this round drops it
+        stored.intent_context = {key: {"value": True, "turns_remaining": 0}}
+        stale = {key: {"value": True, "turns_remaining": 0}}
+
+        def handler(dispatch):
+            # the handler answers with a copy that predates the prune
+            SessionManager.get(dispatch)  # bind, as a real handler does
+            dispatch.context["session"]["intent_context"] = dict(stale)
+
+        def done_from(skill_copy):
+            # forward from the stale copy itself, bypassing the bound session
+            return Message("stale", {}, dict(skill_copy.context))
+
+        self.run_utterance(handler,
+                           carrier=Session(DEFAULT_SESSION_ID).serialize(),
+                           done_from=done_from)
+
+        self.assertNotIn(key, self.end_session().get("intent_context") or {},
+                         "the pre-match prune is authoritative; a stale "
+                         "handler copy must not put the entry back")
+        self.assertNotIn(key,
+                         SessionManager.get_default_session().intent_context)
+
+    def test_a_key_the_handler_re_arms_is_not_beaten_by_the_prune(self):
+        """The decay outranks a stale carry-over, not a fresh write: a handler
+        arming the same key again in the round that pruned its predecessor is
+        writing, and the write lands."""
+        key = f"{SKILL_ID}:expired"
+        carrier = Session("client-1")
+        carrier.intent_context = {key: {"value": "stale", "turns_remaining": 0}}
+
+        def handler(dispatch):
+            SessionManager.get(dispatch).set_intent_context(
+                "expired", "fresh", owner_id=SKILL_ID)
+
+        self.run_utterance(handler, carrier=carrier.serialize())
+
+        entry = (self.end_session().get("intent_context") or {}).get(key)
+        self.assertIsNotNone(entry, "the handler's re-arm of a key pruned "
+                                    "this round was dropped")
+        self.assertEqual(entry["value"], "fresh")
+
+
+class TestFaultyDoneSignals(CompletionSyncTestCase):
+    """A bad done-signal is a fault to log, never a lost round.
+
+    Both cases are driven at the sync callback rather than over the bus: a
+    signal whose session names another id does not correlate to any in-flight
+    dispatch in the first place, and FakeBus refuses to carry a malformed
+    carrier at all. The guard exists for the transports that do deliver them.
+    """
+
+    def dispatched_message(self) -> Message:
+        dispatched = []
+        self.run_utterance(dispatched.append,
+                           carrier=Session("client-1").serialize())
+        self.assertEqual(len(self.complete), 1)
+        self.assertEqual(len(self.handled), 1)
+        return dispatched[0]
+
+    def test_a_signal_naming_another_session_is_ignored(self):
+        dispatch = self.dispatched_message()
+        live = dict(dispatch.context["session"])
+
+        intruder = Message("done", {}, dict(dispatch.context))
+        other = Session("someone-else")
+        other.intent_context = {f"{SKILL_ID}:kitchen": _entry(True)}
+        intruder.context["session"] = other.serialize()
+
+        with patch("ovos_core.intent_services.service.LOG") as log:
+            self.svc._sync_handler_mutations(intruder, dispatch)
+        log.error.assert_called()
+        self.assertEqual(dispatch.context["session"], live,
+                         "a done-signal for another session must not write "
+                         "into this round")
+
+    def test_a_malformed_carrier_is_logged_and_the_round_still_closes(self):
+        """A carrier that is not a JSON object is malformed (SESSION-1 §2.5):
+        the sync is skipped, and the round still reached its terminal — the
+        dispatcher owns the §8 obligation of one terminal per dispatch."""
+        dispatch = self.dispatched_message()
+
+        broken = Message("done", {}, dict(dispatch.context))
+        broken.context["session"] = "not-an-object"
+        with patch("ovos_core.intent_services.service.LOG") as log:
+            self.svc._sync_handler_mutations(broken, dispatch)
+        log.error.assert_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

OVOS-SESSION-2 §2.6 makes the session a handler receives on its dispatch the round's single working session, and requires the orchestrator to sync that working session with the handler's mutations at handler completion. PIPELINE-1 §8 says the `.complete`/`.error` event carries the session as synced, and every event emitted afterward — including `ovos.utterance.handled` (§9.5) — derives from it. For `session_id == "default"` the same mutations merge into the default-session store the way an intake merge does (§5.1), with the entry-level `intent_context` merge OVOS-CONTEXT-1 §5.3 defines. None of that happened: a skill runs in its own process and mutates its own copy of the dispatch, and nothing folded that copy back, so an `intent_context` entry written through the §5.3 handler pathway was silently dropped at the end of the round and a `requires_context` follow-up could never match.

The mutation arrives on the framework done-signal. ovos-workshop forwards `mycroft.skill.handler.complete`/`.error` from the very Message the handler was given, so its session carries whatever the handler wrote. The dispatcher already consumes that signal to emit the spec terminal; it now hands it to the orchestrator first, through a callback that keeps session semantics out of the dispatcher. The orchestrator takes only fields the handler owns: `intent_context`, merged entry-by-entry through `SessionManager.merge_intent_context` (the helper an inbound sync already uses, so there is no second merge algorithm and a `null` entry still removes), `response_mode`, and removals from `active_handlers` — the one write OVOS-STOP-1 §4.4 prescribes there. A write to `lang`, `pipeline`, `site_id` or anything else is forbidden by §2.6 and is not applied.

What is taken is the difference against the dispatch snapshot rather than the carrier wholesale, so a handler that touched nothing changes nothing. On top of that the round's decay stays authoritative over a stale carry-over: the pre-match prune records the entries it removed, and the sync drops a key from the payload only when the handler's value for it is byte-equal to the entry the prune dropped. That distinction matters — a skill that arms the same confirmation window on every invocation re-arms the very key whose predecessor expired and was pruned in that same round, and that is a write, not an echo, so it lands. For the default session the working session is the store, so mutating it in place is the §5.1 store merge. The dispatch Message is then re-stamped with the synced session, which is how `ovos.intent.handler.complete`/`.error` and — through the existing `close_round` path — `ovos.utterance.handled` come to carry it. `ovos.intent.handler.start` still carries the dispatch session, as §8 requires, and the `mycroft.skill.handler.*` topics stay the internal workshop-to-core signal they have always been; nothing new appears on the bus.

Eleven unit tests drive the real `IntentService` and `IntentDispatcher` over a FakeBus with the process boundary simulated as a serialize/deserialize round trip, covering the named and default sessions, removals, decay authority against a stale handler copy, the re-arm of a key pruned in the same round, the non-owned-field rule, and the two faulty-signal paths. Three end-to-end tests run a real `OVOSSkill` under MiniCroft: it speaks, writes `session.intent_context`, and the entry has to ride `ovos.utterance.handled` and then satisfy a `requires_context` gate when the client re-declares the session it adopted. Reverting the source hunks makes both end-to-end tests fail on their own assertions (`'test-completion-sync.openvoiceos:confirming' not found in {}`, and the gated intent never matching) and all eleven unit tests fail; reverting only the byte-equality guard to a bare-key drop fails the re-arm pair on "the handler's re-arm of a key pruned this round was dropped". The unit suite goes 484 to 494 passing with no pre-existing test changing status; the session, context, stop, converse and activation end-to-end files are green (16 passed).
