### PR TITLE
fix: key the targeted-stop pre-drain snapshot by round, not session

### DIFF
--- a/ovos_core/intent_services/stop_service.py
+++ b/ovos_core/intent_services/stop_service.py
@@ -1,6 +1,6 @@
 from os.path import dirname, join
 from threading import Event
-from typing import Optional, Dict, List, NamedTuple, Tuple, Union
+from typing import Optional, Dict, List, NamedTuple, Set, Tuple, Union
 
 from ovos_bus_client.client import MessageBusClient
 from ovos_bus_client.handler import HandlerLifecycle
@@ -16,7 +16,6 @@ from ovos_utils.log import LOG
 from ovos_utils.parse import match_one
 
 from ovos_core.intent_services.stop_service_legacy import _LegacyStopBridge
-from ovos_core.intent_services.working_session import raw_session_id
 
 
 class PreDrainSnapshot(NamedTuple):
@@ -24,9 +23,15 @@ class PreDrainSnapshot(NamedTuple):
 
     ``match()`` drains ``active_handlers``/``response_mode`` before dispatch,
     so by the time ``.stop.response`` arrives the live session already lies
-    about both fields. Capture them together at drain time, keyed by
-    ``(session_id, skill_id)``, and pop them together in
-    ``handle_stop_confirmation`` before either result branch runs.
+    about both fields. OVOS-PIPELINE-1 §4.2 permits a plugin's own bus
+    side effects and internal bookkeeping inside ``match()`` — this is
+    recorded there, keyed by ``(utterance_id, skill_id)``, and popped in
+    ``handle_stop_confirmation`` before either result branch runs. Keying by
+    the round rather than the session means a barge-in for a NEW utterance in
+    the same session can never evict a still-running dispatched stop's
+    snapshot — only that round's own §9.5 ``ovos.utterance.handled`` end
+    marker does (see ``_on_utterance_handled``), and a dispatched stop is
+    always consumed before its own round's end marker fires.
     """
     was_active: bool
     utt_state: UtteranceState
@@ -67,12 +72,18 @@ class StopService(ConfidenceMatcherPipeline):
         self.suppress_activation = suppress_activation
         # §5 global-stop dispatch target; bound once, shared across tiers (§3.1).
         self.bus.on(f"{self.pipeline_id}:global_stop", self.handle_global_stop)
+        # The ONLY `_pre_drain` eviction: §9.5's universal, exactly-once-per-
+        # round end marker.
+        self.bus.on(SpecMessage.UTTERANCE_HANDLED.value, self._on_utterance_handled)
         self._legacy = _LegacyStopBridge(self)
-        #: (session_id, skill_id) -> PreDrainSnapshot captured by _targeted_stop
-        #: and consumed once by handle_stop_confirmation. Keyed per-session
-        #: (not bare skill_id) so two concurrent targeted stops for the same
-        #: skill_id in different sessions can't clobber each other's snapshot.
+        #: (utterance_id, skill_id) -> PreDrainSnapshot recorded by
+        #: `_targeted_stop` and consumed once by `handle_stop_confirmation`.
+        #: Keyed per-round (not bare skill_id) so two concurrent targeted
+        #: stops for the same skill_id can't clobber each other's snapshot.
         self._pre_drain: Dict[Tuple[str, str], PreDrainSnapshot] = {}
+        #: skill_ids with a permanent `<skill_id>.stop.response` listener
+        #: already bound (see `_targeted_stop`).
+        self._stop_listeners: Set[str] = set()
 
     def handle_global_stop(self, message: Message) -> None:
         """OVOS-STOP-1 §5.3 — broadcast the universal ``ovos.stop``.
@@ -250,54 +261,71 @@ class StopService(ConfidenceMatcherPipeline):
         dispatcher's 5-minute §8.3 timeout. Emitting the framework done-signal
         here, rather than reaching into ``IntentDispatcher`` directly, keeps
         ``StopService`` decoupled from the dispatcher's internals.
+
+        The ``.stop.response`` listener is bound permanently per skill_id
+        (``_targeted_stop``), so this fires for every round's response for
+        that skill, not just the one that just dispatched it. A response with
+        no matching ``(utterance_id, skill_id)`` snapshot is therefore a
+        no-op: either this skill_id was never targeted by a stop for this
+        round, or its snapshot was already consumed/evicted.
         """
         skill_id = (message.data.get("skill_id") or
                     message.context.get("skill_id") or
                     message.msg_type.split(".stop.response")[0])
-        sess_id = raw_session_id(message)
-        if sess_id is None:
-            # malformed carrier (OVOS-SESSION-1 §2.5): already logged, and
-            # there is no (session_id, skill_id) key to resolve against.
+        utt_id = message.context.get("utterance_id")
+        if not utt_id:
+            # no round to correlate against (a V0/direct-invocation caller
+            # that never entered through the orchestrator's §9.1.1 stamping)
+            # -- `_targeted_stop` never records a snapshot for this case
+            # either, so there is nothing to resolve.
             return
-        # Pop both snapshots unconditionally before either branch below: the
-        # error/no-dispatch paths must not leak them or hold the
-        # _resolve_dispatch_lifecycle gate open for this (session_id, skill_id).
-        snapshot = self._pre_drain.pop((sess_id, skill_id), None)
+        snapshot = self._pre_drain.pop((utt_id, skill_id), None)
+        if snapshot is None:
+            return  # no pending targeted stop for this (round, skill) pair
         try:
-            if snapshot is not None:
-                self._resolve_dispatch_lifecycle(message, skill_id)
+            self._resolve_dispatch_lifecycle(message, skill_id)
         except Exception:
             LOG.exception(f"failed to resolve dispatch lifecycle for {skill_id}:stop")
         if 'error' in message.data:
             error_msg = message.data['error']
             LOG.error(f"{skill_id}: {error_msg}")
         elif message.data.get('result', False):
-            sess = SessionManager.get(message)
-            # The session on this .stop.response is already post-drain, so
-            # live reads of utterance_states/active_handlers lie; consult the
-            # pre-drain snapshot popped above, falling back to the live read
-            # for direct-invocation callers that bypass _targeted_stop.
-            utt_state = snapshot.utt_state if snapshot else (
-                UtteranceState.RESPONSE
-                if sess.response_mode and sess.response_mode.get("skill_id") == skill_id
-                else UtteranceState.INTENT)
-            if utt_state == UtteranceState.RESPONSE:
+            if snapshot.utt_state == UtteranceState.RESPONSE:
                 LOG.debug("Forcing get_response timeout")
                 # force-kill any ongoing get_response - see @killable_event decorator (ovos-workshop)
                 self.bus.emit(message.reply("mycroft.skills.abort_question", {"skill_id": skill_id}))
-            was_active = snapshot.was_active if snapshot else sess.is_active(skill_id)
-            if was_active:
+            if snapshot.was_active:
                 LOG.debug("Forcing converse timeout")
                 # force-kill any ongoing converse - see @killable_event decorator (ovos-workshop)
                 self.bus.emit(message.reply("ovos.skills.converse.force_timeout", {"skill_id": skill_id}))
 
             # TODO - track if speech is coming from this skill! not currently tracked (ovos-audio)
+            sess = SessionManager.get(message)
             if sess.is_speaking:
                 # force-kill any ongoing TTS
                 # SpecMessage.AUDIO_STOP.value == "ovos.audio.stop"; the
                 # translator's MIGRATION_MAP mirrors it onto the legacy
                 # "mycroft.audio.speech.stop" ovos-audio still listens on.
                 self.bus.emit(message.forward(SpecMessage.AUDIO_STOP.value, {"skill_id": skill_id}))
+
+    def _on_utterance_handled(self, message: Message) -> None:
+        """Evict every pending ``_pre_drain`` snapshot for a finished round.
+
+        ``ovos.utterance.handled`` (§9.5) is the universal end marker: exactly
+        one is emitted per utterance lifecycle, on every exit path (a
+        dispatched Match's §8 terminal, a discarded/blacklisted Match, no
+        Match at all). A snapshot still pending when its own round's end
+        marker fires can only belong to a Match that was never dispatched, or
+        was dispatched but never got a ``.stop.response`` back — either way
+        the round is over and the snapshot is stale. A dispatched, genuinely
+        answered stop is always popped by `handle_stop_confirmation` before
+        this fires, so this is a no-op for it.
+        """
+        utt_id = message.context.get("utterance_id")
+        if not utt_id:
+            return
+        for key in [k for k in self._pre_drain if k[0] == utt_id]:
+            self._pre_drain.pop(key, None)
 
     def _resolve_dispatch_lifecycle(self, message: Message, skill_id: str) -> None:
         """Emit the framework done-signal for the ``<skill_id>:stop`` dispatch
