### PR TITLE
refactor: readability cleanup of the intent service

### DIFF
--- a/ovos_core/intent_services/converse_service.py
+++ b/ovos_core/intent_services/converse_service.py
@@ -15,7 +15,7 @@ from ovos_utils.log import LOG
 from ovos_plugin_manager.templates.pipeline import PipelinePlugin, IntentHandlerMatch
 from ovos_workshop.permissions import ConverseMode, ConverseActivationMode
 
-from ovos_core.intent_services.working_session import working_session
+from ovos_core.intent_services.working_session import round_session
 
 #: upper bound, seconds, on how long core waits for a skill's
 #: ``skill.converse.response`` before the dispatch lifecycle is declared a
@@ -28,24 +28,6 @@ CONVERSE_HANDLER_TIMEOUT = 5 * 60
 
 class ConverseService(PipelinePlugin):
     """Intent Service handling conversational skills."""
-
-    @staticmethod
-    def _session_for_write(message: Optional[Message]) -> "Session":
-        """Resolve the session object a converse write should mutate.
-
-        Converse's write paths are all reached from a bus event a skill emits
-        while its round is in flight — an activation request, a get_response
-        toggle. OVOS-SESSION-2 §2.6 says such a Message does not revise the
-        working session with its own carrier, so the write lands on the
-        session the round is already running on, found by ``utterance_id``.
-
-        With no round open the write is out-of-band. The default session is
-        the device's store and remains writable at any time (§5); a named
-        session resolves to a throwaway built from the carrier, because §2.2
-        leaves the orchestrator holding nothing for it between utterances and
-        there is no session here for the write to reach.
-        """
-        return working_session(message) or SessionManager.get(message)
 
     def __init__(self, bus: Optional[Union[MessageBusClient, FakeBus]] = None,
                  config: Optional[Dict] = None) -> None:
@@ -162,7 +144,7 @@ class ConverseService(PipelinePlugin):
         source_skill = source_skill or skill_id
         if self._deactivate_allowed(skill_id, source_skill):
             message = message or Message("")
-            session = self._session_for_write(message)
+            session = round_session(message)
             if session.is_active(skill_id):
                 # update converse session
                 session.deactivate_skill(skill_id)
@@ -193,7 +175,7 @@ class ConverseService(PipelinePlugin):
         source_skill = source_skill or skill_id
         if self._activate_allowed(skill_id, source_skill):
             message = message or Message("")
-            session = self._session_for_write(message)
+            session = round_session(message)
             session.activate_skill(skill_id)
 
             # keep message.context
@@ -322,7 +304,7 @@ class ConverseService(PipelinePlugin):
         """
         answered = []  # candidates whose first valid pong already landed
         claimed = set()  # candidates whose first valid pong was a claim
-        session = session or self._session_for_write(message)
+        session = session or round_session(message)
 
         # note: this is sorted by priority already
         active_skills = [skill_id for skill_id in self.get_active_skills(message, session=session)
@@ -425,7 +407,7 @@ class ConverseService(PipelinePlugin):
         """
         timeouts = self.config.get("skill_timeouts") or {}
         def_timeout = self.config.get("timeout", 300)
-        session = self._session_for_write(message)
+        session = round_session(message)
         session.active_handlers = [
             h for h in session.active_handlers
             if time.time() - h["activated_at"] <= timeouts.get(h["skill_id"], def_timeout)]
@@ -460,7 +442,7 @@ class ConverseService(PipelinePlugin):
         # each step reads what the previous one wrote. The arrival already
         # happened at the orchestrator's lifecycle entry (SESSION-2 §5.1);
         # this pipeline does not fold again (§2.6).
-        session = self._session_for_write(message)
+        session = round_session(message)
 
         # we call flatten in case someone is sending the old style list of tuples
         utterances = flatten_list(utterances)
@@ -506,7 +488,7 @@ class ConverseService(PipelinePlugin):
     @staticmethod
     def handle_get_response_enable(message: Message):
         skill_id = message.data["skill_id"]
-        session = ConverseService._session_for_write(message)
+        session = round_session(message)
         session.enable_response_mode(skill_id)
         if session.session_id == "default":
             SessionManager.sync(message)
@@ -514,7 +496,7 @@ class ConverseService(PipelinePlugin):
     @staticmethod
     def handle_get_response_disable(message: Message):
         skill_id = message.data["skill_id"]
-        session = ConverseService._session_for_write(message)
+        session = round_session(message)
         session.disable_response_mode(skill_id)
         if session.session_id == "default":
             SessionManager.sync(message)

--- a/ovos_core/intent_services/dispatcher.py
+++ b/ovos_core/intent_services/dispatcher.py
@@ -22,10 +22,12 @@ as the completion hint. A §8.3 timeout backstops every dispatch. The §9.5
 orchestrator's ``on_terminal`` callback is invoked after each §8 terminal.
 """
 import threading
-from typing import Callable, Dict, List, Optional
+from typing import Callable, Dict, List, Optional, Union
 
+from ovos_bus_client.client import MessageBusClient
 from ovos_bus_client.message import Message
 from ovos_spec_tools import SpecMessage
+from ovos_utils.fakebus import FakeBus
 from ovos_utils.log import LOG
 
 from ovos_core.intent_services.working_session import raw_session_id
@@ -61,7 +63,8 @@ class IntentDispatcher:
     done-signals (``mycroft.skill.handler.complete``/``.error``).
     """
 
