### PR TITLE
fix: drop a malformed session carrier instead of crashing

### DIFF
--- a/ovos_core/intent_services/dispatcher.py
+++ b/ovos_core/intent_services/dispatcher.py
@@ -28,6 +28,8 @@ from ovos_bus_client.message import Message
 from ovos_spec_tools import SpecMessage
 from ovos_utils.log import LOG
 
+from ovos_core.intent_services.working_session import raw_session_id
+
 #: default upper bound on handler execution before §8.3 timeout fires, seconds.
 #: handlers are long-running by design (§6.5) so this is generous; set to 0 or a
 #: negative value (config ``intents.handler_timeout``) to disable the timer.
@@ -124,8 +126,11 @@ class IntentDispatcher:
         if intent_name is None:
             intent_name = topic.split(":", 1)[-1]
 
-        entry = _InFlightDispatch(skill_id, intent_name, dispatch_msg)
         sid = self._session_id(dispatch_msg)
+        if sid is None:
+            # already logged by _session_id; nothing safe to track this under
+            return
+        entry = _InFlightDispatch(skill_id, intent_name, dispatch_msg)
         with self._lock:
             self._in_flight.setdefault(sid, []).append(entry)
             if self.timeout and self.timeout > 0:
@@ -142,8 +147,15 @@ class IntentDispatcher:
 
     # -- emission helpers ------------------------------------------------
     @staticmethod
-    def _session_id(message: Message) -> str:
-        return (message.context.get("session") or {}).get("session_id", "default")
+    def _session_id(message: Message) -> Optional[str]:
+        """The session id a Message's carrier names.
+
+        ``None`` for a malformed carrier (OVOS-SESSION-1 §2.5): callers drop
+        the Message rather than substituting the default session identity
+        for it, and must not crash — a forged or corrupted framework
+        done-signal must not tear down this dispatcher.
+        """
+        return raw_session_id(message)
 
     def _emit(self, topic, dispatch_msg: Message, data: dict):
         """Emit a Message forwarded from the dispatch (§6.1 / §8 — context, incl.
@@ -216,10 +228,35 @@ class IntentDispatcher:
                 return entry
             return None
 
+    def _resolve_entry(self, message: Message) -> Optional[_InFlightDispatch]:
+        """Find the in-flight entry a framework done-signal concludes.
+
+        A malformed session carrier on the done-signal (§2.5) gives no
+        trustworthy session id to key the lookup on. With multiple rounds for
+        the same skill/intent in flight across different sessions,
+        ``skill_id``/``intent_name`` alone cannot tell which session's entry
+        the signal actually belongs to — guessing risks popping the wrong
+        session's entry and misrouting its terminal (§2.5: never fabricate an
+        identity). So this drops the signal instead: every in-flight entry is
+        left untouched and resolves through its own correct done-signal or
+        the §8.3 timeout.
+        """
+        sid = self._session_id(message)
+        if sid is None:
+            LOG.error(
+                "malformed session carrier on framework done-signal "
+                f"{message.msg_type} (skill_id={message.context.get('skill_id')}, "
+                f"intent_name={message.data.get('intent_name')}, "
+                f"carrier_type={type(message.context.get('session')).__name__}); "
+                "dropping signal, in-flight dispatches left untouched")
+            return None
+        skill_id = message.context.get("skill_id")
+        intent_name = message.data.get("intent_name")
+        return self._pop(sid, skill_id, intent_name)
+
     def _on_skill_complete(self, message: Message):
         """Framework done-signal -> ``complete`` (§8.1)."""
-        entry = self._pop(self._session_id(message), message.context.get("skill_id"),
-                          message.data.get("intent_name"))
+        entry = self._resolve_entry(message)
         if entry is None:
             return
         self._sync_handler_session(message, entry.dispatch_msg)
@@ -231,8 +268,7 @@ class IntentDispatcher:
 
     def _on_skill_error(self, message: Message):
         """Framework done-signal -> ``error`` with the exception (§8.2)."""
-        entry = self._pop(self._session_id(message), message.context.get("skill_id"),
-                          message.data.get("intent_name"))
+        entry = self._resolve_entry(message)
         if entry is None:
             return
         self._sync_handler_session(message, entry.dispatch_msg)

--- a/ovos_core/intent_services/manifest.py
+++ b/ovos_core/intent_services/manifest.py
@@ -18,6 +18,8 @@ from ovos_bus_client.message import Message
 from ovos_spec_tools import standardize_lang
 from ovos_utils.log import LOG
 
+from ovos_core.intent_services.working_session import raw_session_id
+
 
 class IntentManifest:
     """INTENT-4 §10 orchestrator-owned manifest.