@@ -332,7 +360,7 @@ class StopService(ConfidenceMatcherPipeline):
         self.bus.emit(done)
 
     def _targeted_stop(self, skill_id: str, conf: float, utterance: str,
-                       sess: Session) -> IntentHandlerMatch:
+                       sess: Session, message: Message) -> IntentHandlerMatch:
         """Build the OVOS-STOP-1 §2 targeted ``<skill_id>:stop`` Match.
 
         Drains the dispatch target from ``active_handlers`` and clears its
@@ -347,29 +375,42 @@ class StopService(ConfidenceMatcherPipeline):
         session if/when ``_dispatch_match`` actually commits it. The live
         ``sess`` passed in is read but never mutated.
 
-        This does have two side effects beyond building the Match: it records
-        a ``_pre_drain`` snapshot and registers a one-shot ``.stop.response``
-        listener, both keyed on ``(sess.session_id, skill_id)``. The snapshot
-        is only consumed by a ``.stop.response`` in the same session, so a
-        discarded Match leaves an entry that is never popped (no eviction), and
-        the stale listener survives to fire on the skill's NEXT genuine
-        ``.stop.response`` in this session — re-emitting the get_response/
-        converse kill signals for a stop this Match never actually caused.
+        Recording the ``_pre_drain`` snapshot and binding the (permanent,
+        per-skill_id) ``.stop.response`` listener here, in ``match()``, is
+        allowed by OVOS-PIPELINE-1 §4.2: a plugin's own bus registrations and
+        internal bookkeeping are not dispatch actions. If this Match is later
+        discarded, the snapshot is stale but not permanently leaked — it is
+        keyed by ``message.context["utterance_id"]`` (§9.1.1, stamped by the
+        orchestrator at lifecycle entry and carried by every derived Message),
+        so it dies with that round's own §9.5 end marker (see
+        ``_on_utterance_handled``) regardless of what happens to this Match.
         """
         LOG.debug(f"Telling skill to stop: {skill_id}")
-        # Captured before the drain: the post-drain session that reaches
-        # handle_stop_confirmation via the dispatch round-trip can no longer
-        # answer either question truthfully.
-        self._pre_drain[(sess.session_id, skill_id)] = PreDrainSnapshot(
-            was_active=sess.is_active(skill_id),
-            utt_state=(UtteranceState.RESPONSE
-                       if sess.response_mode and sess.response_mode.get("skill_id") == skill_id
-                       else UtteranceState.INTENT),
-        )
+        utt_id = message.context.get("utterance_id")
+        if not utt_id:
+            # No round to key the snapshot by (a V0/direct-invocation caller
+            # that never entered through the orchestrator's §9.1.1 stamping).
+            # The stop still dispatches; it just loses the automatic
+            # get_response/converse kill signals and dispatcher-lifecycle
+            # resolution `handle_stop_confirmation` would otherwise provide.
+            LOG.debug(f"no utterance_id on the stop Match for '{skill_id}'; "
+                      f"skipping the pre-drain snapshot")
+        else:
+            # Captured before the drain: the post-drain session that reaches
+            # handle_stop_confirmation via the dispatch round-trip can no
+            # longer answer either question truthfully.
+            self._pre_drain[(utt_id, skill_id)] = PreDrainSnapshot(
+                was_active=sess.is_active(skill_id),
+                utt_state=(UtteranceState.RESPONSE
+                           if sess.response_mode and sess.response_mode.get("skill_id") == skill_id
+                           else UtteranceState.INTENT),
+            )
+        if skill_id not in self._stop_listeners:
+            self._stop_listeners.add(skill_id)
+            self.bus.on(f"{skill_id}.stop.response", self.handle_stop_confirmation)
         drained = Session.deserialize(sess.serialize())
         drained.disable_response_mode(skill_id)
         drained.deactivate_skill(skill_id)