-    def __init__(self, bus, timeout: Optional[float] = DEFAULT_HANDLER_TIMEOUT,
+    def __init__(self, bus: Union[MessageBusClient, FakeBus],
+                 timeout: Optional[float] = DEFAULT_HANDLER_TIMEOUT,
                  on_terminal: Optional[Callable[[Message], None]] = None,
                  on_done_signal: Optional[Callable[[Message, Message], None]] = None):
         self.bus = bus
@@ -126,9 +129,9 @@ class IntentDispatcher:
         if intent_name is None:
             intent_name = topic.split(":", 1)[-1]
 
-        sid = self._session_id(dispatch_msg)
+        sid = raw_session_id(dispatch_msg)
         if sid is None:
-            # already logged by _session_id; nothing safe to track this under
+            # already logged by raw_session_id; nothing safe to track this under
             return
         entry = _InFlightDispatch(skill_id, intent_name, dispatch_msg)
         with self._lock:
@@ -146,17 +149,6 @@ class IntentDispatcher:
         self.bus.emit(dispatch_msg)
 
     # -- emission helpers ------------------------------------------------
-    @staticmethod
-    def _session_id(message: Message) -> Optional[str]:
-        """The session id a Message's carrier names.
-
-        ``None`` for a malformed carrier (OVOS-SESSION-1 §2.5): callers drop
-        the Message rather than substituting the default session identity
-        for it, and must not crash — a forged or corrupted framework
-        done-signal must not tear down this dispatcher.
-        """
-        return raw_session_id(message)
-
     def _emit(self, topic, dispatch_msg: Message, data: dict):
         """Emit a Message forwarded from the dispatch (§6.1 / §8 — context, incl.
         session, preserved unchanged via MSG-1 §5.1 ``forward``)."""
@@ -197,8 +189,7 @@ class IntentDispatcher:
         handler running, so that alone is unambiguous), but a caller with
         more precise knowledge of which dispatch it is concluding (e.g. a
         synthetic completion raised on behalf of a specific intent) can avoid
-        resolving an unrelated in-flight entry for the same skill. Omitted
-        (the default), this behaves exactly as before.
+        resolving an unrelated in-flight entry for the same skill.
 
         Callers MUST source this from ``message.data``, never
         ``message.context`` — context is forwarded/deep-copied down the
@@ -241,7 +232,7 @@ class IntentDispatcher:
         left untouched and resolves through its own correct done-signal or
         the §8.3 timeout.
         """
-        sid = self._session_id(message)
+        sid = raw_session_id(message)
         if sid is None:
             LOG.error(
                 "malformed session carrier on framework done-signal "

--- a/ovos_core/intent_services/manifest.py
+++ b/ovos_core/intent_services/manifest.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional
+from typing import List, Optional, Tuple, Union
 
+from ovos_bus_client.client import MessageBusClient
 from ovos_bus_client.message import Message
 from ovos_spec_tools import standardize_lang
+from ovos_utils.fakebus import FakeBus
 from ovos_utils.log import LOG
 
 from ovos_core.intent_services.working_session import raw_session_id
@@ -30,7 +32,7 @@ class IntentManifest:
     ``(session_id, skill_id, intent_name, lang, method)`` per §11.1.
     """
 
-    def __init__(self, bus):
+    def __init__(self, bus: Union[MessageBusClient, FakeBus]):
         self.bus = bus
         # (session_id, skill_id, intent_name, lang, method) → entry dict
         self._index: dict = {}
@@ -60,10 +62,10 @@ class IntentManifest:
 
     @staticmethod
     def _key(session_id: str, skill_id: str, intent_name: str,
-              lang: str, method: str) -> tuple:
+              lang: str, method: str) -> Tuple[str, str, str, str, str]:
         return session_id, skill_id, intent_name, standardize_lang(lang), method
 
-    def _effective_pool(self, session_id: str) -> list:
+    def _effective_pool(self, session_id: str) -> List[dict]:
         """Return entries for *session_id* merged with 'default' (§11.2)."""
         seen = {}
         for key, entry in self._index.items():
@@ -98,7 +100,7 @@ class IntentManifest:
         return ctx_session_id
 
     def get_required_slots(self, session_id: str, skill_id: str,
-                           intent_name: str, lang: str) -> list:
+                           intent_name: str, lang: str) -> List[str]:
         """OVOS-INTENT-4 §6.1 / §10 — the ``required_slots`` an intent declares.
 
         The canonical source for the OVOS-PIPELINE-1 §6.2 orchestrator backstop:
@@ -263,7 +265,7 @@ class IntentManifest:
     # OVOS-CONTEXT-1: orchestrator lookups for declared context gates / slots
 
     def _matching_definitions(self, session_id: str, skill_id: str,
-                              intent_name: str, lang: Optional[str]) -> list:
+                              intent_name: str, lang: Optional[str]) -> List[dict]:
         lang = standardize_lang(lang) if lang else None
         out = []
         for entry in self._effective_pool(session_id):
@@ -275,7 +277,8 @@ class IntentManifest:
         return out
 
     def get_context_requirements(self, session_id: str, skill_id: str,
-                                 intent_name: str, lang: Optional[str] = None):
+                                 intent_name: str, lang: Optional[str] = None
+                                 ) -> Tuple[List[str], List[str]]:
         """OVOS-CONTEXT-1 §6/§6.1 — declared ``requires_context`` /
         ``excludes_context``, unioned across registration definitions.
 

--- a/ovos_core/intent_services/service.py
+++ b/ovos_core/intent_services/service.py
@@ -40,7 +40,7 @@ from ovos_core.transformers import MetadataTransformersService, UtteranceTransfo
 from ovos_core.intent_services.dispatcher import IntentDispatcher, DEFAULT_HANDLER_TIMEOUT
 from ovos_core.intent_services.manifest import IntentManifest
 from ovos_core.intent_services.working_session import (
-    close_round, open_round, pruned_entries, record_pruned, working_session,
+    close_round, open_round, pruned_entries, record_pruned, round_session, working_session,
 )
 from ovos_core.version import OVOS_VERSION_STR
 from ovos_plugin_manager.pipeline import OVOSPipelineFactory