@@ -74,17 +76,22 @@ class IntentManifest:
         return list(seen.values())
 
     @staticmethod
-    def _session_id_of(message: Message) -> str:
+    def _session_id_of(message: Message) -> Optional[str]:
         """Mutation scope per §11.1/§11.3 — always ``context.session.session_id``,
         NEVER ``Message.data``. A ``data.session_id`` on a mutation is not a
         scope assertion the producer is entitled to make; a producer could
         otherwise deregister/disable another session's intents by forging the
         payload. Any ``data.session_id`` that disagrees with the context is
         logged and ignored.
+
+        ``None`` for a malformed carrier (OVOS-SESSION-1 §2.5) — already
+        logged by ``raw_session_id``; matches no real key so the mutation is
+        a no-op instead of a crash or a misrouted default-session mutation.
         """
-        ctx_session_id = (message.context.get("session") or {}).get("session_id", "default")
+        ctx_session_id = raw_session_id(message)
         data_session_id = message.data.get("session_id")
-        if data_session_id is not None and data_session_id != ctx_session_id:
+        if (ctx_session_id is not None and data_session_id is not None
+                and data_session_id != ctx_session_id):
             LOG.warning(
                 f"{message.msg_type}: ignoring forged data.session_id={data_session_id!r}; "
                 f"session scope is context.session.session_id={ctx_session_id!r} (§11.1)")
@@ -134,7 +141,12 @@ class IntentManifest:
                 f"this collides with the OVOS-STOP-1 reserved '{skill_id}:stop' "
                 "targeted-dispatch topic, so both the registered intent handler "
                 "and the stop machinery will react to messages on that topic.")