-        self.bus.once(f"{skill_id}.stop.response", self.handle_stop_confirmation)
         return IntentHandlerMatch(
             match_type=f"{skill_id}:stop",
             match_data={"conf": conf, "skill_id": skill_id},
@@ -441,7 +482,7 @@ class StopService(ConfidenceMatcherPipeline):
             # check if any skill can stop (§4 cascade)
             candidates = self._collect_stop_skills(message)
             if candidates:
-                return self._targeted_stop(candidates[0], conf, utterance, sess)
+                return self._targeted_stop(candidates[0], conf, utterance, sess, message)
 
         return None
 
@@ -482,7 +523,7 @@ class StopService(ConfidenceMatcherPipeline):
         # check if any skill can stop (§4 cascade)
         candidates = self._collect_stop_skills(message)
         if candidates:
-            return self._targeted_stop(candidates[0], conf, utterance, sess)
+            return self._targeted_stop(candidates[0], conf, utterance, sess, message)
 
         # no positive pong responder -> escalate to a §5 global stop
         return self._global_stop(conf, utterance, sess)
@@ -490,4 +531,8 @@ class StopService(ConfidenceMatcherPipeline):
     def shutdown(self) -> None:
         """Remove bus listeners registered by this service."""
         self.bus.remove(f"{self.pipeline_id}:global_stop", self.handle_global_stop)
+        self.bus.remove(SpecMessage.UTTERANCE_HANDLED.value, self._on_utterance_handled)
+        for skill_id in self._stop_listeners:
+            self.bus.remove(f"{skill_id}.stop.response", self.handle_stop_confirmation)
+        self._stop_listeners.clear()
         self._legacy.shutdown()

--- a/test/unittests/test_stop_service.py
+++ b/test/unittests/test_stop_service.py
@@ -29,6 +29,16 @@ from ovos_core.intent_services.stop_service_legacy import _LegacyStopBridge
 GLOBAL_STOP = f"{StopService.pipeline_id}:global_stop"
 
 
+def _round_message(utterance_id, sess=None):
+    """A Message carrying ``context["utterance_id"]`` the way the
+    orchestrator stamps it at lifecycle entry (§9.1.1) -- what
+    ``_targeted_stop`` needs as its ``message`` argument."""
+    context = {"utterance_id": utterance_id}
+    if sess is not None:
+        context["session"] = sess.serialize()
+    return Message("test", {}, context)
+
+
 def _make_service() -> StopService:
     """Construct a StopService backed by a FakeBus."""
     bus = FakeBus()
@@ -45,6 +55,7 @@ def _make_service() -> StopService:
         svc._locale = MagicMock()
         svc._legacy = MagicMock()
         svc._pre_drain = {}
+        svc._stop_listeners = set()
     return svc
 
 
@@ -405,9 +416,12 @@ class TestHandleStopConfirmation(unittest.TestCase):
     def test_error_in_data_is_logged(self):
         svc = _make_service()
         svc.bus.emit = MagicMock()
+        sess = Session("s")
+        sess.activate_skill("skill_a")
+        svc._targeted_stop("skill_a", 1.0, "stop", sess, _round_message("uid-1"))
         msg = Message("skill_a.stop.response",
                       data={"skill_id": "skill_a", "error": "boom"},
-                      context={})
+                      context={"utterance_id": "uid-1", "session": sess.serialize()})
         with patch("ovos_core.intent_services.stop_service.LOG") as mock_log:
             svc.handle_stop_confirmation(msg)
         mock_log.error.assert_called_once()
@@ -420,10 +434,11 @@ class TestHandleStopConfirmation(unittest.TestCase):
         sess = Session("s")
         sess.activate_skill("skill_a")
         sess.enable_response_mode("skill_a")
+        svc._targeted_stop("skill_a", 1.0, "stop", sess, _round_message("uid-1"))
 
         msg = Message("skill_a.stop.response",
                       data={"skill_id": "skill_a", "result": True},
-                      context={"session": sess.serialize()})
+                      context={"utterance_id": "uid-1", "session": sess.serialize()})
 
         with patch("ovos_core.intent_services.stop_service.SessionManager.get",
                    return_value=sess):
@@ -432,8 +447,9 @@ class TestHandleStopConfirmation(unittest.TestCase):
         emitted = [c[0][0].msg_type for c in svc.bus.emit.call_args_list]
         self.assertIn("mycroft.skills.abort_question", emitted)
 
-    def test_skill_id_extracted_from_msg_type_fallback(self):
-        """skill_id can be inferred from the message type if not in data/context."""
+    def test_no_utterance_id_is_a_no_op(self):
+        """A `.stop.response` with no `utterance_id` (a V0/direct-invocation
+        caller) has no snapshot to resolve against and must not raise."""
         svc = _make_service()
         svc.bus.emit = MagicMock()
         sess = Session("s")
@@ -446,6 +462,8 @@ class TestHandleStopConfirmation(unittest.TestCase):
                    return_value=sess):
             # Should not raise
             svc.handle_stop_confirmation(msg)
+
+        self.assertEqual(svc.bus.emit.call_args_list, [])
 
 
 class TestAbortQuestionReachable(unittest.TestCase):
@@ -465,13 +483,13 @@ class TestAbortQuestionReachable(unittest.TestCase):
 
         # simulate _targeted_stop's pre-drain snapshot + the dispatch carrying
         # the POST-drain session forward to the .stop.response handler.
-        match = svc._targeted_stop("skill_a", 1.0, "stop", sess)
+        match = svc._targeted_stop("skill_a", 1.0, "stop", sess, _round_message("uid-1"))
         drained_sess = match.updated_session
         self.assertFalse(drained_sess.response_mode)  # sanity: already drained
 
         msg = Message("skill_a.stop.response",
                       data={"skill_id": "skill_a", "result": True},
-                      context={"session": drained_sess.serialize()})
+                      context={"utterance_id": "uid-1", "session": drained_sess.serialize()})
 
         with patch("ovos_core.intent_services.stop_service.SessionManager.get",
                    return_value=drained_sess):
@@ -491,12 +509,12 @@ class TestAbortQuestionReachable(unittest.TestCase):
         sess = Session("s")
         sess.activate_skill("skill_a")  # active, NOT response-mode
 
-        match = svc._targeted_stop("skill_a", 1.0, "stop", sess)
+        match = svc._targeted_stop("skill_a", 1.0, "stop", sess, _round_message("uid-1"))
         drained_sess = match.updated_session
 
         msg = Message("skill_a.stop.response",
                       data={"skill_id": "skill_a", "result": True},
-                      context={"session": drained_sess.serialize()})
+                      context={"utterance_id": "uid-1", "session": drained_sess.serialize()})
 
         with patch("ovos_core.intent_services.stop_service.SessionManager.get",
                    return_value=drained_sess):