@@ -158,15 +158,10 @@ class IntentService:
                  alive_hook=on_alive, started_hook=on_started,
                  ready_hook=on_ready,
                  error_hook=on_error, stopping_hook=on_stopping) -> None:
-        """
-        Initializes the IntentService with all intent parsing pipelines, transformer services, and messagebus event handlers.
-
-        Args:
-            bus: The messagebus connection used for event-driven communication.
-            config: Optional configuration dictionary for intent services.
-
-        Sets up skill name mapping, loads all supported intent matching pipelines (including Adapt, Padatious, Padacioso, Fallback, Converse, CommonQA, Stop, OCP, Persona, and optionally LLM and Model2Vec pipelines), initializes utterance and metadata transformer services, connects the session manager, and registers all relevant messagebus event handlers for utterance processing, context management, intent queries, and skill deactivation tracking.
-        """
+        """Loads the installed pipeline plugins, transformer services, and
+        session manager, and registers the bus handlers for utterance
+        processing, context mutation, intent queries, and skill deactivation
+        tracking."""
         callbacks = StatusCallbackMap(on_started=started_hook,
                                       on_alive=alive_hook,
                                       on_ready=ready_hook,
@@ -253,7 +248,7 @@ class IntentService:
             return
         SessionManager.handle_sync(message)
 
-    def handle_reload_pipelines(self, message: Message):
+    def handle_reload_pipelines(self, message: Message) -> None:
         pipeline_plugins = OVOSPipelineFactory.get_installed_pipeline_ids()
         LOG.debug(f"Installed pipeline plugins: {pipeline_plugins}")
 
@@ -292,7 +287,7 @@ class IntentService:
                 LOG.error(f"Failed to load pipeline plugin '{p}': {e}")
         self.status.set_ready()
 
-    def _handle_transformers(self, message):
+    def _handle_transformers(self, message: Message) -> Message:
         """
         Pipe utterance through transformer plugins to get more metadata.
         Utterances may be modified by any parser and context overwritten
@@ -308,7 +303,7 @@ class IntentService:
         return message
 
     @staticmethod
-    def disambiguate_lang(message):
+    def disambiguate_lang(message: Message) -> str:
         """ disambiguate language of the query via pre-defined context keys
         1 - stt_lang -> tagged in stt stage  (STT used this lang to transcribe speech)
         2 - request_lang -> tagged in source message (wake word/request volunteered lang info)
@@ -337,7 +332,7 @@ class IntentService:
 
         return default_lang
 
-    def get_pipeline_matcher(self, matcher_id: str):
+    def get_pipeline_matcher(self, matcher_id: str) -> Optional[Callable]:
         """
         Retrieve a matcher function for a given pipeline matcher ID.
 
@@ -396,7 +391,7 @@ class IntentService:
                 LOG.debug(f"Session '{session.session_id}' blacklisted "
                           f"pipelines skipped: {skipped}")
 
-        matchers = [(p, self.get_pipeline_matcher(p)) for p in requested]
+        matchers: List[Tuple[str, Callable]] = [(p, self.get_pipeline_matcher(p)) for p in requested]
         matchers = [m for m in matchers if m[1] is not None]  # filter any that failed to load
         final_pipeline = [k[0] for k in matchers]
         if requested != final_pipeline:
@@ -406,7 +401,7 @@ class IntentService:
         return matchers
 
     @staticmethod
-    def _validate_session(message, lang):
+    def _validate_session(message: Message, lang: str) -> Session:
         """Take the inbound utterance into session state and return the session
         to run it on.
 
@@ -437,7 +432,7 @@ class IntentService:
         sess.touch()
         return sess
 
-    def _handle_deactivate(self, message):
+    def _handle_deactivate(self, message: Message) -> None:
         """internal helper, track if a skill asked to be removed from active list during intent match
         in this case we want to avoid reactivating it again
         This only matters in PipelineMatchers, such as fallback and converse
@@ -489,7 +484,7 @@ class IntentService:
         if not carrier:
             return
 
-        live = working_session(dispatch_msg) or SessionManager.get(dispatch_msg)
+        live = round_session(dispatch_msg)
         carried_id = resolve_session_id(carrier)
         if carried_id != live.resolved_session_id():
             # §2.6 scopes the sync to the round's own session; a done-signal
@@ -503,8 +498,10 @@ class IntentService:
         baseline = dispatch_msg.context.get("session") or {}
         base_ctx = baseline.get("intent_context") or {}
         new_ctx = carrier.get("intent_context") or {}
-        payload = {k: v for k, v in new_ctx.items() if base_ctx.get(k) != v}
-        payload.update({k: None for k in base_ctx if k not in new_ctx})
+        # None is CONTEXT-1 §5.3's "remove this key" tombstone, not a value
+        changed = {k: v for k, v in new_ctx.items() if base_ctx.get(k) != v}
+        removed = {k: None for k in base_ctx if k not in new_ctx}
+        payload = {**changed, **removed}
         for key, dropped in pruned_entries(dispatch_msg).items():
             # only the stale carry-over of a pruned entry is beaten by the
             # decay; the same key re-armed with a different entry is a fresh
@@ -520,10 +517,9 @@ class IntentService:
         if carrier.get("response_mode") != baseline.get("response_mode"):
             live.response_mode = carrier.get("response_mode")
 
-        def handler_ids(session_dict):
-            return {h.get("skill_id") for h in session_dict.get("active_handlers") or []}
-
-        for skill_id in handler_ids(baseline) - handler_ids(carrier):
+        baseline_handlers = {h.get("skill_id") for h in baseline.get("active_handlers") or []}
+        carrier_handlers = {h.get("skill_id") for h in carrier.get("active_handlers") or []}
+        for skill_id in baseline_handlers - carrier_handlers:
             live.remove_active_handler(skill_id)
 
         SessionManager.update(live)
@@ -596,7 +592,7 @@ class IntentService:
         return [slot for slot in required_slots
                 if not match_data.get(slot) and not from_context.get(slot)]
 
-    def _context_supplied_slots(self, match, session_id: str, lang: str,
+    def _context_supplied_slots(self, match: IntentHandlerMatch, session_id: str, lang: str,
                                 intent_context: Optional[dict]) -> dict:
         """OVOS-CONTEXT-1 §7 — the slots the live ``intent_context`` can fill
         for ``match``. Shared by the §6.2 missing-required backstop and by the
@@ -623,7 +619,7 @@ class IntentService:
         )
 
     @staticmethod
