### PR TITLE
test: remove stale SessionManager.default_session mirror assignments

### DIFF
--- a/test/unittests/test_intent_context.py
+++ b/test/unittests/test_intent_context.py
@@ -236,12 +236,10 @@ class TestLiveSessionManagerSync(unittest.TestCase):
     def setUp(self):
         # isolate the singleton between tests
         SessionManager.sessions = {"default": Session("default")}
-        SessionManager.default_session = SessionManager.sessions["default"]
         SessionManager.bus = None
 
     def tearDown(self):
         SessionManager.sessions = {"default": Session("default")}
-        SessionManager.default_session = SessionManager.sessions["default"]
         SessionManager.bus = None
 
     @pytest.mark.xfail(strict=True, reason=_NEEDS_BUS_CLIENT_278)
@@ -416,7 +414,6 @@ class TestDispatchMatchRejectsMismatchedUpdatedSession(unittest.TestCase):
 
     def setUp(self):
         SessionManager.sessions = {"default": Session("default")}
-        SessionManager.default_session = SessionManager.sessions["default"]
         SessionManager.bus = None
 
     tearDown = setUp
@@ -460,7 +457,6 @@ class TestSessionSyncCarrier(unittest.TestCase):
 
     def setUp(self):
         SessionManager.sessions = {"default": Session("default")}
-        SessionManager.default_session = SessionManager.sessions["default"]
         SessionManager.bus = None
 
     tearDown = setUp
@@ -518,7 +514,6 @@ class TestDecayIgnoresUnknownSession(unittest.TestCase):
 
     def setUp(self):
         SessionManager.sessions = {"default": Session("default")}
-        SessionManager.default_session = SessionManager.sessions["default"]
         SessionManager.bus = None
 
     tearDown = setUp
@@ -713,12 +708,10 @@ class TestDecayPropagatesToTerminalEmissions(unittest.TestCase):
 
     def setUp(self):
         SessionManager.sessions = {"default": Session("default")}
-        SessionManager.default_session = SessionManager.sessions["default"]
         SessionManager.bus = None
 
     def tearDown(self):
         SessionManager.sessions = {"default": Session("default")}
-        SessionManager.default_session = SessionManager.sessions["default"]
         SessionManager.bus = None
 
     def _run_full_dispatch(self, sess):
@@ -863,7 +856,6 @@ class TestRequiredSlotFilledFromContext(unittest.TestCase):
 
     def setUp(self):
         SessionManager.sessions = {"default": Session("default")}
-        SessionManager.default_session = SessionManager.sessions["default"]
         SessionManager.bus = None
 
     tearDown = setUp


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Haiku 4.5 (claude-haiku-4-5-20251001) via Claude Code — NOT human-reviewed. Verify before acting.

ovos-spec-tools 1.10.5a2 removed SessionManager.default_session as a class attribute; the registry SessionManager.sessions["default"] and get_default_session() are the sole state. This change deletes all eight setUp/tearDown assignments that created stray mirror attributes across test_intent_context.py. Tests confirm no code relied on them, with the full test file passing (45 passed, 6 xfailed) after removal; a grep of test/ and ovos_core/ shows only method names (reset_default_session, get_default_session) remaining.