@@ -538,7 +556,6 @@ class TestMatchHigh(unittest.TestCase):
              patch.object(self.svc, "_collect_stop_skills", return_value=["skill_a"]), \
              patch("ovos_core.intent_services.stop_service.SessionManager.get",
                    return_value=Session("s")):
-            self.svc.bus.once = MagicMock()
             result = self.svc.match_high(["stop"], "en-US", Message("test"))
 
         self.assertIsNotNone(result)
@@ -604,7 +621,6 @@ class TestMatchLow(unittest.TestCase):
     def test_above_threshold_with_stoppable_skill(self):
         """A confident match with a stoppable skill → skill stop."""
         self.svc.config = {"min_conf": 0.5}
-        self.svc.bus.once = MagicMock()
         with patch.object(self.svc._locale, "voc_list", return_value=["stop"]), \
              patch("ovos_core.intent_services.stop_service.match_one",
                    return_value=("stop", 0.8)), \
@@ -632,10 +648,11 @@ class TestHandleStopConfirmationExtra(unittest.TestCase):
         sess.activate_skill("skill_a")
         # INTENT state (not RESPONSE) — should NOT trigger abort_question
         # but skill is still active → should trigger converse force_timeout
+        svc._targeted_stop("skill_a", 1.0, "stop", sess, _round_message("uid-1"))
 
         msg = Message("skill_a.stop.response",
                       data={"skill_id": "skill_a", "result": True},
-                      context={"session": sess.serialize()})
+                      context={"utterance_id": "uid-1", "session": sess.serialize()})
 
         with patch("ovos_core.intent_services.stop_service.SessionManager.get",
                    return_value=sess):
@@ -653,10 +670,11 @@ class TestHandleStopConfirmationExtra(unittest.TestCase):
         sess = Session("s")
         sess.activate_skill("skill_a")
         sess.is_speaking = True
+        svc._targeted_stop("skill_a", 1.0, "stop", sess, _round_message("uid-1"))
 
         msg = Message("skill_a.stop.response",
                       data={"skill_id": "skill_a", "result": True},
-                      context={"session": sess.serialize()})
+                      context={"utterance_id": "uid-1", "session": sess.serialize()})
 
         with patch("ovos_core.intent_services.stop_service.SessionManager.get",
                    return_value=sess):
@@ -900,7 +918,6 @@ class TestResponseModeHolderCandidate(unittest.TestCase):
         sess = Session("s")
         sess.enable_response_mode("skill_x")  # no active_handlers push
 
-        self.svc.bus.once = MagicMock()
         with patch.object(self.svc._locale, "voc_match",
                           side_effect=lambda utt, voc, lang, exact: voc == "stop"), \
              patch.object(StopService, "get_active_skills", return_value=[]), \
@@ -1039,9 +1056,9 @@ class TestDispatcherLifecycleResolvedByStopRoundTrip(unittest.TestCase):
                lambda m: bus.emit(m.reply(f"{skill_id}.stop.response",
                                           {"skill_id": skill_id, "result": True})))
 
-        match = svc._targeted_stop(skill_id, 1.0, "stop", sess)
+        match = svc._targeted_stop(skill_id, 1.0, "stop", sess, _round_message("uid-1"))
         reply = Message(match.match_type, dict(match.match_data),
-                        {"skill_id": skill_id,
+                        {"skill_id": skill_id, "utterance_id": "uid-1",
                          "session": match.updated_session.serialize()})
 
         disp.dispatch(reply, skill_id, "stop")
@@ -1055,24 +1072,17 @@ class TestDispatcherLifecycleResolvedByStopRoundTrip(unittest.TestCase):
             "parked on the 5-minute §8.3 timeout")
 
 
-class TestStaleStopOnceDoesNotResolveUnrelatedEntry(unittest.TestCase):
-    """`_targeted_stop` registers
-    `bus.once(f"{skill_id}.stop.response", handle_stop_confirmation)`
-    at MATCH-BUILD time -- a side effect that survives even when the
-    orchestrator later DISCARDS the Match (blacklisted intent, missing
-    slots, etc: see service.py's blacklist check) and never actually
-    dispatches it. Before this fix, if that skill later emits ANY
-    `.stop.response` for an unrelated reason (e.g. a global stop's own
-    ping-pong round trip), the stale listener fires `handle_stop_confirmation`,
-    whose synthetic `mycroft.skill.handler.complete` popped the dispatcher's
-    in-flight entry for that skill_id regardless of which intent it actually
-    belonged to -- a still-running, unrelated intent handler got a premature
-    `ovos.utterance.handled` end-marker.
+class TestStaleStopResponseDoesNotResolveUnrelatedEntry(unittest.TestCase):
+    """`_targeted_stop` records the `_pre_drain` snapshot and binds the
+    (permanent) `.stop.response` listener at MATCH-BUILD time -- allowed by
+    OVOS-PIPELINE-1 §4.2. If the orchestrator later DISCARDS this Match
+    (blacklisted intent, missing slots, etc: see service.py's blacklist
+    check) and never actually dispatches it, the snapshot is stale but keyed
+    by this round's own `utterance_id`, so it can only ever resolve a
+    `.stop.response` correlated to THIS round -- never an unrelated,
+    genuinely in-flight intent for the same skill_id in a different round."""
 
-    Mirrors the live auditor's attack.py::test_B_stale_once_pops_wrong_entry.
-    """
-
-    def test_stale_once_does_not_resolve_unrelated_running_intent(self):
+    def test_stale_snapshot_does_not_resolve_unrelated_running_intent(self):
         from ovos_core.intent_services.dispatcher import IntentDispatcher
 
         svc = _make_service()
@@ -1083,22 +1093,26 @@ class TestStaleStopOnceDoesNotResolveUnrelatedEntry(unittest.TestCase):
         sess = Session("sessB")
         sess.activate_skill("skillA")
 
-        # 1) a stop match is built (registers the bus.once side effect) but
-        #    is DISCARDED -- never handed to disp.dispatch().
-        svc._targeted_stop("skillA", 1.0, "stop", sess)
+        # 1) a stop match is built for round "uid-discarded" (records the
+        #    pre-drain snapshot + permanent listener) but is DISCARDED --
+        #    never handed to disp.dispatch().
+        svc._targeted_stop("skillA", 1.0, "stop", sess, _round_message("uid-discarded"))
 