-    def _apply_post_match_decay(sess: "Session", pre_match_entries: dict):
+    def _apply_post_match_decay(sess: "Session", pre_match_entries: dict) -> Session:
         """OVOS-CONTEXT-1 §4/§4.1: decrement turns_remaining on the session the
         round is running on, skipping keys refreshed since ``pre_match_entries``
         was snapshotted (compared by value, not identity, since reply/forward
@@ -650,7 +646,7 @@ class IntentService:
         return sess
 
     def _dispatch_match(self, match: IntentHandlerMatch, message: Message, lang: str,
-                        pipeline_id: str = None,
+                        pipeline_id: Optional[str] = None,
                         pre_match_entries: Optional[dict] = None) -> None:
         """Orchestrate the OVOS-PIPELINE-1 §6.1 post-match steps, then dispatch.
 
@@ -680,7 +676,7 @@ class IntentService:
         # §5.1: a committed ``Match.updated_session`` replaces the working
         # session wholesale; otherwise the round continues on the session it
         # was folded onto at entry. No fold here (§2.6).
-        sess = working_session(message) or SessionManager.get(message)
+        sess = round_session(message)
         if match.updated_session is not None:
             updated = match.updated_session
             if updated.resolved_session_id() != sess.resolved_session_id():
@@ -824,25 +820,9 @@ class IntentService:
             except Exception as e:
                 LOG.warning(f"Failed to upload metrics: {e}")
 
-    def send_cancel_event(self, message):
-        """
-        Emit events and play a sound when an utterance is canceled.
-
-        Logs the cancellation with the specific cancel word, plays a predefined cancel sound,
-        and emits multiple events to signal the utterance cancellation.
-
-        Parameters:
-            message (Message): The original message that triggered the cancellation.
-
-        Events Emitted:
-            - 'mycroft.audio.play_sound': Plays a cancel sound from configuration
-            - 'ovos.utterance.cancelled': Signals that the utterance was canceled
-            - 'ovos.utterance.handled': Indicates the utterance processing is complete
-
-        Notes:
-            - Uses the default cancel sound path 'snd/cancel.mp3' if not specified in configuration
-            - Ensures events are sent as replies to the original message
-        """
+    def send_cancel_event(self, message: Message) -> None:
+        """OVOS-PIPELINE-1 §6.4 cancellation terminal path: play the cancel
+        sound, emit ``ovos.utterance.cancelled``, then the §9.5 end-marker."""
         LOG.info(f"utterance canceled, cancel_word:{message.context.get('cancel_word')}")
         # play dedicated cancel sound
         sound = Configuration().get('sounds', {}).get('cancel', "snd/cancel.mp3")
@@ -883,31 +863,14 @@ class IntentService:
         return uid
 
     def handle_utterance(self, message: Message):
-        """Main entrypoint for handling user utterances
+        """Main entrypoint for handling user utterances, typically generated
+        by a spoken interaction but potentially also from a CLI or other
+        method of injecting a 'user utterance' into the system.
 
-        Monitor the messagebus for 'ovos.utterance.handle', typically
-        generated by a spoken interaction but potentially also from a CLI
-        or other method of injecting a 'user utterance' into the system.
-
-        Utterances then work through this sequence to be handled:
-        1) UtteranceTransformers can modify the utterance and metadata in message.context
-        2) MetadataTransformers can modify the metadata in message.context
-        3) Language is extracted from message
-        4) Active skills attempt to handle using converse()
-        5) Padatious high match intents (conf > 0.95)
-        6) Adapt intent handlers
-        7) CommonQuery Skills
-        8) High Priority Fallbacks
-        9) Padatious near match intents (conf > 0.8)
-        10) General Fallbacks
-        11) Padatious loose match intents (conf > 0.5)
-        12) Catch all fallbacks including Unknown intent handler
-
-        If all these fail the complete_intent_failure message will be sent
-        and a generic error sound played.
-
-        Args:
-            message (Message): The messagebus data
+        Runs the utterance/metadata transformer chain, disambiguates
+        language, then tries each configured pipeline matcher in order until
+        one produces a Match. If none does, ``send_complete_intent_failure``
+        is emitted instead.
         """
         # OVOS-SESSION-1 §2.5: reject a present-but-non-object session carrier
         # before anything downstream (transformers, lang disambiguation, the
@@ -1090,7 +1053,6 @@ class IntentService:
             SessionManager.sync(message)
         elif sess.session_id in self._deactivations:
             self._deactivations.pop(sess.session_id)
-        return match, message.context, stopwatch
 
     def send_complete_intent_failure(self, message):
         """Emit the OVOS-PIPELINE-1 §9.3 no-match terminal.