-        session_id = (message.context.get("session") or {}).get("session_id", "default")
+        session_id = raw_session_id(message)
+        if session_id is None:
+            # malformed carrier (OVOS-SESSION-1 §2.5): already logged; drop
+            # the registration rather than indexing it under a fabricated
+            # session identity.
+            return
         key = self._key(session_id, skill_id, intent_name, lang, method)
         self._index[key] = {
             "skill_id": skill_id,

--- a/ovos_core/intent_services/service.py
+++ b/ovos_core/intent_services/service.py
@@ -909,6 +909,21 @@ class IntentService:
         Args:
             message (Message): The messagebus data
         """
+        # OVOS-SESSION-1 §2.5: reject a present-but-non-object session carrier
+        # before anything downstream (transformers, lang disambiguation, the
+        # §5.1 arrival) tries to read it through SessionManager and raises.
+        # It is never folded into the default session nor substituted for
+        # it — that would process the utterance under a fabricated identity.
+        # The Message is dropped before it ever enters the lifecycle (no
+        # utterance_id is stamped, no dispatch happens), so no §9.5
+        # ovos.utterance.handled end-marker is owed for it either.
+        carrier = message.context.get("session")
+        if carrier is not None and not isinstance(carrier, dict):
+            LOG.error(f"OVOS-SESSION-1 §2.5: malformed session carrier on "
+                      f"{message.msg_type} (got {type(carrier).__name__}, "
+                      f"expected object); dropping utterance")
+            return
+
         # OVOS-PIPELINE-1 §9.1.1: stamp the lifecycle identifier exactly once,
         # at lifecycle entry, before anything derives from this Message. A value
         # already present is never overwritten — regenerating it downstream would
@@ -939,7 +954,21 @@ class IntentService:
         stopwatch = Stopwatch()
 
         # get session: the single arrival of the round (SESSION-2 §5.1)
-        sess = self._validate_session(message, lang)
+        try:
+            sess = self._validate_session(message, lang)
+        except MalformedSession:
+            # OVOS-SESSION-1 §2.5: a present-but-non-object session carrier is
+            # a producer error. It is never folded into the default session
+            # nor substituted for it — that would process the utterance under
+            # a fabricated identity. The Message is dropped before it ever
+            # enters the lifecycle (no utterance_id was bound to a session,
+            # no dispatch happened), so no §9.5 ovos.utterance.handled
+            # end-marker is owed for it either.
+            LOG.error(f"OVOS-SESSION-1 §2.5: malformed session carrier on "
+                      f"{message.msg_type} (got "
+                      f"{type(message.context.get('session')).__name__}, "
+                      f"expected object); dropping utterance")
+            return
         # §2.2's utterance-scoped cache. Every Message derived from this round
         # can now reach the session the round is running on, which for a named
         # session is the only place it lives.

--- a/ovos_core/intent_services/stop_service.py
+++ b/ovos_core/intent_services/stop_service.py
@@ -16,6 +16,7 @@ from ovos_utils.log import LOG
 from ovos_utils.parse import match_one
 
 from ovos_core.intent_services.stop_service_legacy import _LegacyStopBridge
+from ovos_core.intent_services.working_session import raw_session_id
 
 
 class PreDrainSnapshot(NamedTuple):
@@ -280,7 +281,11 @@ class StopService(ConfidenceMatcherPipeline):
         skill_id = (message.data.get("skill_id") or
                     message.context.get("skill_id") or
                     message.msg_type.split(".stop.response")[0])
-        sess_id = (message.context.get("session") or {}).get("session_id", "default")
+        sess_id = raw_session_id(message)
+        if sess_id is None:
+            # malformed carrier (OVOS-SESSION-1 §2.5): already logged, and
+            # there is no (session_id, skill_id) key to resolve against.
+            return
         # Pop both snapshots unconditionally before either branch below: the
         # error/no-dispatch paths must not leak them or hold the
         # _resolve_dispatch_lifecycle gate open for this (session_id, skill_id).

--- a/ovos_core/intent_services/working_session.py
+++ b/ovos_core/intent_services/working_session.py
@@ -28,6 +28,7 @@ from typing import Dict, Optional
 
 from ovos_bus_client.message import Message
 from ovos_bus_client.session import Session
+from ovos_utils.log import LOG
 
 #: An utterance whose dispatch never reaches a terminal is never closed, so the
 #: oldest round is evicted once this many are open at once. Reaching the bound
@@ -39,6 +40,29 @@ _OPEN_ROUNDS: "OrderedDict[str, Session]" = OrderedDict()
 #: intent-context entries the round's pre-match prune removed, per open
 #: round, as key -> the entry the prune dropped.
 _PRUNED_ENTRIES: "OrderedDict[str, Dict[str, dict]]" = OrderedDict()
+
+
+def raw_session_id(message: Message) -> Optional[str]:
+    """The ``session_id`` a Message's raw ``context.session`` carrier names,
+    without folding it through :class:`Session` (OVOS-SESSION-1 §2.5).
+
+    A missing/``None`` carrier is the default session (§2.1/§3.1). A carrier
+    that is present but not a JSON object is malformed: this returns ``None``
+    instead of raising or substituting the default session's identity, so a
+    correlation lookup keyed on it is dropped rather than misrouted. Use for
+    call sites that only need the id for correlation (dispatch tracking,
+    manifest scoping) — not for reading session content, which goes through
+    ``SessionManager``/``Session`` and its own ``MalformedSession`` handling.
+    """
+    session = message.context.get("session")
+    if session is None:
+        return "default"
+    if not isinstance(session, dict):
+        LOG.error(f"OVOS-SESSION-1 §2.5: malformed session carrier on "
+                  f"{message.msg_type} (got {type(session).__name__}, "
+                  f"expected object); dropping")
+        return None
+    return session.get("session_id", "default")
 
 
 def _utterance_id(message: Optional[Message]) -> Optional[str]:

--- a/test/unittests/test_malformed_session_carrier.py
+++ b/test/unittests/test_malformed_session_carrier.py
@@ -1,0 +1,177 @@
+"""OVOS-SESSION-1 §2.5 — a malformed session carrier (a present ``session``
+that is not a JSON object) must never crash a consumer, and must never be
+substituted for the default session.
+
+These drive the real entry points a forged/corrupted carrier can reach:
+utterance intake (``IntentService.handle_utterance``) and the
+``IntentDispatcher`` framework done-signal path.
+"""
+import unittest
+from collections import defaultdict
+from unittest.mock import MagicMock, patch
+
+from ovos_bus_client.message import Message
+from ovos_bus_client.session import DEFAULT_SESSION_ID, SessionManager
+from ovos_utils.fakebus import FakeBus
+
+from ovos_core.intent_services.dispatcher import IntentDispatcher
+from ovos_core.intent_services.manifest import IntentManifest
+from ovos_core.intent_services.service import IntentService
+
+MALFORMED_CARRIERS = ["notanobject", [1], 5, True]
+
+
+def _make_service(bus) -> IntentService:
+    svc = IntentService.__new__(IntentService)
+    svc.bus = bus
+    svc.config = {}
+    svc.pipeline_plugins = {}
+    svc._deactivations = defaultdict(list)
+    svc.status = MagicMock()
+
+    for attr, transform in (("utterance_plugins", lambda utt, ctx: (utt, ctx)),
+                            ("metadata_plugins", lambda ctx: ctx),
+                            ("intent_plugins", lambda intent: intent)):
+        plugins = MagicMock()
+        plugins.transform.side_effect = transform
+        setattr(svc, attr, plugins)
+
+    svc.disambiguate_lang = lambda m: "en-US"
+    svc.intent_manifest = IntentManifest(bus)
+    svc.intent_dispatcher = IntentDispatcher(
+        bus, timeout=0, on_terminal=svc._emit_utterance_handled)
+    svc.get_pipeline = lambda session: []
+    return svc
+
+
+def _utterance(session_carrier, utterance="hello") -> Message:
+    return Message("recognizer_loop:utterance",
+                   data={"utterances": [utterance]},
+                   context={"session": session_carrier})
+
+
+class TestMalformedCarrierAtIntake(unittest.TestCase):
+    def setUp(self):
+        self.bus = FakeBus()
+        SessionManager.sessions.clear()
+        SessionManager.reset_default_session()
+        SessionManager.bus = None
+
+    tearDown = setUp
+
+    def test_malformed_carrier_never_crashes_and_is_dropped(self):
+        for carrier in MALFORMED_CARRIERS:
+            with self.subTest(carrier=carrier):
+                svc = _make_service(self.bus)
+                default_before = SessionManager.get_default_session().serialize()
+
+                handled = []
+                self.bus.on("ovos.utterance.handled", handled.append)
+                try:
+                    svc.handle_utterance(_utterance(carrier))  # must not raise
+                finally:
+                    self.bus.remove("ovos.utterance.handled", handled.append)
+
+                self.assertEqual(len(handled), 0,
+                                 "a dropped utterance owes no end-marker")
+                self.assertEqual(
+                    SessionManager.get_default_session().serialize(),
+                    default_before,
+                    "malformed carrier must not touch the default session")
+
+    def test_service_keeps_working_after_a_malformed_carrier(self):
+        svc = _make_service(self.bus)
+        svc.handle_utterance(_utterance("notanobject"))  # dropped
+
+        handled = []
+        self.bus.on("ovos.utterance.handled", handled.append)
+        svc.handle_utterance(_utterance(None))  # a normal follow-up
+        self.bus.remove("ovos.utterance.handled", handled.append)
+        self.assertEqual(len(handled), 1,
+                         "a normal utterance after a malformed one must still "
+                         "be handled")
+
+
+class TestMalformedCarrierAtDispatcherDoneSignal(unittest.TestCase):
+    def setUp(self):
+        self.bus = FakeBus()
+
+    def test_malformed_done_signal_does_not_crash_or_lose_other_rounds(self):
+        dispatcher = IntentDispatcher(self.bus, timeout=0)
+
+        good_dispatch = Message("lights.skill:on", {},
+                                {"session": {"session_id": "client-1"}})
+        dispatcher.dispatch(good_dispatch)
+
+        for carrier in MALFORMED_CARRIERS:
+            with self.subTest(carrier=carrier):
+                bad_signal = Message("mycroft.skill.handler.complete",
+                                     {"intent_name": "on"},
+                                     {"skill_id": "some.skill",
+                                      "session": carrier})
+                dispatcher._on_skill_complete(bad_signal)  # must not raise
+
+        # the unrelated, well-formed in-flight dispatch is still tracked
+        self.assertIn("client-1", dispatcher._in_flight)
+
+        good_signal = Message("mycroft.skill.handler.complete",
+                              {"intent_name": "on"},
+                              {"skill_id": "lights.skill",
+                               "session": {"session_id": "client-1"}})
+        dispatcher._on_skill_complete(good_signal)
+        self.assertNotIn("client-1", dispatcher._in_flight)
+
+    def test_malformed_done_signal_does_not_misroute_across_sessions(self):
+        """A malformed carrier on the done-signal gives no trustworthy session
+        id. With the same skill/intent in flight on two different sessions
+        (A and B), a done-signal that can only be matched by
+        skill_id/intent_name is ambiguous between them — guessing which one
+        it concludes risks popping the WRONG session's entry and misrouting
+        its terminal into the other round (OVOS-SESSION-1 §2.5: never
+        fabricate an identity; dropping is safer). So the malformed signal
+        must be dropped outright, logged once, with every in-flight entry
+        left untouched -- each then resolves through its own correct
+        done-signal."""
+        for carrier in MALFORMED_CARRIERS:
+            with self.subTest(carrier=carrier):
+                terminals = []
+                dispatcher = IntentDispatcher(self.bus, timeout=0,
+                                              on_terminal=terminals.append)
+
+                dispatch_a = Message("some.skill:greet", {},
+                                     {"session": {"session_id": "session-a"}})
+                dispatch_b = Message("some.skill:greet", {},
+                                     {"session": {"session_id": "session-b"}})
+                dispatcher.dispatch(dispatch_a)
+                dispatcher.dispatch(dispatch_b)
+
+                bad_signal = Message("mycroft.skill.handler.complete",
+                                     {"intent_name": "greet"},
+                                     {"skill_id": "some.skill", "session": carrier})
+                with patch("ovos_core.intent_services.dispatcher.LOG") as mock_log:
+                    dispatcher._on_skill_complete(bad_signal)  # must not raise
+
+                self.assertEqual(len(terminals), 0,
+                                 "a malformed done-signal must not fabricate "
+                                 "which in-flight round it concludes")
+                self.assertIn("session-a", dispatcher._in_flight,
+                             "session A's round must be left untouched")
+                self.assertIn("session-b", dispatcher._in_flight,
+                             "session B's round must be left untouched")
+                self.assertEqual(mock_log.error.call_count, 1,
+                                 "exactly one ERROR for the dropped signal")
+
+                # session A's own, correctly-carried done-signal resolves only A
+                good_signal = Message("mycroft.skill.handler.complete",
+                                      {"intent_name": "greet"},
+                                      {"skill_id": "some.skill",
+                                       "session": {"session_id": "session-a"}})
+                dispatcher._on_skill_complete(good_signal)
+                self.assertEqual(len(terminals), 1)
+                self.assertNotIn("session-a", dispatcher._in_flight)
+                self.assertIn("session-b", dispatcher._in_flight,
+                             "session B's round is unaffected by A's resolution")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Sonnet 5 (claude-sonnet-5) via Claude Code — NOT human-reviewed. Verify before acting.

OVOS-SESSION-1 §2.5 requires that a malformed session carrier (a present `session` field that is not a JSON object) never be substituted for a real session identity, and never crash the consumer that receives it. This PR makes `IntentDispatcher` and `IntentService` handle a malformed carrier by dropping the affected message rather than guessing.

At intake, an incoming utterance whose carrier is malformed is dropped with no `ovos.utterance.handled` end-marker, and the default session is left untouched. A follow-up utterance with a well-formed carrier is handled normally afterward, so a single bad message does not take down the pipeline.

On the framework done-signal path (`mycroft.skill.handler.complete`/`.error`), a malformed carrier gives the dispatcher no trustworthy session id to resolve against. When only one round is in flight for a skill this is unambiguous either way, but with two rounds for the same skill/intent in flight across different sessions it is not: nothing in the signal says which session's round it concludes. Rather than search across all sessions by `skill_id`/`intent_name` and pop the first match — which can silently pop the wrong session's entry and misroute its terminal into the other round — the dispatcher now drops the signal outright, logs one ERROR naming the message type, skill_id, intent_name and the carrier's type, and leaves every in-flight entry untouched. Each round then resolves through its own correctly-carried done-signal or the existing handler timeout, so no dispatch is lost, only delayed to its backstop at worst.

The regression test for this path was rewritten to assert the intended behaviour instead of the previous, incorrect one: with two rounds in flight on sessions A and B for the same skill and intent, a malformed done-signal must produce no terminal and leave both entries in flight, with exactly one ERROR logged. A subsequent done-signal for session A with a correct carrier then resolves only A, leaving B still in flight.

Verified fail-before by reverting only the dispatcher source change and keeping the new test: it failed 4 of 4 subtests (one per malformed carrier shape), each showing a terminal fired when none should have — the exact misrouting this fix prevents. Reapplying the fix made all four pass. Targeted run: `test_malformed_session_carrier.py` + `test_dispatcher.py` — 20 passed, 12 subtests passed. A broader sweep also covering `test_session2_completion_sync.py`, `test_intent_context.py`, `test_session2_intake.py`, `test_stop_service.py` and `test_intent_service_extended.py` — 224 passed, 6 xfailed, 21 subtests passed.