-        # 2) an ordinary, unrelated intent for the SAME skill is genuinely
-        #    in flight.
+        # 2) an ordinary, unrelated intent for the SAME skill, a DIFFERENT
+        #    round, is genuinely in flight.
         intent_msg = Message("skillA:my.intent", {},
-                             {"skill_id": "skillA", "session": sess.serialize()})
+                             {"skill_id": "skillA", "utterance_id": "uid-running",
+                              "session": sess.serialize()})
         disp.dispatch(intent_msg, "skillA", "my.intent")
 
         # 3) later, skillA answers .stop.response for an unrelated reason
-        #    (e.g. a global stop's ping-pong) -- this fires the stale
-        #    bus.once() listener from step 1.
+        #    (e.g. a global stop's ping-pong), carrying the RUNNING intent's
+        #    round id -- the discarded snapshot is keyed on "uid-discarded"
+        #    and can never match this.
         bus.emit(Message("skillA.stop.response",
                          {"skill_id": "skillA", "result": True},
-                         {"skill_id": "skillA", "session": sess.serialize()}))
+                         {"skill_id": "skillA", "utterance_id": "uid-running",
+                          "session": sess.serialize()}))
 
         with disp._lock:
             entries = list(disp._in_flight.get("sessB", []))
@@ -1106,7 +1120,7 @@ class TestStaleStopOnceDoesNotResolveUnrelatedEntry(unittest.TestCase):
             [(e.skill_id, e.intent_name) for e in entries],
             [("skillA", "my.intent")],
             "the still-running, unrelated intent's dispatcher entry must "
-            "survive a stale/foreign .stop.response for the same skill_id")
+            "survive a stale/foreign .stop.response for a different round")
 
 
 class TestFailedStopYieldsErrorTerminal(unittest.TestCase):
@@ -1138,9 +1152,9 @@ class TestFailedStopYieldsErrorTerminal(unittest.TestCase):
                                           {"skill_id": "skillA",
                                            "error": "stop() raised ValueError"})))
 
-        match = svc._targeted_stop("skillA", 1.0, "stop", sess)
+        match = svc._targeted_stop("skillA", 1.0, "stop", sess, _round_message("uid-1"))
         reply = Message(match.match_type, dict(match.match_data),
-                        {"skill_id": "skillA",
+                        {"skill_id": "skillA", "utterance_id": "uid-1",
                          "session": match.updated_session.serialize()})
         disp.dispatch(reply, "skillA", "stop")
 
@@ -1210,9 +1224,9 @@ class TestIntentNameFilterIsDataNotContext(unittest.TestCase):
                lambda m: bus.emit(m.reply("skillA.stop.response",
                                           {"skill_id": "skillA", "result": True})))
 
-        match = svc._targeted_stop("skillA", 1.0, "stop", sess)
+        match = svc._targeted_stop("skillA", 1.0, "stop", sess, _round_message("uid-1"))
         reply = Message(match.match_type, dict(match.match_data),
-                        {"skill_id": "skillA",
+                        {"skill_id": "skillA", "utterance_id": "uid-1",
                          "session": match.updated_session.serialize()})
         disp.dispatch(reply, "skillA", "stop")
 
@@ -1225,7 +1239,7 @@ class TestPreDrainSnapshotsDoNotLeakOnFailedStop(unittest.TestCase):
     """The pre-drain snapshot must be popped for every `.stop.response`,
     not only a successful one: an error, a decline (`result: False`), or a
     response for a dispatch that never completed must not leave
-    `(session_id, skill_id)` in `_pre_drain` forever, and must not leave the
+    `(utterance_id, skill_id)` in `_pre_drain` forever, and must not leave the
     `_resolve_dispatch_lifecycle` presence-gate open for that pair."""
 
     def test_fifty_failed_stops_leave_no_leaked_snapshot_keys(self):
@@ -1233,11 +1247,12 @@ class TestPreDrainSnapshotsDoNotLeakOnFailedStop(unittest.TestCase):
         for i in range(50):
             sess = Session(f"sess{i}")
             sess.activate_skill("skillA")
-            svc._targeted_stop("skillA", 1.0, "stop", sess)
+            svc._targeted_stop("skillA", 1.0, "stop", sess, _round_message(f"uid-{i}"))
             svc.handle_stop_confirmation(Message(
                 "skillA.stop.response",
                 {"skill_id": "skillA", "error": "boom"},
-                {"skill_id": "skillA", "session": sess.serialize()}))
+                {"skill_id": "skillA", "utterance_id": f"uid-{i}",
+                 "session": sess.serialize()}))
         self.assertEqual(len(svc._pre_drain), 0)
 
     def test_fifty_declined_stops_leave_no_leaked_snapshot_keys(self):
@@ -1245,11 +1260,12 @@ class TestPreDrainSnapshotsDoNotLeakOnFailedStop(unittest.TestCase):
         for i in range(50):
             sess = Session(f"x{i}")
             sess.activate_skill("skillA")
-            svc._targeted_stop("skillA", 1.0, "stop", sess)
+            svc._targeted_stop("skillA", 1.0, "stop", sess, _round_message(f"uid-{i}"))
             svc.handle_stop_confirmation(Message(
                 "skillA.stop.response",
                 {"skill_id": "skillA", "result": False},
-                {"skill_id": "skillA", "session": sess.serialize()}))
+                {"skill_id": "skillA", "utterance_id": f"uid-{i}",
+                 "session": sess.serialize()}))
         self.assertEqual(len(svc._pre_drain), 0)
 
     def test_successful_stop_still_clears_snapshot(self):
@@ -1257,17 +1273,17 @@ class TestPreDrainSnapshotsDoNotLeakOnFailedStop(unittest.TestCase):
         svc = _make_service()
         sess = Session("ok")
         sess.activate_skill("skillA")