@@ -1116,7 +1078,7 @@ class IntentService:
         # §9.5: universal end-marker
         self.bus.emit(message.reply(SpecMessage.UTTERANCE_HANDLED))
 
-    def _apply_context_slots(self, match, sess, reply) -> None:
+    def _apply_context_slots(self, match: IntentHandlerMatch, sess: Session, reply: Message) -> None:
         """OVOS-CONTEXT-1 §7 — fill an intent's unfilled slots from live
         context. Fallback for engines that don't implement §7 themselves;
         no-op when the intent declares no context-gated slot.
@@ -1131,26 +1093,6 @@ class IntentService:
             reply.data[key] = value
         if supplied:
             LOG.debug(f"context-supplied slots (§7): {supplied}")
-
-    @staticmethod
-    def _session_for_context_write(message: Message) -> "Session":
-        """Resolve the session object a legacy context write should mutate.
-
-        A context write belongs to the round it was emitted from, so it lands
-        on that round's working session (SESSION-2 §2.6: a mutation happens at
-        a lifecycle boundary the writer participates in, and an incidental
-        Message may not revise the working session with its own snapshot). The
-        working session is looked up by ``utterance_id``, which the skill's
-        handler frame carries for free.
-
-        With no round open there is no lifecycle to write into. The default
-        session is still the device's store and a write to it is meaningful at
-        any time (§5), so that case resolves to the store; a named session
-        resolves to a throwaway built from the carrier and the write goes
-        nowhere, which is what §2.2 leaves available — the orchestrator holds
-        no named session between utterances to write into.
-        """
-        return working_session(message) or SessionManager.get(message)
 
     @staticmethod
     def handle_add_context(message: Message):
@@ -1190,19 +1132,13 @@ class IntentService:
         entity['match'] = word
         entity['key'] = word
         entity['origin'] = origin
-        sess = IntentService._session_for_context_write(message)
-        # Finding 30a: `sess.context.inject_context()` folds its own write
-        # into `intent_context` under `ovos_bus_client.session._CONTEXT_LOCK`
-        # (the same lock guarding `Session.set_intent_context` /
-        # `remove_intent_context`, which a skill's `set_context`/
-        # `remove_context` call reaches concurrently). The copy-modify-assign
-        # below must run in the SAME critical section as that fold, or a
-        # concurrent skill-side write landing between the read and the
-        # reassign is silently clobbered when the stale snapshot is written
-        # back. Holding `_CONTEXT_LOCK` (an `RLock`) across the whole
-        # sequence - including the nested `inject_context()` call and
-        # `_replace_intent_context()`, both of which reacquire it - makes the
-        # read-modify-write atomic with every other locked mutator.
+        sess = round_session(message)
+        # The read-modify-write below must share the critical section with
+        # `inject_context()`'s own fold under `_CONTEXT_LOCK`, or a concurrent
+        # skill-side `set_context`/`remove_context` write landing between the
+        # read and the reassign is silently clobbered. `_CONTEXT_LOCK` is an
+        # RLock because the nested `inject_context()` and
+        # `_replace_intent_context()` calls below both reacquire it.
         with _CONTEXT_LOCK:
             sess.context.inject_context(entity)
             # Two dialects meet here: ADAPT's munged `skillidkey` spelling and
@@ -1259,12 +1195,10 @@ class IntentService:
         """
         context = message.data.get('context')
         if context:
-            sess = IntentService._session_for_context_write(message)
-            # Finding 30a: same atomicity requirement as `handle_add_context`
-            # - hold `_CONTEXT_LOCK` across the `remove_context`-style fold
-            # AND the copy-modify-assign below, so a concurrent skill-side
-            # `set_intent_context`/`remove_intent_context` call can't land
-            # between the read and the reassign and get silently clobbered.
+            sess = round_session(message)
+            # Same atomicity requirement as `handle_add_context`: hold
+            # `_CONTEXT_LOCK` across the fold and the copy-modify-assign below,
+            # or a concurrent skill-side session write is silently clobbered.
             with _CONTEXT_LOCK:
                 sess.context.remove_context(context)
                 # mirror the removal into the OVOS-CONTEXT-1 map (see
@@ -1284,14 +1218,14 @@ class IntentService:
     @staticmethod
     def handle_clear_context(message: Message):
         """Clears all keywords from context """
-        sess = IntentService._session_for_context_write(message)
-        # Finding 30a: same atomicity requirement as `handle_add_context`.
+        sess = round_session(message)
+        # Same atomicity requirement as `handle_add_context`.
         with _CONTEXT_LOCK:
             sess.context.clear_context()
             # mirror the clear into the OVOS-CONTEXT-1 map (see `handle_add_context`)
             _replace_intent_context(sess, {})
 
-    def handle_get_intent(self, message):
+    def handle_get_intent(self, message: Message) -> None:
         """Get intent from either adapt or padatious.
 
         Args:

--- a/ovos_core/intent_services/stop_service.py
+++ b/ovos_core/intent_services/stop_service.py
@@ -1,6 +1,6 @@
 from os.path import dirname, join
 from threading import Event
-from typing import Optional, Dict, List, NamedTuple, Union
+from typing import Optional, Dict, List, NamedTuple, Tuple, Union
 
 from ovos_bus_client.client import MessageBusClient
 from ovos_bus_client.handler import HandlerLifecycle
@@ -72,7 +72,7 @@ class StopService(ConfidenceMatcherPipeline):
         #: and consumed once by handle_stop_confirmation. Keyed per-session
         #: (not bare skill_id) so two concurrent targeted stops for the same
         #: skill_id in different sessions can't clobber each other's snapshot.
-        self._pre_drain: Dict[tuple, PreDrainSnapshot] = {}
+        self._pre_drain: Dict[Tuple[str, str], PreDrainSnapshot] = {}
 
     def handle_global_stop(self, message: Message) -> None:
         """OVOS-STOP-1 §5.3 — broadcast the universal ``ovos.stop``.