-        svc._targeted_stop("skillA", 1.0, "stop", sess)
+        svc._targeted_stop("skillA", 1.0, "stop", sess, _round_message("uid-1"))
         svc.handle_stop_confirmation(Message(
             "skillA.stop.response",
             {"skill_id": "skillA", "result": True},
-            {"skill_id": "skillA", "session": sess.serialize()}))
+            {"skill_id": "skillA", "utterance_id": "uid-1", "session": sess.serialize()}))
         self.assertEqual(len(svc._pre_drain), 0)
 
 
 class TestPreDrainGateBlocksUnknownPair(unittest.TestCase):
     """`handle_stop_confirmation` must only emit a synthetic
-    handler.complete/.error for a (session_id, skill_id) pair it actually
+    handler.complete/.error for a (utterance_id, skill_id) pair it actually
     has a pre-drain snapshot for. A `.stop.response` for a pair with NO
     pre-drain snapshot at all (never went through `_targeted_stop`) must
     emit no `mycroft.skill.handler.complete`/`.error` whatsoever."""
@@ -1279,18 +1295,19 @@ class TestPreDrainGateBlocksUnknownPair(unittest.TestCase):
 
         sess = Session("unknown-sess")
         # deliberately skip _targeted_stop -- no pre-drain snapshot exists
-        # for ("unknown-sess", "skillA").
+        # for ("uid-unknown", "skillA").
         svc.handle_stop_confirmation(Message(
             "skillA.stop.response",
             {"skill_id": "skillA", "result": True},
-            {"skill_id": "skillA", "session": sess.serialize()}))
+            {"skill_id": "skillA", "utterance_id": "uid-unknown",
+             "session": sess.serialize()}))
 
         handler_signals = [t for t in emitted
                            if t in ("mycroft.skill.handler.complete",
                                     "mycroft.skill.handler.error")]
         self.assertEqual(
             handler_signals, [],
-            "a .stop.response for a (session, skill) pair with no pre-drain "
+            "a .stop.response for a (round, skill) pair with no pre-drain "
             f"snapshot must never emit a synthetic handler signal, got {emitted!r}")
 
 
@@ -1302,25 +1319,44 @@ class TestShutdown(unittest.TestCase):
         svc.shutdown()
         calls = {c[0][0] for c in svc.bus.remove.call_args_list}
         self.assertIn(GLOBAL_STOP, calls)
+        self.assertIn(SpecMessage.UTTERANCE_HANDLED.value, calls)
         # the legacy listeners are removed by the (mocked) bridge
         svc._legacy.shutdown.assert_called_once()
 
+    def test_shutdown_removes_one_listener_per_skill_regardless_of_dispatch_count(self):
+        """50 targeted-stop dispatches for the SAME skill_id must bind the
+        `.stop.response` listener exactly once -- shutdown() must remove
+        exactly that one registration, not 50."""
+        svc = _make_service()
+        for i in range(50):
+            sess = Session(f"s{i}")
+            sess.activate_skill("skillA")
+            svc._targeted_stop("skillA", 1.0, "stop", sess, _round_message(f"uid-{i}"))
+        self.assertEqual(svc._stop_listeners, {"skillA"})
 
-class TestPreDrainSnapshotsAreSessionScoped(unittest.TestCase):
-    """`_pre_drain` is keyed by ``(session_id, skill_id)``, not bare
+        svc.bus.remove = MagicMock()
+        svc.shutdown()
+        stop_response_removals = [c for c in svc.bus.remove.call_args_list
+                                  if c[0][0] == "skillA.stop.response"]
+        self.assertEqual(len(stop_response_removals), 1)
+        self.assertEqual(svc._stop_listeners, set())
+
+
+class TestPreDrainSnapshotsAreRoundScoped(unittest.TestCase):
+    """`_pre_drain` is keyed by ``(utterance_id, skill_id)``, not bare
     ``skill_id``: two concurrent targeted stops for the same skill_id in
-    different sessions must not collide or consume each other's snapshot."""
+    different rounds must not collide or consume each other's snapshot."""
 
-    def test_interleaved_targeted_stops_same_skill_different_sessions(self):
+    def test_interleaved_targeted_stops_same_skill_different_rounds(self):
         svc = _make_service()
         svc.bus.emit = MagicMock()
 
-        # Session A: skill_a is blocked in get_response (RESPONSE state) ->
+        # Round A: skill_a is blocked in get_response (RESPONSE state) ->
         # its confirmation must trigger abort_question.
         sess_a = Session("session_a")
         sess_a.enable_response_mode("skill_a")
 
-        # Session B: skill_a is merely active via converse (INTENT state) ->
+        # Round B: skill_a is merely active via converse (INTENT state) ->
         # its confirmation must trigger converse.force_timeout, NOT
         # abort_question.
         sess_b = Session("session_b")
@@ -1328,21 +1364,21 @@ class TestPreDrainSnapshotsAreSessionScoped(unittest.TestCase):
 
         # interleave: A's pre-drain snapshot, then B's pre-drain snapshot,
         # both for the same skill_id, BEFORE either confirmation arrives.
-        match_a = svc._targeted_stop("skill_a", 1.0, "stop", sess_a)
-        match_b = svc._targeted_stop("skill_a", 1.0, "stop", sess_b)
+        match_a = svc._targeted_stop("skill_a", 1.0, "stop", sess_a, _round_message("uid-a"))
+        match_b = svc._targeted_stop("skill_a", 1.0, "stop", sess_b, _round_message("uid-b"))
         drained_a = match_a.updated_session
         drained_b = match_b.updated_session
 
         self.assertEqual(
             len(svc._pre_drain), 2,
-            "both sessions' snapshots must coexist, keyed independently")
+            "both rounds' snapshots must coexist, keyed independently")
 
         msg_a = Message("skill_a.stop.response",
                         data={"skill_id": "skill_a", "result": True},
-                        context={"session": drained_a.serialize()})
+                        context={"utterance_id": "uid-a", "session": drained_a.serialize()})
         msg_b = Message("skill_a.stop.response",
                         data={"skill_id": "skill_a", "result": True},
-                        context={"session": drained_b.serialize()})
+                        context={"utterance_id": "uid-b", "session": drained_b.serialize()})
 
         # A's confirmation arrives first, then B's.
         with patch("ovos_core.intent_services.stop_service.SessionManager.get",
@@ -1350,10 +1386,10 @@ class TestPreDrainSnapshotsAreSessionScoped(unittest.TestCase):
             svc.handle_stop_confirmation(msg_a)
         emitted_after_a = [c[0][0].msg_type for c in svc.bus.emit.call_args_list]
         self.assertIn("mycroft.skills.abort_question", emitted_after_a,
-                      "session A's own RESPONSE-state snapshot must drive its "
-                      "confirmation, not session B's")
+                      "round A's own RESPONSE-state snapshot must drive its "
+                      "confirmation, not round B's")
         self.assertNotIn("ovos.skills.converse.force_timeout", emitted_after_a,
-                         "session A was never converse-active; only its own "
+                         "round A was never converse-active; only its own "
                          "snapshot (RESPONSE-state) should be consulted")
 
         svc.bus.emit.reset_mock()