@@ -146,27 +146,9 @@ class StopService(ConfidenceMatcherPipeline):
         return candidates
 
     def _collect_stop_skills(self, message: Message) -> List[str]:
-        """
-        Collect skills that can be stopped based on a ping-pong mechanism (§4).
-
-        This method determines which active skills can handle a stop request by sending
-        a stop ping to each active skill and waiting for their acknowledgment.
-
-        Individual skills respond to this request via the `can_stop` method.
-
-        Parameters:
-            message (Message): The original message triggering the stop request.
-
-        Returns:
-            List[str]: A list of skill IDs that can be stopped. If no skills explicitly
-                      indicate they can stop, returns all active skills.
-
-        Notes:
-            - Excludes skills that are blacklisted in the current session (§6.3)
-            - Uses a non-blocking event mechanism to collect skill responses
-            - Waits up to 0.5 seconds for skills to respond (§4.1)
-            - Falls back to all active skills if no explicit stop confirmation is received
-        """
+        """OVOS-STOP-1 §4 ping-pong: ask each active skill whether it can
+        stop, wait up to 0.5s (§4.1), and return the stoppable ones in
+        recency order. Falls back to all active skills if none confirm."""
         want_stop = []
         skill_ids = []
 
@@ -187,17 +169,8 @@ class StopService(ConfidenceMatcherPipeline):
         round_session_id = SessionManager.get(message).session_id
 
         def handle_ack(msg: Message) -> None:
-            """
-            Handle acknowledgment from skills during the stop process.
-
-            Parameters:
-                msg (Message): Message containing skill acknowledgment details.
-
-            Side Effects:
-                - Modifies the `want_stop` list with skills that can handle stopping
-                - Updates the `skill_ids` list to track which skills have responded
-                - Sets the threading event when all active skills have responded
-            """
+            """Record a skill's stop-ping pong, and signal ``event`` once
+            every active skill has answered."""
             nonlocal event, skill_ids
             skill_id = msg.data.get("skill_id")
             if not skill_id:
@@ -367,12 +340,21 @@ class StopService(ConfidenceMatcherPipeline):
         §7.1 stamping push is suppressed (``suppress_activation``, §7.3), so the
         removal is the final state.
 
-        CONFIRMED-3: match() must be side-effect-free — the orchestrator may
-        still discard this Match (blacklisted intent, missing required slots, a
+        match() must not touch the live session: the orchestrator may still
+        discard this Match (blacklisted intent, missing required slots, a
         dispatch exception) without ever consuming ``updated_session``, so the
         drain is carried on a COPY and only lands on the live SessionManager
         session if/when ``_dispatch_match`` actually commits it. The live
-        ``sess`` passed in is read but never mutated here.
+        ``sess`` passed in is read but never mutated.
+
+        This does have two side effects beyond building the Match: it records
+        a ``_pre_drain`` snapshot and registers a one-shot ``.stop.response``
+        listener, both keyed on ``(sess.session_id, skill_id)``. The snapshot
+        is only consumed by a ``.stop.response`` in the same session, so a
+        discarded Match leaves an entry that is never popped (no eviction), and
+        the stale listener survives to fire on the skill's NEXT genuine
+        ``.stop.response`` in this session — re-emitting the get_response/
+        converse kill signals for a stop this Match never actually caused.
         """
         LOG.debug(f"Telling skill to stop: {skill_id}")
         # Captured before the drain: the post-drain session that reaches
@@ -405,17 +387,17 @@ class StopService(ConfidenceMatcherPipeline):
         and ``converse_handlers`` emptied and ``response_mode`` removed, all
         committed before dispatch.
 
-        CONFIRMED-3: side-effect-free like ``_targeted_stop`` — the clear is
-        carried on a COPY, never the live ``sess``, so a discarded Match
-        (blacklist/missing-slots/dispatch-exception) leaves the live session
-        untouched.
+        Like ``_targeted_stop``, match() must not touch the live session: the
+        clear is carried on a COPY, never the live ``sess``, so a discarded
+        Match (blacklist/missing-slots/dispatch-exception) leaves the live
+        session untouched.
         """
         LOG.info(f"Emitting global stop, {len(sess.active_handlers)} active skills")
         # read-only: the pre-drain holder, carried through match_data so
         # handle_global_stop (dispatch time, NOT here) can emit the targeted
-        # `<skill_id>.stop` a killable-event abort actually listens on —
-        # emitting it here would violate the CONFIRMED-3 side-effect-free
-        # match() invariant, since this Match can still be discarded.
+        # `<skill_id>.stop` a killable-event abort actually listens on — match()
+        # must not act on the world: this Match can still be discarded, so the
+        # targeted stop topic goes out at dispatch time.
         holder = sess.response_mode.get("skill_id") if sess.response_mode else None
         drained = Session.deserialize(sess.serialize())
         drained.active_handlers = []
@@ -434,22 +416,12 @@ class StopService(ConfidenceMatcherPipeline):
         )
 
     def match_high(self, utterances: List[str], lang: str, message: Message) -> Optional[IntentHandlerMatch]:
-        """
-        Handle high-confidence stop requests by matching exact stop vocabulary (§4/§5).
+        """High-confidence stop match: exact stop vocabulary only (§4/§5).
 