@@ -1362,13 +1398,175 @@ class TestPreDrainSnapshotsAreSessionScoped(unittest.TestCase):
             svc.handle_stop_confirmation(msg_b)
         emitted_after_b = [c[0][0].msg_type for c in svc.bus.emit.call_args_list]
         self.assertIn("ovos.skills.converse.force_timeout", emitted_after_b,
-                      "session B's own converse-active snapshot must drive "
-                      "its confirmation, not session A's (already-consumed) one")
+                      "round B's own converse-active snapshot must drive "
+                      "its confirmation, not round A's (already-consumed) one")
         self.assertNotIn("mycroft.skills.abort_question", emitted_after_b,
-                         "session B was never in RESPONSE state; the bug would "
-                         "have it consume session A's leftover/absent snapshot")
+                         "round B was never in RESPONSE state; the bug would "
+                         "have it consume round A's leftover/absent snapshot")
 
         self.assertEqual(len(svc._pre_drain), 0)
+
+
+class TestPreDrainEvictedByUtteranceHandled(unittest.TestCase):
+    """The ONLY `_pre_drain` eviction is `ovos.utterance.handled` (§9.5): the
+    universal, exactly-once-per-round end marker. A discarded Match's
+    snapshot dies with its own round's end marker; a barge-in for a NEW
+    utterance in the SAME session must never evict a different round's
+    still-pending (dispatched) snapshot."""
+
+    def test_discarded_match_snapshot_evicted_by_its_own_end_marker(self):
+        svc = _make_service()
+        svc.bus.emit = MagicMock()
+
+        sess = Session("discarded-sess")
+        sess.activate_skill("skillA")
+
+        # match() builds the Match and records the snapshot, but the
+        # orchestrator discards it (e.g. blacklist, missing slots, a
+        # higher-priority Match wins) -- never dispatched.
+        svc._targeted_stop("skillA", 1.0, "stop", sess, _round_message("uid-discarded"))
+        self.assertEqual(len(svc._pre_drain), 1)
+
+        # this round's own §9.5 end marker fires regardless of whether a
+        # Match from it was ever dispatched.
+        svc._on_utterance_handled(Message(
+            SpecMessage.UTTERANCE_HANDLED.value, {},
+            {"utterance_id": "uid-discarded"}))
+
+        self.assertEqual(len(svc._pre_drain), 0,
+                         "the discarded Match's snapshot must be evicted by "
+                         "its own round's end marker")
+
+        # skillA later answers a genuine, unrelated .stop.response carrying a
+        # DIFFERENT round id (e.g. a global stop's own ping-pong round trip
+        # in a later utterance) -- no snapshot is left to resolve against.
+        svc.handle_stop_confirmation(Message(
+            "skillA.stop.response",
+            {"skill_id": "skillA", "result": True},
+            {"skill_id": "skillA", "utterance_id": "uid-later",
+             "session": sess.serialize()}))
+
+        emitted = [c[0][0].msg_type for c in svc.bus.emit.call_args_list]
+        self.assertEqual(
+            emitted, [],
+            "a discarded Match's evicted snapshot must not fire kill signals "
+            f"for a stop it never caused, got {emitted!r}")
+
+    def test_barge_in_same_session_does_not_evict_a_different_dispatched_round(self):
+        """A NEW utterance (a barge-in) in the SAME session must not evict a
+        still-running, dispatched stop's snapshot from an EARLIER round --
+        only that earlier round's own end marker may."""
+        svc = _make_service()
+        svc.bus.emit = MagicMock()
+
+        sess = Session("bargein-sess")
+        sess.activate_skill("skillA")
+
+        # round 1: a targeted stop is dispatched (genuinely, not discarded)
+        # and is still awaiting its .stop.response.
+        match = svc._targeted_stop("skillA", 1.0, "stop", sess, _round_message("uid-1"))
+        self.assertEqual(len(svc._pre_drain), 1)
+
+        # round 2: a NEW utterance barges in on the SAME session and
+        # concludes (its own end marker fires) before round 1's stop() ever
+        # answers.
+        svc._on_utterance_handled(Message(
+            SpecMessage.UTTERANCE_HANDLED.value, {},
+            {"utterance_id": "uid-2", "session": sess.serialize()}))
+
+        self.assertEqual(len(svc._pre_drain), 1,
+                         "a different round's end marker must not evict "
+                         "round 1's still-pending snapshot")
+
+        # round 1's stop() finally answers -- it must still resolve.
+        svc.handle_stop_confirmation(Message(
+            "skillA.stop.response",
+            {"skill_id": "skillA", "result": True},
+            {"skill_id": "skillA", "utterance_id": "uid-1",
+             "session": match.updated_session.serialize()}))
+
+        emitted = [c[0][0].msg_type for c in svc.bus.emit.call_args_list]
+        self.assertIn("ovos.skills.converse.force_timeout", emitted,
+                      "round 1's dispatched stop must still resolve after "
+                      "surviving the barge-in in round 2")
+        self.assertEqual(len(svc._pre_drain), 0)
+
+        # round 1's own (belated) end marker is a no-op -- already consumed.
+        svc._on_utterance_handled(Message(
+            SpecMessage.UTTERANCE_HANDLED.value, {}, {"utterance_id": "uid-1"}))
+        self.assertEqual(len(svc._pre_drain), 0)
+
+    def test_dispatched_match_still_registers_and_resolves(self):
+        """Sanity companion: a Match that IS dispatched and confirmed
+        resolves correctly and clears its own snapshot."""
+        svc = _make_service()
+        svc.bus.emit = MagicMock()
+
+        sess = Session("dispatched-sess")
+        sess.enable_response_mode("skillA")
+
+        match = svc._targeted_stop("skillA", 1.0, "stop", sess, _round_message("uid-1"))
+        self.assertEqual(len(svc._pre_drain), 1)
+
+        svc.handle_stop_confirmation(Message(
+            "skillA.stop.response",
+            {"skill_id": "skillA", "result": True},
+            {"skill_id": "skillA", "utterance_id": "uid-1",
+             "session": match.updated_session.serialize()}))
+
+        emitted = [c[0][0].msg_type for c in svc.bus.emit.call_args_list]
+        self.assertIn("mycroft.skills.abort_question", emitted)
+        self.assertEqual(len(svc._pre_drain), 0)
+
+
+class TestPreDrainCrossSessionIsolationOnDispatch(unittest.TestCase):
+    """Two sessions targeting the same skill_id must both be resolved
+    correctly over the real bus: the listener is a single PERMANENT
+    `bus.on` per skill_id (not a fresh `bus.once` per dispatch, which pyee
+    dedupes by (topic, function) and would silently drop a second
+    concurrent session's confirmation for the same skill_id)."""
+
+    def test_two_sessions_same_skill_both_resolve_over_the_bus(self):
+        svc = _make_service()
+        bus = svc.bus
+        emitted = []
+        orig_emit = bus.emit
+
+        def capture(m):
+            emitted.append(m)
+            return orig_emit(m)
+
+        bus.emit = capture
+
+        sess_1 = Session("sess-1")
+        sess_1.enable_response_mode("skillA")  # RESPONSE state
+        sess_2 = Session("sess-2")
+        sess_2.activate_skill("skillA")  # INTENT state (converse-active)
+
+        match_1 = svc._targeted_stop("skillA", 1.0, "stop", sess_1, _round_message("uid-1"))
+        match_2 = svc._targeted_stop("skillA", 1.0, "stop", sess_2, _round_message("uid-2"))
+        self.assertEqual(len(svc._pre_drain), 2)
+
+        # both sessions' skillA answer on the SAME topic, over the real bus
+        # (the single permanent listener bound for "skillA").
+        bus.emit(Message("skillA.stop.response",
+                         {"skill_id": "skillA", "result": True},
+                         {"skill_id": "skillA", "utterance_id": "uid-1",
+                          "session": match_1.updated_session.serialize()}))
+        bus.emit(Message("skillA.stop.response",
+                         {"skill_id": "skillA", "result": True},
+                         {"skill_id": "skillA", "utterance_id": "uid-2",
+                          "session": match_2.updated_session.serialize()}))
+
+        emitted_types = [m.msg_type for m in emitted]
+        self.assertIn("mycroft.skills.abort_question", emitted_types,
+                      "round 1's RESPONSE-state snapshot must still fire "
+                      "abort_question")
+        self.assertIn("ovos.skills.converse.force_timeout", emitted_types,
+                      "round 2's converse-active snapshot must still fire "
+                      "force_timeout, not be dropped by a once() dedupe")
+        self.assertEqual(len(svc._pre_drain), 0,
+                         "both rounds' snapshots must be consumed")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Sonnet 5 (claude-sonnet-5) via Claude Code — NOT human-reviewed. Verify before acting.

The previous revision of this PR fixed the race, the leak and the `once()`-dedupe drop, but its evictors (`_on_intent_matched`/`_on_intent_unmatched`) still keyed `_pre_drain` by `session_id`. That leaves one real defect: a barge-in for a NEW utterance in the SAME session — an ordinary Match landing while an earlier targeted stop is still genuinely dispatched and awaiting its `.stop.response` — evicts that still-running stop's snapshot. Its kill signals (`abort_question`/`converse.force_timeout`) are lost, its dispatcher-lifecycle done-signal is never emitted, and its §8 entry sits parked on the 5-minute timeout.

The fix keys `_pre_drain` by `(utterance_id, skill_id)` instead of `(session_id, skill_id)`. `match()` receives the utterance Message whose `context["utterance_id"]` the orchestrator stamps once at lifecycle entry (§9.1.1), and `_targeted_stop` now takes that Message and records the snapshot under it. The `<skill_id>:stop` dispatch is forwarded/replied from that same Message down the whole chain, and the skill's `.stop.response` is itself a reply of it, so both sides of the round trip carry the same `utterance_id` for `handle_stop_confirmation` to key its lookup on. The only eviction left is `ovos.utterance.handled` — PIPELINE-1 §9.5's universal, exactly-once-per-round end marker. A snapshot still pending when its OWN round's end marker fires is stale (never dispatched, or dispatched but never answered) and gets dropped; a dispatched, genuinely-answered stop is always popped by `handle_stop_confirmation` before its own round's end marker, and a different round's end marker can never touch it. `_on_intent_matched`, `_on_intent_unmatched` and `_evict_pre_drain` are deleted along with their subscriptions, and `shutdown()` now removes the end-marker subscription plus the per-skill_id `.stop.response` listeners.

A missing `utterance_id` — a V0/direct-invocation caller that never entered through the orchestrator's §9.1.1 stamping — has no round to key the snapshot by, so `_targeted_stop` skips recording it and logs once at debug; the stop still dispatches, it just loses the automatic kill-signal and dispatcher-lifecycle resolution. `stop_service_legacy.py`'s `_LegacyStopBridge` was checked directly to confirm it does not already cover this case: it only bridges pre-STOP-1 dispatch topics (`stop:global`/`stop:skill` inbound, `mycroft.stop`/`<skill_id>.stop` outbound) via its own `ovos.intent.matched` observer, has no `.stop.response`/confirmation path at all, and does nothing with `utterance_id`. The fallback above stands on its own rather than on that assumption.

Fail-before: reverting the source to `origin/dev` fails 20 tests in `test/unittests/test_stop_service.py`, either on the now-deleted evictor methods or on `_targeted_stop`'s new required `message` argument. The new barge-in regression test (`TestPreDrainEvictedByUtteranceHandled::test_barge_in_same_session_does_not_evict_a_different_dispatched_round`) also fails against the immediately preceding revision of this branch (the session-keyed evictors) with the same signature mismatch, confirming it exercises code this fix actually changed. Restoring the fix turns all 59 tests in the file green.

The full `test/unittests` suite passes 505 tests with 6 xfailed (the pre-existing baseline was 500 passed / 6 xfailed; 5 new/reworked tests account for the difference). `test/end2end/test_stop_legacy_e2e.py`, `test/end2end/test_stop_response_mode_e2e.py` and `test/end2end/test_stop_spec_e2e.py` all pass (6 tests), exercising `utterance_id` propagation through the real `service.py`/dispatcher round trip end to end.