-        - explicit ``global_stop`` vocabulary (or bare ``stop`` with no active
-          skills) yields a §5 global stop;
-        - a bare ``stop`` with active skills runs the §4 cascade and yields a
-          targeted ``<skill_id>:stop`` for the recency-selected stoppable skill.
-
-        Parameters:
-            utterances (List[str]): List of user utterances to match against stop vocabulary
-            lang (str): Four-letter ISO language code for language-specific matching
-            message (Message): Message context for generating appropriate responses
-
-        Returns:
-            Optional[IntentHandlerMatch]: the stop Match, or None if no stop
-            vocabulary matched.
+        Explicit ``global_stop`` vocabulary (or bare ``stop`` with no active
+        skills) yields a §5 global stop; a bare ``stop`` with active skills
+        runs the §4 cascade and yields a targeted ``<skill_id>:stop`` for the
+        recency-selected stoppable skill.
         """
         sess = SessionManager.get(message)
 
@@ -458,7 +430,7 @@ class StopService(ConfidenceMatcherPipeline):
 
         is_stop = self._locale.voc_match(utterance, 'stop', lang, exact=True)
         is_global_stop = self._locale.voc_match(utterance, 'global_stop', lang, exact=True) or \
-                         (is_stop and not len(self._stop_candidates(message)))
+                         (is_stop and not self._stop_candidates(message))
 
         conf = 1.0
 
@@ -467,64 +439,29 @@ class StopService(ConfidenceMatcherPipeline):
 
         if is_stop:
             # check if any skill can stop (§4 cascade)
-            for skill_id in self._collect_stop_skills(message):
-                return self._targeted_stop(skill_id, conf, utterance, sess)
+            candidates = self._collect_stop_skills(message)
+            if candidates:
+                return self._targeted_stop(candidates[0], conf, utterance, sess)
 
         return None
 
     def match_medium(self, utterances: List[str], lang: str, message: Message) -> Optional[IntentHandlerMatch]:
-        """
-        Handle stop intent with additional context beyond simple stop commands.
-
-        This method processes utterances that contain "stop" or global stop vocabulary but may include
-        additional words not explicitly defined in intent files. It performs a medium-confidence
-        intent matching for stop requests.
-
-        Parameters:
-            utterances (List[str]): List of input utterances to analyze
-            lang (str): Four-letter ISO language code for localization
-            message (Message): Message context for generating appropriate responses
-
-        Returns:
-            Optional[IntentHandlerMatch]: A pipeline match if the stop intent is successfully processed,
-            otherwise None if no stop intent is detected
-
-        Notes:
-            - Attempts to match stop vocabulary with fuzzy matching
-            - Falls back to low-confidence matching if medium-confidence match is inconclusive
-            - Handles global stop scenarios when no active skills are present
-        """
+        """Medium-confidence stop match: fuzzy ``stop``/``global_stop``
+        vocabulary, delegated to ``match_low`` for the actual dispatch."""
         # we call flatten in case someone is sending the old style list of tuples
         utterance = flatten_list(utterances)[0]
 
-        is_stop = self._locale.voc_match(utterance, 'stop', lang, exact=False)
-        if not is_stop:
-            is_global_stop = self._locale.voc_match(utterance, 'global_stop', lang, exact=False) or \
-                             (is_stop and not len(self._stop_candidates(message)))
-            if not is_global_stop:
-                return None
-
+        if not (self._locale.voc_match(utterance, 'stop', lang, exact=False) or
+                self._locale.voc_match(utterance, 'global_stop', lang, exact=False)):
+            return None
         return self.match_low(utterances, lang, message)
 
     def match_low(self, utterances: List[str], lang: str, message: Message) -> Optional[IntentHandlerMatch]:
-        """
-        Perform a low-confidence fuzzy match for stop intent before fallback processing.
+        """Low-confidence fuzzy stop match, tried last before fallback.
 
-        This method attempts to match stop-related vocabulary with low confidence and handle stopping of active skills.
-
-        Parameters:
-            utterances (List[str]): List of input utterances to match against stop vocabulary
-            lang (str): Four-letter ISO language code for vocabulary matching
-            message (Message): Message context used for generating replies and managing session
-
-        Returns:
-            Optional[IntentHandlerMatch]: A pipeline match object if a stop action is handled, otherwise None
-
-        Notes:
-            - Increases confidence if active skills are present
-            - Attempts to stop individual skills before emitting a global stop signal
-            - Handles language-specific vocabulary matching
-            - Configurable minimum confidence threshold for stop intent
+        Confidence is boosted when active skills are present. Below
+        ``min_conf`` (default 0.5), no match. Otherwise runs the §4 cascade
+        and falls back to a §5 global stop when no skill responds.
         """
         sess = SessionManager.get(message)
         # we call flatten in case someone is sending the old style list of tuples
@@ -543,8 +480,9 @@ class StopService(ConfidenceMatcherPipeline):
             return None
 
         # check if any skill can stop (§4 cascade)
-        for skill_id in self._collect_stop_skills(message):
-            return self._targeted_stop(skill_id, conf, utterance, sess)
+        candidates = self._collect_stop_skills(message)
+        if candidates:
+            return self._targeted_stop(candidates[0], conf, utterance, sess)
 
         # no positive pong responder -> escalate to a §5 global stop
         return self._global_stop(conf, utterance, sess)

--- a/ovos_core/intent_services/working_session.py
+++ b/ovos_core/intent_services/working_session.py
@@ -27,7 +27,7 @@ from threading import RLock
 from typing import Dict, Optional
 
 from ovos_bus_client.message import Message
-from ovos_bus_client.session import Session
+from ovos_bus_client.session import Session, SessionManager
 from ovos_utils.log import LOG
 
 #: An utterance whose dispatch never reaches a terminal is never closed, so the
@@ -66,8 +66,7 @@ def raw_session_id(message: Message) -> Optional[str]:
 
 
 def _utterance_id(message: Optional[Message]) -> Optional[str]:
-    ctx = getattr(message, "context", None) or {}
-    return ctx.get("utterance_id")
+    return message.context.get("utterance_id") if message else None
 
 
 def open_round(message: Message, session: Session) -> None:
@@ -116,6 +115,11 @@ def working_session(message: Optional[Message]) -> Optional[Session]:
         return None
     with _LOCK:
         return _OPEN_ROUNDS.get(uid)
+
+
+def round_session(message: Message) -> Session:
+    """The session the round is running on, or the one the Message names."""
+    return working_session(message) or SessionManager.get(message)
 
 
 def close_round(message: Optional[Message]) -> Optional[Session]:

--- a/test/unittests/test_stop_service.py
+++ b/test/unittests/test_stop_service.py
@@ -695,6 +695,18 @@ class TestMatchMedium(unittest.TestCase):
         self.assertEqual(result, "LOW_RESULT")
         mock_low.assert_called_once()
 
+    def test_global_stop_voc_without_stop_voc_still_matches(self):
+        """A 'global_stop' utterance with no 'stop' vocab match must still
+        reach match_low (the dead is_stop-guarded branch never applied)."""
+        def voc_match_side_effect(utt, voc, lang, exact):
+            return voc == "global_stop"
+
+        with patch.object(self.svc._locale, "voc_match", side_effect=voc_match_side_effect), \
+             patch.object(self.svc, "match_low", return_value="LOW_RESULT") as mock_low:
+            result = self.svc.match_medium(["global_stop_only"], "en-US", Message("test"))
+        self.assertEqual(result, "LOW_RESULT")
+        mock_low.assert_called_once()
+
 
 class TestGetActiveSkills(unittest.TestCase):
 


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Sonnet 5 (claude-sonnet-5) via Claude Code — NOT human-reviewed. Verify before acting.

This collapses the repeated `working_session(message) or SessionManager.get(message)` pattern into a single `round_session()` helper in `working_session.py`, used at all four call sites, and deletes the two indirection-only private twins that only wrapped it (`IntentService._session_for_context_write`, `ConverseService._session_for_write`). It also inlines `IntentDispatcher._session_id`, a ten-line docstring wrapping a single call to `raw_session_id`, at its two call sites, and drops a defensive `getattr` in `working_session._utterance_id` that guarded against a `None` message no caller ever passes.

Several comments that pointed at an internal review-round identifier (`# Finding 30a:`, `# CONFIRMED-3:`) or narrated a diff ("this behaves exactly as before") are rewritten to state the constraint itself, so they still mean something once that round is forgotten — including the `_CONTEXT_LOCK` reentrancy note (it's an RLock because the nested `inject_context()`/`_replace_intent_context()` calls reacquire it). `_sync_handler_mutations`'s dict-diff trick gets named locals (`changed`/`removed`) and a comment naming the `None` tombstone sentinel it relies on, and its nested `handler_ids` closure becomes two inline set comprehensions. A run of auto-generated docstrings on `IntentService.__init__`, `send_cancel_event`, `handle_utterance`, `_collect_stop_skills`, `handle_ack`, and the three `match_*` methods in `stop_service.py` are cut to one or two sentences that describe what the code actually does today rather than an enumerated pipeline list that predates plugin discovery. The missing type hints called out for `service.py`, `manifest.py`, and `stop_service.py` are filled in, and `handle_utterance`'s unused three-tuple return value is dropped (grepped every test file that calls it; none reads the return).

`_targeted_stop`'s docstring claimed match() never touches the live session and left it there; it does have two side effects — a `_pre_drain` write and a `bus.once` registration — and the docstring now says what actually happens when a discarded Match leaves them behind: the `_pre_drain` entry, keyed on `(session_id, skill_id)`, is never popped (there's no eviction), and the stale `.stop.response` listener survives to fire on that skill's next genuine stop confirmation in the same session, re-emitting the get_response/converse kill signals for a stop this particular Match never actually caused. `_global_stop`'s neighboring comment is corrected the same way: the targeted `<skill_id>.stop` topic is deferred to dispatch time because match() must not act on the world while this Match can still be discarded, not because emitting it earlier would "touch the live session" (it wouldn't).

The one edit with any behavioural surface is `StopService.match_medium`'s dead branch. Inside `if not is_stop:`, `is_stop` is always `False`, so the disjunct `(is_stop and not len(...))` can never be true — dead code, and it happened to be the branch that would have called `_stop_candidates`. Rewriting it as a single guard clause turned out not to change behaviour: the surrounding fallthrough already reached `match_low` in every case that dead branch would have mattered for. The new test added here (`test_global_stop_voc_without_stop_voc_still_matches`) is a characterization test, not a regression test — it passes both before and after the rewrite, confirmed via a patch-revert check that kept only the test file reverted to the fix's baseline. It's included as dead-code cleanup, not a bug fix, and this description says so rather than claiming a fail-before that doesn't exist.

500 unit tests pass locally, which is the 499 on `dev` plus the one new test; the dev baseline (6 xfailed, no failures) is otherwise unchanged. The stop/session end-to-end suite most likely to notice a change in this area (`test_stop_legacy_e2e`, `test_stop_response_mode_e2e`, `test_stop_spec_e2e`, `test_completion_sync_e2e`, `test_context1_reachability` — 12 tests) also passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved session handling throughout intent and conversation processing for more consistent context and lifecycle behavior.
  - Ensured global stop commands are recognized even when standard stop vocabulary does not match.
  - Streamlined stop-command matching to target the most relevant skill.

- **Refactor**
  - Added clearer type information across intent services and improved support for simulated message buses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->