### PR TITLE
fix: bring the stop pipeline in line with OVOS-STOP-1 and PIPELINE-1 §7.3

### DIFF
--- a/ovos_core/intent_services/fallback_service.py
+++ b/ovos_core/intent_services/fallback_service.py
@@ -240,6 +240,12 @@ class FallbackService(ConfidenceMatcherPipeline):
                                 "utterances": utterances,
                                 "lang": lang},
                     utterance=utterances[0],
+                    # OVOS-PIPELINE-1 §7.3: `fallback` PUSHES onto
+                    # `active_handlers` -- "the dispatch *is* its activation".
+                    # The push is keyed on `Match.skill_id` (§7.1), so without
+                    # it the handler stays invisible to OVOS-STOP-1's cascade
+                    # and ineligible for a converse follow-up.
+                    skill_id=skill_id,
                     updated_session=sess
                 )
 

--- a/ovos_core/intent_services/manifest.py
+++ b/ovos_core/intent_services/manifest.py
@@ -134,15 +134,15 @@ class IntentManifest:
             LOG.warning(f"malformed intent registration from {skill_id!r}: missing required fields")
             return
         if intent_name == "stop":
-            # OVOS-STOP-1 reserves "<skill_id>:stop" for the pipeline's own
-            # targeted-stop dispatch (stop_service.py _targeted_stop); a real
-            # intent registered under the same name binds the identical topic
-            # and is shadowed by / collides with the reserved dispatch.
+            # OVOS-STOP-1 §2: "Skills and other pipelines MUST NOT register
+            # `stop`". Such a registration is malformed under OVOS-INTENT-4
+            # §5.3/§6.3 and PIPELINE-1 §7.3 — "log at WARN, do not index".
             LOG.warning(
                 f"skill '{skill_id}' registered an intent literally named 'stop' — "
-                f"this collides with the OVOS-STOP-1 reserved '{skill_id}:stop' "
-                "targeted-dispatch topic, so both the registered intent handler "
-                "and the stop machinery will react to messages on that topic.")
+                f"'stop' is reserved by OVOS-STOP-1 for the '{skill_id}:stop' "
+                "targeted-dispatch topic, so this registration is malformed "
+                "and is not indexed.")
+            return
         session_id = raw_session_id(message)
         if session_id is None:
             # malformed carrier (OVOS-SESSION-1 §2.5): already logged; drop

--- a/ovos_core/intent_services/service.py
+++ b/ovos_core/intent_services/service.py
@@ -42,7 +42,7 @@ from ovos_core.intent_services.manifest import IntentManifest
 from ovos_core.intent_services.working_session import (
     close_round, open_round, pruned_entries, record_pruned, round_session, working_session,
 )
-from ovos_core.version import OVOS_VERSION_STR
+from ovos_core.version import OVOS_VERSION_STR, VERSION_MAJOR
 from ovos_plugin_manager.pipeline import OVOSPipelineFactory
 from ovos_plugin_manager.templates.pipeline import IntentHandlerMatch, ConfidenceMatcherPipeline
 
@@ -81,31 +81,51 @@ _PIPELINE_MIGRATION_MAP = {
 
 _PIPELINE_RE = re.compile(r'-(high|medium|low)$')
 
-# OVOS-PIPELINE-1 §7.3 reserved intent_names. A Match produced by one of the
-# reserving pipeline-plugin roles below is a reserved-name dispatch: §7.1
-# requires the ``session.active_handlers`` push to be SUPPRESSED for it, because
-# a reserved name represents a continuation/termination of an already-active
-# skill's participation, not a fresh activation. Keyed off the producing
-# pipeline_id (the role that holds the namespace lease), with the confidence
-# suffix (``-high``/``-medium``/``-low``) stripped before lookup.
+# OVOS-PIPELINE-1 §7.3 reserved intent_names, with the registry's "activation
+# push" column. §7.1: "Suppression MUST be keyed on the Match's ``intent_name``
+# and its registry row — never on the producing ``pipeline_id``". §7.3 states
+# the column per row rather than for reserved names as a class:
 #
-#   converse       -> ovos-converse-pipeline-plugin     (CONVERSE-1 §4/§5: converse, response)
-#   fallback       -> ovos-fallback-pipeline-plugin      (FALLBACK-1 §6.3: fallback)
-#   common_query   -> ovos-common-query-pipeline-plugin  (COMMON-QUERY-1 §3: common_query)
+#   converse      suppressed  (CONVERSE-1 §4)      continues an existing participation
+#   response      suppressed  (CONVERSE-1 §5)      continues an existing participation
+#   stop          suppressed  (STOP-1 §4)          ends an existing participation
+#   common_query  suppressed  (COMMON-QUERY-1 §3)  runs the plugin's own bundled handler
+#   fallback      PUSHES      (FALLBACK-1 §6.3)    the dispatch *is* its activation
 #
-# OVOS-STOP-1 dispatches (``stop``/``global_stop``) also suppress the §7.1 push,
-# but express it per-Match via ``IntentHandlerMatch.suppress_activation`` (§6.2)
-# rather than through this pipeline_id table.
+# ``global_stop`` is not a reserved intent_name (STOP-1 §2), so it pushes: §5.2
+# requires the committed post-dispatch ``active_handlers`` to hold exactly the
+# stop plugin's own entry.
+_ACTIVATION_PUSH_SUPPRESSED = {"converse", "response", "stop", "common_query"}
+
+# Pre-spec fallback for producers that have not migrated to spec-shaped
+# ``intent_name``s yet. Their match_types carry no recognizable reserved name —
+# ``converse:skill``, ``<skill_id>.converse.get_response``,
+# ``question:action.<skill_id>`` — so the rule above cannot see them and the
+# §7.3 suppression they are entitled to would be lost. Keyed off the producing
+# pipeline_id, with the confidence suffix stripped, until each producer emits
+# the reserved name:
+#
+#   converse plugin                  -> ``<skill_id>:converse`` / ``<skill_id>:response``
+#   ovos-common-query-pipeline-plugin -> ``<pipeline_id>:common_query``
+#
+# Removed in ovos-core _RESERVED_PIPELINE_FALLBACK_REMOVAL_VERSION, at which
+# point suppression is keyed on intent_name alone as §7.1 requires. The
+# fallback plugin is deliberately absent: §7.3 marks ``fallback`` as PUSHING,
+# and listing it here is what suppressed the push it is owed.
 _RESERVED_NAME_PIPELINES = {
     "ovos-converse-pipeline-plugin",
-    "ovos-fallback-pipeline-plugin",
     "ovos-common-query-pipeline-plugin",
 }
 
+_RESERVED_PIPELINE_FALLBACK_REMOVAL_VERSION = f"{VERSION_MAJOR + 1}.0.0"
+
 
 def _produces_reserved_name(pipeline_id: Optional[str]) -> bool:
-    """OVOS-PIPELINE-1 §7.3: True when ``pipeline_id`` is a reserved-name role
-    whose dispatches must NOT stamp ``session.active_handlers`` (§7.1)."""
+    """Whether ``pipeline_id`` is an unmigrated reserved-name producer.
+
+    Transitional companion to ``_ACTIVATION_PUSH_SUPPRESSED``; see the comment
+    above for the producers it covers and when it goes away.
+    """
     if not pipeline_id:
         return False
     return _PIPELINE_RE.sub("", pipeline_id) in _RESERVED_NAME_PIPELINES
@@ -731,20 +751,19 @@ class IntentService:
                 reply.context["skill_id"] = match.skill_id
 
                 was_deactivated = match.skill_id in self._deactivations[sess.session_id]
-                # ``suppress_activation`` (OVOS-STOP-1 §6.2/§7.3) marks a dispatch
-                # that terminates an already-active skill's participation — a stop —
-                # so it must register no activation at all: neither the §7.1
-                # ``active_handlers`` push nor the ``{skill_id}.activate`` callback.
-                if not was_deactivated and not match.suppress_activation:
-                    # OVOS-PIPELINE-1 §7.1 pushes the skill onto the session's
-                    # active-handler recency list. §7.3 SUPPRESSES that push for
-                    # reserved intent_name dispatches (converse/response/
-                    # fallback/common_query): a reserved name is a continuation
-                    # or termination of an already-active skill's participation,
-                    # not a fresh activation. `activate_skill` is a back-compat
-                    # shim over `add_active_handler` (§7.1) in current bus-client.
-                    if not _produces_reserved_name(pipeline_id):
-                        sess.activate_skill(match.skill_id)
+                # OVOS-PIPELINE-1 §7.1 pushes the skill onto the session's
+                # active-handler recency list; §7.3's registry suppresses that
+                # push per reserved intent_name, keyed on the Match's
+                # `intent_name` and never on the producing pipeline_id.
+                # `_produces_reserved_name` is the transitional second gate for
+                # producers still emitting pre-spec match_types.
+                # `activate_skill` is a back-compat shim over
+                # `add_active_handler` (§7.1) in current bus-client.
+                dispatched_intent = match.match_type.split(":", 1)[-1]
+                if not was_deactivated and \
+                        dispatched_intent not in _ACTIVATION_PUSH_SUPPRESSED and \
+                        not _produces_reserved_name(pipeline_id):
+                    sess.activate_skill(match.skill_id)
                     # emit event for skills callback -> self.handle_activate
                     self.bus.emit(reply.forward(f"{match.skill_id}.activate"))
 

--- a/ovos_core/intent_services/stop_service.py
+++ b/ovos_core/intent_services/stop_service.py
@@ -1,6 +1,6 @@
 from os.path import dirname, join
 from threading import Event
-from typing import Optional, Dict, List, NamedTuple, Tuple, Union
+from typing import Optional, Dict, List, NamedTuple, Set, Tuple, Union
 
 from ovos_bus_client.client import MessageBusClient
 from ovos_bus_client.handler import HandlerLifecycle
@@ -16,7 +16,11 @@ from ovos_utils.log import LOG
 from ovos_utils.parse import match_one
 
 from ovos_core.intent_services.stop_service_legacy import _LegacyStopBridge
-from ovos_core.intent_services.working_session import raw_session_id
+from ovos_core.version import VERSION_MAJOR
+
+#: Removal is scheduled for the next major release; derived from version.py so
+#: the deprecation notice never goes stale.
+_LEGACY_PING_REMOVAL_VERSION = f"{VERSION_MAJOR + 1}.0.0"
 
 
 class PreDrainSnapshot(NamedTuple):
@@ -24,9 +28,15 @@ class PreDrainSnapshot(NamedTuple):
 
     ``match()`` drains ``active_handlers``/``response_mode`` before dispatch,
     so by the time ``.stop.response`` arrives the live session already lies
-    about both fields. Capture them together at drain time, keyed by
-    ``(session_id, skill_id)``, and pop them together in
-    ``handle_stop_confirmation`` before either result branch runs.
+    about both fields. OVOS-PIPELINE-1 §4.2 permits a plugin's own bus side
+    effects and internal bookkeeping inside ``match()`` — this is recorded
+    there, keyed by ``(utterance_id, skill_id)``, and popped in
+    ``handle_stop_confirmation`` before either result branch runs. Keying by
+    the round rather than the session means a barge-in for a NEW utterance in
+    the same session can never evict a still-running dispatched stop's
+    snapshot — only that round's own §9.5 ``ovos.utterance.handled`` end
+    marker does (see ``_on_utterance_handled``), and a dispatched stop is
+    always consumed before its own round's end marker fires.
     """
     was_active: bool
     utt_state: UtteranceState
@@ -45,10 +55,11 @@ class StopService(ConfidenceMatcherPipeline):
       ``active_handlers`` (§4.1 step 1), or no positive pong responder
       (§4.1 step 5).
 
-    Both dispatches set ``suppress_activation`` (§6.2/§7.3): a stop terminates
-    an already-active skill's participation, so it registers no fresh
-    activation. The session drain mandated by §5.2/§6 is committed via
-    ``Match.updated_session`` before dispatch.
+    The reserved ``stop`` intent_name suppresses the OVOS-PIPELINE-1 §7.1
+    activation push by the §7.3 registry; ``global_stop`` is not reserved and
+    pushes (STOP-1 §5.2). Neither is a property of the Match — the
+    orchestrator reads the registry. The session drain mandated by §5.2/§6 is
+    committed via ``Match.updated_session`` before dispatch.
     """
 
     #: OVOS-STOP-1 §3.1 shared identity. Every confidence tier reports the same
@@ -56,23 +67,29 @@ class StopService(ConfidenceMatcherPipeline):
     #: tiers and exactly one ``ovos.stop`` broadcast is emitted per event.
     pipeline_id = "ovos-stop-pipeline-plugin"
 
+    #: one-shot guard for the legacy per-skill ping deprecation notice
+    _warned_legacy_ping = False
+
     def __init__(self, bus: Optional[Union[MessageBusClient, FakeBus]] = None,
-                 config: Optional[Dict] = None,
-                 suppress_activation: bool = True) -> None:
+                 config: Optional[Dict] = None) -> None:
         config = config if config is not None else Configuration().get("skills", {}).get("stop") or {}
         bus = bus or FakeBus()
         ConfidenceMatcherPipeline.__init__(self, config=config, bus=bus)
         self._locale = LocaleResources(skill_locale=join(dirname(__file__), "locale"))
-        #: Stamped onto every Match this plugin returns (§6.2/§7.3).
-        self.suppress_activation = suppress_activation
         # §5 global-stop dispatch target; bound once, shared across tiers (§3.1).
         self.bus.on(f"{self.pipeline_id}:global_stop", self.handle_global_stop)
+        # The ONLY `_pre_drain` eviction: §9.5's universal, exactly-once-per-
+        # round end marker.
+        self.bus.on(SpecMessage.UTTERANCE_HANDLED.value, self._on_utterance_handled)
         self._legacy = _LegacyStopBridge(self)
-        #: (session_id, skill_id) -> PreDrainSnapshot captured by _targeted_stop
-        #: and consumed once by handle_stop_confirmation. Keyed per-session
-        #: (not bare skill_id) so two concurrent targeted stops for the same
-        #: skill_id in different sessions can't clobber each other's snapshot.
+        #: (utterance_id, skill_id) -> PreDrainSnapshot recorded by
+        #: `_targeted_stop` and consumed once by `handle_stop_confirmation`.
+        #: Keyed per-round (not bare skill_id) so two concurrent targeted
+        #: stops for the same skill_id can't clobber each other's snapshot.
         self._pre_drain: Dict[Tuple[str, str], PreDrainSnapshot] = {}
+        #: skill_ids with a permanent `<skill_id>.stop.response` listener
+        #: already bound (see `_targeted_stop`).
+        self._stop_listeners: Set[str] = set()
 
     def handle_global_stop(self, message: Message) -> None:
         """OVOS-STOP-1 §5.3 — broadcast the universal ``ovos.stop``.
@@ -80,23 +97,15 @@ class StopService(ConfidenceMatcherPipeline):
         Bound on ``<pipeline_id>:global_stop`` and wrapped in HandlerLifecycle
         so the orchestrator observes the §8 terminal for the dispatch.
 
-        A ``response_mode`` holder (OVOS-CONVERSE-1 §2.2 pending get_response
-        window) is carried through ``Match.match_data`` (``_global_stop``) as
-        ``response_mode_holder`` — the global broadcast alone (``ovos.stop`` /
-        legacy ``mycroft.stop``) is never observed by ovos-workshop's
-        killable-event abort, which listens ONLY on the per-skill
-        ``<skill_id>.stop`` topic. Without this, a skill blocked in
-        ``get_response`` survives a global stop until its own timeout. Emit
-        the targeted topic first — the session's response_mode has already
-        been cleared via ``updated_session`` by dispatch time, so this only
-        needs to reach the still-blocked handler.
+        §5.3 names exactly one emission: "The handler dispatched by
+        ``<pipeline_id>:global_stop`` MUST emit ``ovos.stop``". No per-skill
+        topic is emitted alongside it — a component with user-visible activity
+        subscribes to ``ovos.stop`` and ceases activity for the session_id in
+        Message context.
         """
         with HandlerLifecycle(self.bus, message,
                               skill_id=self.pipeline_id,
                               data={"name": "StopService.handle_global_stop"}):
-            holder = message.data.get("response_mode_holder")
-            if holder:
-                self.bus.emit(message.forward(f"{holder}.stop"))
             self.bus.emit(message.forward(SpecMessage.STOP.value))
 
     @staticmethod
@@ -106,11 +115,21 @@ class StopService(ConfidenceMatcherPipeline):
         This is the OVOS-STOP-1 §4.1 recency input (``active_handlers``): the
         order in which stop is attempted.
 
+        OVOS-PIPELINE-1 §7.1 defines the recency order once, normatively, and
+        forbids consumers from defining their own: ``activated_at`` is
+        authoritative, and entries sharing an ``activated_at`` are ordered by
+        proximity to the head of the list. Sorting is stable, so listing the
+        entries head-first and sorting by descending ``activated_at`` applies
+        both rules.
+
         Returns:
             active_skills (list): ordered list of skill_ids
         """
         session = SessionManager.get(message)
-        return [h["skill_id"] for h in session.active_handlers]
+        handlers = sorted(session.active_handlers,
+                          key=lambda h: h.get("activated_at") or 0,
+                          reverse=True)
+        return [h["skill_id"] for h in handlers]
 
     @staticmethod
     def get_response_mode_holder(message: Optional[Message] = None) -> Optional[str]:
@@ -129,19 +148,26 @@ class StopService(ConfidenceMatcherPipeline):
     def _stop_candidates(self, message: Message) -> List[str]:
         """OVOS-STOP-1 §4.1 recency-ordered stop candidates.
 
-        A response_mode holder ranks FIRST — it is the most recent
-        interaction by definition, even when ``active_handlers`` is empty
-        (see ``get_response_mode_holder``) — followed by the recency-ordered
-        ``active_handlers`` list, minus blacklisted skills and de-duplicated.
+        §4.1's candidate set "additionally includes, as its first member, the
+        ``skill_id`` named by ``session.response_mode``" — CONVERSE-1 §2.2
+        sets that field with no ``active_handlers`` push, so its holder would
+        otherwise be invisible despite being the most recent interaction by
+        construction. The recency-ordered ``active_handlers`` entries follow.
+
+        The §4.1 candidate filter then drops, before any recency comparison,
+        an entry whose ``skill_id`` is blacklisted (§6.3) or equals this
+        plugin's own ``pipeline_id`` — the entry §7.1 stamps for a preceding
+        ``global_stop`` dispatch. "The stop plugin is never its own stop
+        target."
         """
         sess = SessionManager.get(message)
         blacklisted = sess.blacklisted_skills or []
         candidates: List[str] = []
         holder = self.get_response_mode_holder(message)
-        if holder and holder not in blacklisted:
-            candidates.append(holder)
-        for skill_id in self.get_active_skills(message):
-            if skill_id not in candidates and skill_id not in blacklisted:
+        for skill_id in [holder] + self.get_active_skills(message):
+            if skill_id and skill_id not in candidates \
+                    and skill_id not in blacklisted \
+                    and skill_id != self.pipeline_id:
                 candidates.append(skill_id)
         return candidates
 
@@ -194,10 +220,12 @@ class StopService(ConfidenceMatcherPipeline):
                           f"round session {round_session_id!r}")
                 return
 
-            # validate the stop pong; default False — a non-responding skill
-            # should not be assumed stoppable (§4.2)
+            # §4.2: a pong is valid only when it carries a `skill_id` string
+            # and a `can_handle` BOOLEAN — "a truthy non-boolean value MUST
+            # NOT be coerced to true". A missing or non-boolean `can_handle`
+            # leaves the responder not stoppable for this round.
             if all((skill_id not in want_stop,
-                    msg.data.get("can_handle", False),
+                    msg.data.get("can_handle") is True,
                     skill_id in active_skills)):
                 want_stop.append(skill_id)
 
@@ -215,7 +243,21 @@ class StopService(ConfidenceMatcherPipeline):
         # legacy emission (verified against the installed translator).
         self.bus.on(SpecMessage.STOP_PONG.value, handle_ack)
         try:
-            # ask skills if they can stop
+            # §4.1 step 2 / §4.2: one `ovos.stop.ping` BROADCAST, derived via
+            # `reply` from the inbound utterance Message so it carries the
+            # inbound session_id and the utterance emitter's routing metadata.
+            self.bus.emit(message.reply(SpecMessage.STOP_PING.value))
+            # Pre-spec compatibility: skills that predate the broadcast only
+            # answer their own `<skill_id>.stop.ping`. Dropped in ovos-core
+            # `_LEGACY_PING_REMOVAL_VERSION`.
+            if not StopService._warned_legacy_ping:
+                StopService._warned_legacy_ping = True
+                LOG.warning(
+                    "Emitting the pre-STOP-1 per-skill '<skill_id>.stop.ping' "
+                    "alongside the 'ovos.stop.ping' broadcast for backward "
+                    f"compatibility; removed in ovos-core "
+                    f"{_LEGACY_PING_REMOVAL_VERSION}. Migrate skills to "
+                    "subscribe to 'ovos.stop.ping'.")
             for skill_id in active_skills:
                 self.bus.emit(message.forward(f"{skill_id}.stop.ping",
                                               {"skill_id": skill_id}))
@@ -238,107 +280,82 @@ class StopService(ConfidenceMatcherPipeline):
         return sorted(want_stop, key=active_skills.index)
 
     def handle_stop_confirmation(self, message: Message) -> None:
-        """Handle a skill's stop.response and force-terminate any in-flight interactions.
+        """Force-terminate the in-flight interactions a targeted stop killed.
 
-        Also resolves the ``IntentDispatcher``'s §8 handler-lifecycle entry for
-        this ``<skill_id>:stop`` dispatch: the dispatch goes out on the spec
-        colon-topic ``<skill_id>:stop``, which ovos-workshop has no direct
-        listener for, so nothing else emits the normal completion signal for
-        it. This ``.stop.response`` is the real completion signal — it only
-        fires once ``stop()`` has actually finished — so it is the correct
-        point to resolve the dispatch, instead of leaving it parked on the
-        dispatcher's 5-minute §8.3 timeout. Emitting the framework done-signal
-        here, rather than reaching into ``IntentDispatcher`` directly, keeps
-        ``StopService`` decoupled from the dispatcher's internals.
+        PIPELINE-1 §8 gives the handler-lifecycle trio to the orchestrator
+        alone — "the orchestrator alone emits ``.complete`` on normal return
+        or ``.error`` on exception, and that terminal event resolves the stop
+        round. The stop handler does not emit either event itself" (STOP-1
+        §4.3). This listener therefore only fires the kill signals the
+        pre-drain snapshot says are owed.
+
+        The ``.stop.response`` listener is bound permanently per skill_id
+        (``_targeted_stop``), so this fires for every round's response for
+        that skill, not just the one that just dispatched it. A response with
+        no matching ``(utterance_id, skill_id)`` snapshot is therefore a
+        no-op: either this skill_id was never targeted by a stop for this
+        round, or its snapshot was already consumed/evicted.
         """
         skill_id = (message.data.get("skill_id") or
                     message.context.get("skill_id") or
                     message.msg_type.split(".stop.response")[0])
-        sess_id = raw_session_id(message)
-        if sess_id is None:
-            # malformed carrier (OVOS-SESSION-1 §2.5): already logged, and
-            # there is no (session_id, skill_id) key to resolve against.
+        utt_id = message.context.get("utterance_id")
+        if not utt_id:
+            # no round to correlate against (a V0/direct-invocation caller
+            # that never entered through the orchestrator's §9.1.1 stamping)
+            # -- `_targeted_stop` never records a snapshot for this case
+            # either, so there is nothing to resolve.
             return
-        # Pop both snapshots unconditionally before either branch below: the
-        # error/no-dispatch paths must not leak them or hold the
-        # _resolve_dispatch_lifecycle gate open for this (session_id, skill_id).
-        snapshot = self._pre_drain.pop((sess_id, skill_id), None)
-        try:
-            if snapshot is not None:
-                self._resolve_dispatch_lifecycle(message, skill_id)
-        except Exception:
-            LOG.exception(f"failed to resolve dispatch lifecycle for {skill_id}:stop")
+        snapshot = self._pre_drain.pop((utt_id, skill_id), None)
+        if snapshot is None:
+            return  # no pending targeted stop for this (round, skill) pair
         if 'error' in message.data:
-            error_msg = message.data['error']
-            LOG.error(f"{skill_id}: {error_msg}")
+            LOG.error(f"{skill_id}: {message.data['error']}")
         elif message.data.get('result', False):
-            sess = SessionManager.get(message)
-            # The session on this .stop.response is already post-drain, so
-            # live reads of utterance_states/active_handlers lie; consult the
-            # pre-drain snapshot popped above, falling back to the live read
-            # for direct-invocation callers that bypass _targeted_stop.
-            utt_state = snapshot.utt_state if snapshot else (
-                UtteranceState.RESPONSE
-                if sess.response_mode and sess.response_mode.get("skill_id") == skill_id
-                else UtteranceState.INTENT)
-            if utt_state == UtteranceState.RESPONSE:
+            if snapshot.utt_state == UtteranceState.RESPONSE:
                 LOG.debug("Forcing get_response timeout")
                 # force-kill any ongoing get_response - see @killable_event decorator (ovos-workshop)
                 self.bus.emit(message.reply("mycroft.skills.abort_question", {"skill_id": skill_id}))
-            was_active = snapshot.was_active if snapshot else sess.is_active(skill_id)
-            if was_active:
+            if snapshot.was_active:
                 LOG.debug("Forcing converse timeout")
                 # force-kill any ongoing converse - see @killable_event decorator (ovos-workshop)
                 self.bus.emit(message.reply("ovos.skills.converse.force_timeout", {"skill_id": skill_id}))
 
             # TODO - track if speech is coming from this skill! not currently tracked (ovos-audio)
-            if sess.is_speaking:
+            if SessionManager.get(message).is_speaking:
                 # force-kill any ongoing TTS
                 # SpecMessage.AUDIO_STOP.value == "ovos.audio.stop"; the
                 # translator's MIGRATION_MAP mirrors it onto the legacy
                 # "mycroft.audio.speech.stop" ovos-audio still listens on.
                 self.bus.emit(message.forward(SpecMessage.AUDIO_STOP.value, {"skill_id": skill_id}))
 
-    def _resolve_dispatch_lifecycle(self, message: Message, skill_id: str) -> None:
-        """Emit the framework done-signal for the ``<skill_id>:stop`` dispatch
-        this ``.stop.response`` concludes.
+    def _on_utterance_handled(self, message: Message) -> None:
+        """Evict every pending ``_pre_drain`` snapshot for a finished round.
 
-        ``IntentDispatcher._on_skill_complete``/``._on_skill_error`` listen for
-        exactly these topics and resolve the matching in-flight entry (by
-        session_id + skill_id + ``data["intent_name"]``), cancelling its §8.3
-        timeout timer. See ``handle_stop_confirmation``'s docstring for why
-        this lives here rather than in ovos-workshop.
-
-        ``data["intent_name"] = "stop"`` is stamped explicitly, since a
-        skill can have an ordinary intent handler running concurrently with
-        its ``.stop`` — the dispatcher's ``_pop`` needs it to resolve the
-        right in-flight entry rather than whichever is on top of the LIFO
-        stack. It goes on ``data``, not ``context``: see ``_pop``'s docstring
-        in dispatcher.py for why context is client-inherited and unsafe here.
-
-        §8.2: a ``.stop.response`` carrying ``error`` resolves as an
-        ``error`` terminal, not ``complete``.
+        ``ovos.utterance.handled`` (§9.5) is the universal end marker: exactly
+        one is emitted per utterance lifecycle, on every exit path (a
+        dispatched Match's §8 terminal, a discarded/blacklisted Match, no
+        Match at all). A snapshot still pending when its own round's end
+        marker fires can only belong to a Match that was never dispatched, or
+        was dispatched but never got a ``.stop.response`` back — either way
+        the round is over and the snapshot is stale. A dispatched, genuinely
+        answered stop is always popped by `handle_stop_confirmation` before
+        this fires, so this is a no-op for it.
         """
-        if 'error' in message.data:
-            done = message.forward("mycroft.skill.handler.error",
-                                   {"name": f"{skill_id}:stop",
-                                    "exception": message.data['error'],
-                                    "intent_name": "stop"})
-        else:
-            done = message.forward("mycroft.skill.handler.complete",
-                                   {"name": f"{skill_id}:stop",
-                                    "intent_name": "stop"})
-        done.context["skill_id"] = skill_id
-        self.bus.emit(done)
+        utt_id = message.context.get("utterance_id")
+        if not utt_id:
+            return
+        for key in [k for k in self._pre_drain if k[0] == utt_id]:
+            self._pre_drain.pop(key, None)
 
-    def _targeted_stop(self, skill_id: str, conf: float, utterance: str,
-                       sess: Session) -> IntentHandlerMatch:
+    def _targeted_stop(self, skill_id: str, utterance: str,
+                       sess: Session, message: Message) -> IntentHandlerMatch:
         """Build the OVOS-STOP-1 §2 targeted ``<skill_id>:stop`` Match.
 
         Drains the dispatch target from ``active_handlers`` and clears its
         ``response_mode`` entry (§6.1/§6.2) via ``Match.updated_session``. The
-        §7.1 stamping push is suppressed (``suppress_activation``, §7.3), so the
-        removal is the final state.
+        §7.1 stamping push is suppressed for the reserved ``stop``
+        intent_name by the §7.3 registry, so the removal is the final state.
 
         match() must not touch the live session: the orchestrator may still
         discard this Match (blacklisted intent, missing required slots, a
@@ -347,40 +364,50 @@ class StopService(ConfidenceMatcherPipeline):
         session if/when ``_dispatch_match`` actually commits it. The live
         ``sess`` passed in is read but never mutated.
 
-        This does have two side effects beyond building the Match: it records
-        a ``_pre_drain`` snapshot and registers a one-shot ``.stop.response``
-        listener, both keyed on ``(sess.session_id, skill_id)``. The snapshot
-        is only consumed by a ``.stop.response`` in the same session, so a
-        discarded Match leaves an entry that is never popped (no eviction), and
-        the stale listener survives to fire on the skill's NEXT genuine
-        ``.stop.response`` in this session — re-emitting the get_response/
-        converse kill signals for a stop this Match never actually caused.
+        Recording the ``_pre_drain`` snapshot and binding the (permanent,
+        per-skill_id) ``.stop.response`` listener here, in ``match()``, is
+        allowed by OVOS-PIPELINE-1 §4.2: a plugin's own bus registrations and
+        internal bookkeeping are not dispatch actions. If this Match is later
+        discarded, the snapshot is stale but not permanently leaked — it is
+        keyed by ``message.context["utterance_id"]`` (§9.1.1, stamped by the
+        orchestrator at lifecycle entry and carried by every derived Message),
+        so it dies with that round's own §9.5 end marker (see
+        ``_on_utterance_handled``) regardless of what happens to this Match.
         """
         LOG.debug(f"Telling skill to stop: {skill_id}")
-        # Captured before the drain: the post-drain session that reaches
-        # handle_stop_confirmation via the dispatch round-trip can no longer
-        # answer either question truthfully.
-        self._pre_drain[(sess.session_id, skill_id)] = PreDrainSnapshot(
-            was_active=sess.is_active(skill_id),
-            utt_state=(UtteranceState.RESPONSE
-                       if sess.response_mode and sess.response_mode.get("skill_id") == skill_id
-                       else UtteranceState.INTENT),
-        )
+        utt_id = message.context.get("utterance_id")
+        if not utt_id:
+            # No round to key the snapshot by (a V0/direct-invocation caller
+            # that never entered through the orchestrator's §9.1.1 stamping).
+            # The stop still dispatches; it just loses the automatic
+            # get_response/converse kill signals.
+            LOG.debug(f"no utterance_id on the stop Match for '{skill_id}'; "
+                      f"skipping the pre-drain snapshot")
+        else:
+            # Captured before the drain: the post-drain session that reaches
+            # handle_stop_confirmation via the dispatch round-trip can no
+            # longer answer either question truthfully.
+            self._pre_drain[(utt_id, skill_id)] = PreDrainSnapshot(
+                was_active=sess.is_active(skill_id),
+                utt_state=(UtteranceState.RESPONSE
+                           if sess.response_mode and sess.response_mode.get("skill_id") == skill_id
+                           else UtteranceState.INTENT),
+            )
+        if skill_id not in self._stop_listeners:
+            self._stop_listeners.add(skill_id)
+            self.bus.on(f"{skill_id}.stop.response", self.handle_stop_confirmation)
         drained = Session.deserialize(sess.serialize())
         drained.disable_response_mode(skill_id)
         drained.deactivate_skill(skill_id)
-        self.bus.once(f"{skill_id}.stop.response", self.handle_stop_confirmation)
         return IntentHandlerMatch(
             match_type=f"{skill_id}:stop",
-            match_data={"conf": conf, "skill_id": skill_id},
+            match_data={"skill_id": skill_id},
             updated_session=drained,
             utterance=utterance,
             skill_id=skill_id,
-            suppress_activation=self.suppress_activation,
         )
 
-    def _global_stop(self, conf: float, utterance: str,
-                     sess: Session) -> IntentHandlerMatch:
+    def _global_stop(self, utterance: str, sess: Session) -> IntentHandlerMatch:
         """Build the OVOS-STOP-1 §5 global ``<pipeline_id>:global_stop`` Match.
 
         Carries a fully-cleaned ``updated_session`` (§5.2): ``active_handlers``
@@ -393,26 +420,16 @@ class StopService(ConfidenceMatcherPipeline):
         session untouched.
         """
         LOG.info(f"Emitting global stop, {len(sess.active_handlers)} active skills")
-        # read-only: the pre-drain holder, carried through match_data so
-        # handle_global_stop (dispatch time, NOT here) can emit the targeted
-        # `<skill_id>.stop` a killable-event abort actually listens on — match()
-        # must not act on the world: this Match can still be discarded, so the
-        # targeted stop topic goes out at dispatch time.
-        holder = sess.response_mode.get("skill_id") if sess.response_mode else None
         drained = Session.deserialize(sess.serialize())
         drained.active_handlers = []
         drained.converse_handlers = []
         drained.clear_response_mode()
-        match_data = {"conf": conf}
-        if holder:
-            match_data["response_mode_holder"] = holder
         return IntentHandlerMatch(
             match_type=f"{self.pipeline_id}:global_stop",
-            match_data=match_data,
+            match_data={},
             updated_session=drained,
             utterance=utterance,
             skill_id=self.pipeline_id,
-            suppress_activation=self.suppress_activation,
         )
 
     def match_high(self, utterances: List[str], lang: str, message: Message) -> Optional[IntentHandlerMatch]:
@@ -432,16 +449,14 @@ class StopService(ConfidenceMatcherPipeline):
         is_global_stop = self._locale.voc_match(utterance, 'global_stop', lang, exact=True) or \
                          (is_stop and not self._stop_candidates(message))
 
-        conf = 1.0
-
         if is_global_stop:
-            return self._global_stop(conf, utterance, sess)
+            return self._global_stop(utterance, sess)
 
         if is_stop:
             # check if any skill can stop (§4 cascade)
             candidates = self._collect_stop_skills(message)
             if candidates:
-                return self._targeted_stop(candidates[0], conf, utterance, sess)
+                return self._targeted_stop(candidates[0], utterance, sess, message)
 
         return None
 
@@ -482,12 +497,16 @@ class StopService(ConfidenceMatcherPipeline):
         # check if any skill can stop (§4 cascade)
         candidates = self._collect_stop_skills(message)
         if candidates:
-            return self._targeted_stop(candidates[0], conf, utterance, sess)
+            return self._targeted_stop(candidates[0], utterance, sess, message)
 
         # no positive pong responder -> escalate to a §5 global stop
-        return self._global_stop(conf, utterance, sess)
+        return self._global_stop(utterance, sess)
 
     def shutdown(self) -> None:
         """Remove bus listeners registered by this service."""
         self.bus.remove(f"{self.pipeline_id}:global_stop", self.handle_global_stop)
+        self.bus.remove(SpecMessage.UTTERANCE_HANDLED.value, self._on_utterance_handled)
+        for skill_id in self._stop_listeners:
+            self.bus.remove(f"{skill_id}.stop.response", self.handle_stop_confirmation)
+        self._stop_listeners.clear()
         self._legacy.shutdown()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "ovos_bus_client>=2.11.1a1,<3.0.0",
     "ovos-plugin-manager>=2.11.1a1,<3.0.0",
     "ovos-config>=2.1.4a5,<4.0.0",
-    "ovos-workshop>=9.3.11a1,<10.0.0",
+    "ovos-workshop>=9.6.9a1,<10.0.0",
     "rapidfuzz>=3.6,<4.0",
     "ovos-spec-tools[langcodes]>=1.10.4a1,<2.0.0",
 ]

--- a/test/end2end/test_activate.py
+++ b/test/end2end/test_activate.py
@@ -239,9 +239,10 @@ class TestDeactivate(TestCase):
                 Message("skill.converse.pong",
                         data={"can_handle": True, "skill_id": self.skill_id},
                         context={"skill_id": self.skill_id}),
-                Message(f"{self.skill_id}.activate",
-                        data={},
-                        context={"skill_id": self.skill_id}),
+                # PIPELINE-1 §7.3 marks `converse` non-activating: the
+                # dispatch continues an existing participation, so no
+                # activation is registered and no activation callback
+                # fires.
                 # PIPELINE-1 §9.2: matched notification precedes the dispatch
                 Message(SpecMessage.INTENT_MATCHED,
                         data={"skill_id": self.skill_id,

--- a/test/end2end/test_converse.py
+++ b/test/end2end/test_converse.py
@@ -132,9 +132,10 @@ class TestConverse(TestCase):
                 Message("skill.converse.pong",
                         data={"can_handle": True, "skill_id": self.skill_id},
                         context={"skill_id": self.skill_id}),
-                Message(f"{self.skill_id}.activate",
-                        data={},
-                        context={"skill_id": self.skill_id}),
+                # PIPELINE-1 §7.3 marks `converse` non-activating: the
+                # dispatch continues an existing participation, so no
+                # activation is registered and no activation callback
+                # fires.
                 Message(INTENT_MATCHED,
                         data={"skill_id": self.skill_id, "intent_name": "converse:skill"},
                         context={"skill_id": self.skill_id}),
@@ -183,10 +184,10 @@ class TestConverse(TestCase):
                 Message("skill.converse.pong",
                         data={"can_handle": True, "skill_id": self.skill_id},
                         context={"skill_id": self.skill_id}),
-                Message(f"{self.skill_id}.activate",
-                        data={},
-                        context={"skill_id": self.skill_id}),
-
+                # PIPELINE-1 §7.3 marks `converse` non-activating: the
+                # dispatch continues an existing participation, so no
+                # activation is registered and no activation callback
+                # fires.
                 Message(INTENT_MATCHED,
                         data={"skill_id": self.skill_id, "intent_name": "converse:skill"},
                         context={"skill_id": self.skill_id}),

--- a/test/end2end/test_fallback.py
+++ b/test/end2end/test_fallback.py
@@ -64,6 +64,10 @@ class TestFallback(TestCase):
                               {"session": session.serialize(), "source": "A", "destination": "B"})
 
             final_session = deepcopy(session)
+            # PIPELINE-1 §7.3: the fallback dispatch activates its handler, so
+            # it is in active_handlers when the round ends -- what makes it
+            # reachable by OVOS-STOP-1 and eligible for a converse follow-up.
+            final_session.activate_skill(self.skill_id)
 
             test = End2EndTest(
                 minicroft=minicroft,
@@ -85,6 +89,11 @@ class TestFallback(TestCase):
                     Message("ovos.skills.fallback.ping",
                             {"utterances": ["hello world"], "lang": session.lang, "range": [90, 101]}),
                     Message("ovos.skills.fallback.pong", {"skill_id": self.skill_id, "can_handle": True}),
+                # PIPELINE-1 §7.3: `fallback` PUSHES onto active_handlers --
+                # "the dispatch *is* its activation" -- so the activation
+                # callback fires, unlike converse/response/stop/common_query.
+                    Message(f"{self.skill_id}.activate", {},
+                            {"skill_id": self.skill_id}),
                 # PIPELINE-1 §9.2: matched notification precedes the dispatch. The
                 # fallback match_type is the .request topic; it bears no ':' so
                 # skill_id/intent_name resolve to that topic.

--- a/test/end2end/test_stop_dispatch_resolution_e2e.py
+++ b/test/end2end/test_stop_dispatch_resolution_e2e.py
@@ -1,0 +1,154 @@
+"""End-to-end check that a targeted stop resolves on its handler's return.
+
+OVOS-PIPELINE-1 §8 gives the handler-lifecycle trio to the orchestrator that
+invokes the handler: "`start` before the call, then `complete` on normal return
+or `error` on exception. The handler itself does not emit anything."
+OVOS-STOP-1 §4.3 applies that to the stop dispatch — "the orchestrator alone
+emits `.complete` on normal return or `.error` on exception, and that terminal
+event resolves the stop round."
+
+So `<skill_id>:stop` is resolved by the dispatched handler returning, exactly
+like every other dispatch, and the §8.3 timeout is the exception path rather
+than the normal one. This exercises the whole round trip against a real
+ovos-workshop skill on a real MiniCroft bus: the orchestrator's `.complete`
+must arrive promptly, and the round must produce exactly one `§9.5`
+`ovos.utterance.handled` — "A conformant orchestrator MUST emit exactly one
+`ovos.utterance.handled` per entry-topic Message. Multiple emissions for one
+utterance are malformed; zero is malformed."
+
+The exactly-once assertion is the load-bearing half. The skill now emits a
+genuine framework done-signal for its stop handler, and core's StopService no
+longer synthesizes one; if both were to fire, the round would report two
+terminals for one dispatch.
+"""
+import time
+from threading import Event
+from unittest import TestCase
+
+from ovos_bus_client.message import Message
+from ovos_bus_client.session import Session
+from ovos_spec_tools import SpecMessage
+from ovos_utils import create_daemon
+from ovos_utils.log import LOG
+
+from ovoscope import get_minicroft
+
+SPEC_UTTERANCE = SpecMessage.UTTERANCE.value
+
+#: Generous next to the PIPELINE-1 §8.3 handler timeout the unresolved path
+#: would otherwise wait out (five minutes by default), tight enough that a
+#: parked dispatch cannot pass.
+RESOLVE_WINDOW = 20.0
+
+
+class TestTargetedStopResolves(TestCase):
+    """A real `<skill_id>:stop` dispatch to a real workshop skill resolves."""
+
+    def setUp(self):
+        LOG.set_level("DEBUG")
+        self.skill_id = "ovos-skill-count.openvoiceos"
+        # the translator bridges the spec `<skill_id>:stop` dispatch onto the
+        # `<skill_id>.stop` subscription ovos-workshop registers
+        self.minicroft = get_minicroft([self.skill_id],
+                                       modernize=True, emit_legacy=True)
+
+    def tearDown(self):
+        self.minicroft.stop()
+        LOG.set_level("CRITICAL")
+
+    def _start_counting(self, session):
+        """Put the skill in `active_handlers` with a long-running intent, so
+        the §4 cascade has a real stop target.
+
+        Returns the LIVE session carried on the dispatch — a named session
+        never lands in ``SessionManager.sessions``, so the §7.1 push is only
+        visible on the round's own messages, not on the snapshot emitted here.
+        """
+        activated = Event()
+        observed = {}
+
+        def on_start(msg):
+            if msg.data.get("skill_id") == self.skill_id:
+                observed["session"] = Session.from_message(msg)
+                activated.set()
+
+        self.minicroft.bus.on(SpecMessage.INTENT_HANDLER_START.value, on_start)
+        create_daemon(lambda: self.minicroft.bus.emit(Message(
+            SPEC_UTTERANCE,
+            {"utterances": ["count to infinity"], "lang": session.lang},
+            {"session": session.serialize()})))
+        self.assertTrue(activated.wait(RESOLVE_WINDOW),
+                        "the count skill never started")
+        self.minicroft.bus.remove(SpecMessage.INTENT_HANDLER_START.value, on_start)
+        live = observed["session"]
+        self.assertIn(self.skill_id,
+                      [h["skill_id"] for h in live.active_handlers],
+                      "the count skill must be an active handler for the "
+                      "§4 cascade to have a targeted stop candidate")
+        return live
+
+    def test_stop_dispatch_resolves_with_exactly_one_terminal(self):
+        session = Session("stop-resolution")
+        session.lang = "en-US"
+        session.pipeline = ["ovos-stop-pipeline-plugin-high",
+                            "ovos-padatious-pipeline-plugin-high"]
+        live = self._start_counting(session)
+
+        stop_dispatched = Event()
+        completes, errors, handled = [], [], []
+        resolved_at = []
+        started_at = []
+
+        def on_dispatch(msg):
+            started_at.append(time.monotonic())
+            stop_dispatched.set()
+
+        def on_complete(msg):
+            if msg.data.get("intent_name") == "stop":
+                resolved_at.append(time.monotonic())
+                completes.append(msg)
+
+        def on_error(msg):
+            if msg.data.get("intent_name") == "stop":
+                errors.append(msg)
+
+        bus = self.minicroft.bus
+        bus.on(f"{self.skill_id}:stop", on_dispatch)
+        bus.on(SpecMessage.INTENT_HANDLER_COMPLETE.value, on_complete)
+        bus.on(SpecMessage.INTENT_HANDLER_ERROR.value, on_error)
+        bus.on(SpecMessage.UTTERANCE_HANDLED.value, handled.append)
+
+        bus.emit(Message(SPEC_UTTERANCE,
+                         {"utterances": ["stop"], "lang": live.lang},
+                         {"session": live.serialize()}))
+
+        deadline = time.monotonic() + RESOLVE_WINDOW
+        while time.monotonic() < deadline and not completes and not errors:
+            time.sleep(0.05)
+
+        self.assertTrue(stop_dispatched.is_set(),
+                        f"no {self.skill_id}:stop dispatch was emitted")
+        self.assertEqual(errors, [],
+                         "the stop handler must resolve as a normal return")
+        self.assertEqual(
+            len(completes), 1,
+            f"§8.1: a dispatch produces exactly one terminal event; got "
+            f"{len(completes)} ovos.intent.handler.complete for intent_name "
+            f"'stop'. The skill emits the framework done-signal and the "
+            f"orchestrator owns the trio — neither StopService nor anything "
+            f"else may add a second.")
+
+        elapsed = resolved_at[0] - started_at[0]
+        self.assertLess(
+            elapsed, RESOLVE_WINDOW,
+            f"the stop dispatch took {elapsed:.1f}s to resolve; an unresolved "
+            f"dispatch is only closed by the §8.3 timeout")
+
+        # §9.5: exactly one end marker for the stop utterance. The count
+        # utterance owns a second one, so wait out both and count the round's.
+        time.sleep(2)
+        self.assertEqual(
+            len(handled), 2,
+            f"§9.5: exactly one ovos.utterance.handled per entry-topic "
+            f"Message — one for the interrupted count utterance and one for "
+            f"the stop; got {[m.msg_type for m in handled]}")

--- a/test/end2end/test_stop_response_mode_e2e.py
+++ b/test/end2end/test_stop_response_mode_e2e.py
@@ -27,6 +27,7 @@ from unittest.mock import MagicMock
 
 from ovos_bus_client.message import Message
 from ovos_bus_client.session import Session, SessionManager
+from ovos_spec_tools import SpecMessage
 from ovos_utils.fakebus import FakeBus
 
 from ovos_core.intent_services.stop_service import StopService
@@ -97,15 +98,33 @@ class TestResponseModeHolderStopE2E(unittest.TestCase):
         self.assertEqual(calls, [f"{skill_id}.stop"],
                          "lifecycle terminal (the abort) must fire exactly once")
 
-    def test_stop_releases_blocked_get_response_via_global_stop_path(self):
-        """Even when the utterance escalates to an explicit global stop, the
-        response-mode holder must still be released (handle_global_stop
-        emits the targeted topic before the broadcast)."""
+    def test_global_stop_releases_the_holder_via_the_ovos_stop_broadcast(self):
+        """An explicit global stop releases the holder through `ovos.stop`.
+
+        STOP-1 §5.3 gives the global-stop handler exactly one emission — "The
+        handler dispatched by `<pipeline_id>:global_stop` MUST emit
+        `ovos.stop`" — and makes the broadcast the universal channel: "Every
+        component performing user-visible activity MUST subscribe to
+        `ovos.stop` and cease activity for the `session_id` carried in Message
+        context." §9 restates it as a skill MUST: subscribe to both
+        `<own_skill_id>:stop` and `ovos.stop`.
+
+        So the release path for a blocked `get_response` under a global stop
+        is the skill's own `ovos.stop` subscription, not a per-skill topic
+        synthesized by the stop plugin.
+        """
         skill_id = "test-skill.openvoiceos"
         session = Session("resp-mode-only-2")
         session.enable_response_mode(skill_id)
 
-        released, calls = self._fake_skill_blocked_in_get_response(skill_id)
+        released = Event()
+        seen = []
+        # a §9-conformant skill: subscribed to the broadcast
+        self.bus.once(SpecMessage.STOP.value,
+                      lambda m: (seen.append(m.msg_type), released.set()))
+        # ...and to its own targeted topic, which a global stop must NOT use
+        targeted = []
+        self.bus.once(f"{skill_id}.stop", lambda m: targeted.append(m.msg_type))
 
         message = Message(
             "recognizer_loop:utterance",
@@ -119,7 +138,11 @@ class TestResponseModeHolderStopE2E(unittest.TestCase):
             match = self.svc.match_high(["stop everything"], "en-US", message)
 
         self.assertEqual(match.match_type, f"{StopService.pipeline_id}:global_stop")
-        self.assertEqual(match.match_data.get("response_mode_holder"), skill_id)
+        # PIPELINE-1 §4.3: slots are string->string, so no plugin-internal
+        # holder rides out on the dispatch.
+        self.assertEqual(match.match_data, {})
+        # §5.2: response_mode removed entirely by the Match's updated_session.
+        self.assertFalse(match.updated_session.response_mode)
 
         data = dict(message.data)
         data.update(match.match_data)
@@ -127,11 +150,13 @@ class TestResponseModeHolderStopE2E(unittest.TestCase):
         reply.context["skill_id"] = match.skill_id
         self.bus.emit(reply)
 
-        fired = released.wait(timeout=POLL_WINDOW)
-        self.assertTrue(fired,
-                        "an explicit global stop must still release a "
-                        "response-mode holder's blocked get_response")
-        self.assertEqual(calls, [f"{skill_id}.stop"])
+        self.assertTrue(released.wait(timeout=POLL_WINDOW),
+                        "an explicit global stop must reach a blocked "
+                        "get_response through the ovos.stop broadcast")
+        self.assertEqual(seen, [SpecMessage.STOP.value])
+        self.assertEqual(targeted, [],
+                         "§5.3 permits no per-skill emission from the "
+                         "global-stop handler")
 
 
 if __name__ == "__main__":

--- a/test/end2end/test_stop_spec_e2e.py
+++ b/test/end2end/test_stop_spec_e2e.py
@@ -6,9 +6,11 @@ These assert the primary, spec-mandated behaviour of the stop pipeline plugin:
   ``Match.skill_id == skill_id`` (§2, §3.1);
 - a **global** stop is dispatched on ``<pipeline_id>:global_stop`` with
   ``Match.skill_id == pipeline_id`` and broadcasts ``ovos.stop`` (§5);
-- ``suppress_activation`` (§6.2/§7.3) means neither dispatch emits a
-  ``{skill_id}.activate`` — a stop terminates participation, it does not
-  activate;
+- the reserved ``stop`` intent_name suppresses the PIPELINE-1 §7.1 activation
+  push per the §7.3 registry, so a targeted stop emits no
+  ``{skill_id}.activate`` — it terminates participation rather than starting
+  it — while the unreserved ``global_stop`` does activate the stop plugin
+  (STOP-1 §5.2);
 - the §5.2/§6 session drain is committed before dispatch.
 
 The un-migrated ``ovos-skill-count`` still subscribes to the legacy
@@ -38,7 +40,8 @@ GLOBAL_STOP = f"{PIPELINE_ID}:global_stop"                  # §5 global dispatc
 # Legacy-bridge and framework topics that wrap or shadow the spec dispatch;
 # ignored so the spec assertions stay focused on the STOP-1 surface. The
 # per-pipeline ``{pipeline_id}.activate`` / ``{skill_id}.activate`` topics are
-# deliberately NOT ignored: their absence is the §6.2 suppress_activation guard.
+# deliberately NOT ignored: whether each one appears is the §7.3 registry
+# assertion.
 _IGNORE = [
     SpecMessage.INTENT_MATCHED,
     SpecMessage.INTENT_HANDLER_START,
@@ -118,8 +121,10 @@ class TestGlobalStopSpec(TestCase):
         """Bare 'stop' with no active skills → global stop on the pipeline_id.
 
         Asserts: the §5 dispatch topic carries ``skill_id == pipeline_id``, it
-        broadcasts ``ovos.stop`` (§5.3), and — because suppress_activation is
-        set — NO ``{pipeline_id}.activate`` is emitted (§6.2/§7.3)."""
+        broadcasts ``ovos.stop`` (§5.3), and the stop plugin IS activated —
+        ``global_stop`` is not a reserved intent_name, so §7.3 suppression
+        does not apply and §5.2 requires the committed post-dispatch
+        ``active_handlers`` to hold exactly the stop plugin's own entry."""
         minicroft = get_minicroft([], modernize=False, emit_legacy=False)
         try:
             session = Session("123")
@@ -139,6 +144,8 @@ class TestGlobalStopSpec(TestCase):
                 source_message=message,
                 expected_messages=[
                     message,
+                    Message(f"{PIPELINE_ID}.activate", {},
+                            {"skill_id": PIPELINE_ID}),
                     Message(GLOBAL_STOP, {},
                             {"skill_id": PIPELINE_ID}),
                     Message(STOP_BROADCAST, {},
@@ -164,8 +171,9 @@ class TestTargetedStopSpec(TestCase):
 
     def test_targeted_stop_dispatch_shape(self):
         """A running skill is stopped via ``<skill_id>:stop`` with Match.skill_id
-        equal to the skill, no ``{skill_id}.activate`` (suppress_activation), and
-        the §6 drain removing the skill from active_handlers.
+        equal to the skill, no ``{skill_id}.activate`` (§7.3 marks the reserved
+        ``stop`` name non-activating), and the §6 drain removing the skill from
+        active_handlers.
 
         The translator (modernize/emit_legacy) bridges the spec ``:stop``
         dispatch onto the skill's legacy ``.stop`` subscription."""

--- a/test/unittests/test_intent_manifest.py
+++ b/test/unittests/test_intent_manifest.py
@@ -67,16 +67,13 @@ class TestManifestRegister(unittest.TestCase):
         self.assertEqual(key[0], "sat-1")
 
     def test_reserved_stop_intent_name_warns(self):
-        """CONFIRMED-5: a skill registering a real intent literally named
-        'stop' binds the same '<skill_id>:stop' topic OVOS-STOP-1 reserves for
-        the targeted-stop dispatch — the manifest must warn about the
-        collision, the natural point where core observes registration."""
+        """STOP-1 §2/§9 and PIPELINE-1 §7.3: a registration naming the
+        reserved `stop` is malformed — "log at WARN, do not index"."""
         with patch("ovos_core.intent_services.manifest.LOG") as mock_log:
             self.m._on_register(_reg("skill.test", "stop"))
         mock_log.warning.assert_called_once()
         self.assertIn("reserved", str(mock_log.warning.call_args))
-        # registration itself still proceeds (warn, don't reject)
-        self.assertEqual(len(self.m._index), 1)
+        self.assertEqual(self.m._index, {})
 
     def test_non_reserved_intent_name_does_not_warn(self):
         with patch("ovos_core.intent_services.manifest.LOG") as mock_log:
@@ -194,7 +191,7 @@ class TestIntentListQuery(unittest.TestCase):
     def setUp(self):
         self.m = _manifest()
         self.m._on_register(_reg("skill.a", "play", lang="en-US"))
-        self.m._on_register(_reg("skill.a", "stop", lang="en-US"))
+        self.m._on_register(_reg("skill.a", "pause", lang="en-US"))
         self.m._on_register(_reg("skill.b", "play", lang="de-DE"))
 
     def _query(self, **kwargs):
@@ -211,7 +208,7 @@ class TestIntentListQuery(unittest.TestCase):
     def test_filter_by_skill(self):
         resp = self._query(skill_id="skill.a")
         names = {e["intent_name"] for e in resp["intents"]}
-        self.assertEqual(names, {"play", "stop"})
+        self.assertEqual(names, {"play", "pause"})
 
     def test_filter_by_lang(self):
         resp = self._query(lang="de-DE")
@@ -333,3 +330,47 @@ class TestManifestContextLookups(unittest.TestCase):
         # a different session does not see the satellite-scoped declaration
         self.assertEqual(self.m.get_context_requirements("other", "s.skill", "on", "en-US"),
                          ([], []))
+
+
+class TestReservedStopIsNotIndexed(unittest.TestCase):
+    """OVOS-STOP-1 §2: "Skills and other pipelines MUST NOT register `stop`
+    under OVOS-INTENT-4. A registration naming this intent_name is malformed
+    per OVOS-INTENT-4 §5.3/§6.3 — consumers log at WARN and do not index."
+    PIPELINE-1 §7.3 repeats the rule for every reserved name, and STOP-1 §9
+    makes it an orchestrator MUST: "treat OVOS-INTENT-4 registrations naming
+    `stop` as malformed — log at WARN and decline to index".
+
+    Warning while indexing anyway is the failure this guards: the entry then
+    shows up in `ovos.intent.list`, in `ovos.intent.describe`, and in the
+    §6.2 required-slot backstop, where it shadows the stop pipeline's own
+    reserved `<skill_id>:stop` dispatch.
+    """
+
+    def setUp(self):
+        self.m = _manifest()
+
+    def test_stop_registration_is_not_indexed(self):
+        with patch("ovos_core.intent_services.manifest.LOG") as mock_log:
+            self.m._on_register(_reg("skill.test", "stop"))
+        mock_log.warning.assert_called_once()
+        self.assertEqual(self.m._index, {})
+
+    def test_stop_registration_absent_from_intent_list(self):
+        self.m._on_register(_reg("skill.test", "play"))
+        self.m._on_register(_reg("skill.test", "stop"))
+        replies = []
+        self.m.bus.on("ovos.intent.list.response", lambda msg: replies.append(msg))
+        self.m._on_list(Message("ovos.intent.list", data={}))
+        names = {e["intent_name"] for e in replies[-1].data["intents"]}
+        self.assertEqual(names, {"play"})
+
+    def test_global_stop_is_not_reserved_and_is_indexed(self):
+        """STOP-1 §2 leaves `global_stop` unreserved; only `stop` is."""
+        self.m._on_register(_reg("skill.test", "global_stop"))
+        self.assertEqual(len(self.m._index), 1)
+
+    def test_both_registration_methods_are_declined(self):
+        for method in ("keyword", "template"):
+            m = _manifest()
+            m._on_register(_reg("skill.test", "stop", method=method))
+            self.assertEqual(m._index, {}, method)

--- a/test/unittests/test_intent_service_extended.py
+++ b/test/unittests/test_intent_service_extended.py
@@ -1233,12 +1233,12 @@ class TestHandleUtterance(unittest.TestCase):
         stop_svc = StopService.__new__(StopService)
         stop_svc.bus = bus
         stop_svc.config = {}
-        stop_svc.suppress_activation = True
         stop_svc._locale = MagicMock()
         stop_svc._locale.voc_match.side_effect = (
             lambda utt, voc, lang, exact=False: voc == "stop")
         stop_svc._legacy = MagicMock()
         stop_svc._pre_drain = {}
+        stop_svc._stop_listeners = set()
 
         sess = Session("s")
         sess.activate_skill("skill_a")
@@ -1416,61 +1416,130 @@ class TestRequiredSlotsBackstop(unittest.TestCase):
 # ---------------------------------------------------------------------------
 
 class TestReservedNameActivation(unittest.TestCase):
+    """OVOS-PIPELINE-1 §7.1: the `active_handlers` push "is **suppressed** for
+    dispatches whose `intent_name` is marked non-activating in the §7.3
+    reserved-name registry... Suppression **MUST** be keyed on the Match's
+    `intent_name` and its registry row — never on the producing
+    `pipeline_id`". §7.3 states the activation-push column per row: `converse`,
+    `response`, `stop` and `common_query` suppress; `fallback` **pushes**.
 
-    def _dispatch(self, pipeline_id, suppress_activation=False):
+    The shipped producers have not migrated to spec-shaped `intent_name`s yet,
+    so every case below uses the match_type that plugin ACTUALLY emits today
+    alongside the spec shape it will emit after migration. Both must reach the
+    same verdict; asserting only on invented `<skill>:<reserved_name>` strings
+    lets the suite stay green while real rounds are unsuppressed.
+    """
+
+    def _dispatch(self, match_type, pipeline_id, skill_id="test.skill"):
         svc = _make_service()
         sess = Session("s1")
         msg = Message("recognizer_loop:utterance", {"utterances": ["hi"]},
                       {"session": sess.serialize()})
-        match = _make_match(match_type="test.skill:intent",
-                            skill_id="test.skill", session=sess)
-        match.suppress_activation = suppress_activation
+        match = _make_match(match_type=match_type,
+                            skill_id=skill_id, session=sess)
         svc._dispatch_match(match, msg, "en-US", pipeline_id=pipeline_id)
-        return sess
+        return [h.get("skill_id") if isinstance(h, dict) else getattr(h, "skill_id", h)
+                for h in sess.active_handlers]
 
-    def test_regular_pipeline_pushes_active_handler(self):
-        sess = self._dispatch("ovos-adapt-pipeline-plugin-high")
-        ids = [h.get("skill_id") if isinstance(h, dict) else getattr(h, "skill_id", h)
-               for h in sess.active_handlers]
-        self.assertIn("test.skill", ids)
+    def test_ordinary_intent_pushes(self):
+        self.assertIn("test.skill",
+                      self._dispatch("test.skill:play_music",
+                                     "ovos-adapt-pipeline-plugin-high"))
 
-    def test_reserved_name_pipeline_suppresses_push(self):
-        # §7.3: converse/fallback/common_query dispatches must NOT push
-        for pid in ("ovos-converse-pipeline-plugin",
-                    "ovos-fallback-pipeline-plugin-medium",
-                    "ovos-common-query-pipeline-plugin"):
-            sess = self._dispatch(pid)
-            ids = [h.get("skill_id") if isinstance(h, dict) else getattr(h, "skill_id", h)
-                   for h in sess.active_handlers]
-            self.assertNotIn("test.skill", ids, f"{pid} should suppress the push")
+    def test_converse_shapes_suppress(self):
+        """`converse_service` emits `converse:skill` (CONVERSE-1 §4) and
+        `<skill_id>.converse.get_response` (§5) today."""
+        for match_type in ("converse:skill",
+                           "test.skill.converse.get_response",
+                           "test.skill:converse",
+                           "test.skill:response"):
+            with self.subTest(match_type=match_type):
+                self.assertNotIn("test.skill",
+                                 self._dispatch(match_type,
+                                                "ovos-converse-pipeline-plugin"))
 
-    def test_suppress_activation_match_suppresses_push(self):
-        # OVOS-STOP-1 §6.2/§7.3: a Match.suppress_activation dispatch (a stop)
-        # must NOT push onto active_handlers regardless of its pipeline_id.
-        sess = self._dispatch("ovos-adapt-pipeline-plugin-high",
-                              suppress_activation=True)
-        ids = [h.get("skill_id") if isinstance(h, dict) else getattr(h, "skill_id", h)
-               for h in sess.active_handlers]
-        self.assertNotIn("test.skill", ids)
+    def test_common_query_shapes_suppress(self):
+        """`ovos-common-query-pipeline-plugin` emits
+        `question:action.<skill_id>` today."""
+        for match_type in ("question:action.test.skill",
+                           "question:action",
+                           "ovos-common-query-pipeline-plugin:common_query"):
+            with self.subTest(match_type=match_type):
+                self.assertNotIn(
+                    "test.skill",
+                    self._dispatch(match_type,
+                                   "ovos-common-query-pipeline-plugin"))
+
+    def test_stop_suppresses(self):
+        """The stop plugin already emits the spec shape."""
+        self.assertNotIn("test.skill",
+                         self._dispatch("test.skill:stop",
+                                        "ovos-stop-pipeline-plugin-high"))
+
+    def test_fallback_shapes_push(self):
+        """§7.3: "`fallback` is different and therefore **not** suppressed. A
+        fallback handler was not active before the dispatch — the dispatch
+        *is* its activation." Suppressing it "would leave the handler
+        unreachable by OVOS-STOP-1". `fallback_service` emits
+        `ovos.skills.fallback.<skill_id>.request` today."""
+        for match_type in ("ovos.skills.fallback.test.skill.request",
+                           "test.skill:fallback"):
+            with self.subTest(match_type=match_type):
+                self.assertIn("test.skill",
+                              self._dispatch(match_type,
+                                             "ovos-fallback-pipeline-plugin-high"))
+
+    def test_global_stop_pushes(self):
+        """STOP-1 §5.2: "`global_stop` is not a reserved intent_name, so
+        PIPELINE-1 §7.1 stamping suppression does not apply: the orchestrator
+        pushes the stop plugin's `pipeline_id` onto `active_handlers`... The
+        committed post-dispatch state is therefore not an empty list"."""
+        self.assertIn("test.skill",
+                      self._dispatch("test.skill:global_stop",
+                                     "ovos-stop-pipeline-plugin-high"))
+
+    def test_spec_reserved_name_suppresses_whatever_produced_it(self):
+        """§7.1 forbids keying suppression on the producer, so a spec-shaped
+        reserved name suppresses even from an ordinary matcher."""
+        self.assertNotIn("test.skill",
+                         self._dispatch("test.skill:stop",
+                                        "ovos-adapt-pipeline-plugin-high"))
+
+    def test_ordinary_name_from_a_reserved_role_still_pushes(self):
+        """The transitional pipeline_id gate covers only the roles whose
+        producers are unmigrated, and the fallback plugin is not one of
+        them."""
+        self.assertIn("test.skill",
+                      self._dispatch("test.skill:play_music",
+                                     "ovos-adapt-pipeline-plugin-high"))
 
 
-class TestProducesReservedName(unittest.TestCase):
+class TestFallbackMatchCarriesSkillId(unittest.TestCase):
+    """OVOS-PIPELINE-1 §7.1 keys the activation push on `Match.skill_id`, and
+    §7.3 requires a `fallback` dispatch to push. A FallbackService Match built
+    without `skill_id` never pushes on either branch, leaving the handler
+    invisible to OVOS-STOP-1's cascade and ineligible for a converse
+    follow-up — exactly what §7.3 says suppressing it would cause."""
 
-    def test_reserved_roles_true_with_confidence_suffix(self):
-        from ovos_core.intent_services.service import _produces_reserved_name
-        self.assertTrue(_produces_reserved_name("ovos-converse-pipeline-plugin"))
-        self.assertTrue(_produces_reserved_name("ovos-fallback-pipeline-plugin-low"))
+    def test_match_sets_skill_id(self):
+        from ovos_core.intent_services.fallback_service import (
+            FallbackRange, FallbackService)
 
-    def test_stop_role_not_in_reserved_table(self):
-        # STOP-1 expresses suppression per-Match (suppress_activation), so the
-        # stop pipeline is intentionally absent from the reserved-name table.
-        from ovos_core.intent_services.service import _produces_reserved_name
-        self.assertFalse(_produces_reserved_name("ovos-stop-pipeline-plugin-high"))
+        bus = FakeBus()
+        svc = FallbackService(bus)
+        svc.registered_fallbacks = {"fallback.skill": 50}
+        sess = Session("s")
+        msg = Message("recognizer_loop:utterance", {"utterances": ["hi"]},
+                      {"session": sess.serialize()})
+        with patch.object(FallbackService, "_collect_fallback_skills",
+                          return_value=["fallback.skill"]), \
+             patch.object(FallbackService, "_fallback_allowed",
+                          return_value=True):
+            match = svc._fallback_range(["hi"], "en-US", msg,
+                                        FallbackRange(0, 100))
 
-    def test_regular_role_false(self):
-        from ovos_core.intent_services.service import _produces_reserved_name
-        self.assertFalse(_produces_reserved_name("ovos-adapt-pipeline-plugin-high"))
-        self.assertFalse(_produces_reserved_name(None))
+        self.assertIsNotNone(match)
+        self.assertEqual(match.skill_id, "fallback.skill")
 
 
 # ---------------------------------------------------------------------------

--- a/test/unittests/test_stop_service.py
+++ b/test/unittests/test_stop_service.py
@@ -18,6 +18,7 @@ import unittest
 from unittest.mock import MagicMock, patch, call
 from threading import Event
 
+from ovos_bus_client.handler import HandlerLifecycle
 from ovos_bus_client.message import Message
 from ovos_bus_client.session import Session, SessionManager, UtteranceState
 from ovos_spec_tools import SpecMessage
@@ -27,6 +28,16 @@ from ovos_core.intent_services.stop_service import StopService
 from ovos_core.intent_services.stop_service_legacy import _LegacyStopBridge
 
 GLOBAL_STOP = f"{StopService.pipeline_id}:global_stop"
+
+
+def _round_message(utterance_id, sess=None):
+    """A Message carrying ``context["utterance_id"]`` the way the
+    orchestrator stamps it at lifecycle entry (§9.1.1) -- what
+    ``_targeted_stop`` needs as its ``message`` argument."""
+    context = {"utterance_id": utterance_id}
+    if sess is not None:
+        context["session"] = sess.serialize()
+    return Message("test", {}, context)
 
 
 def _make_service() -> StopService:
@@ -45,6 +56,7 @@ def _make_service() -> StopService:
         svc._locale = MagicMock()
         svc._legacy = MagicMock()
         svc._pre_drain = {}
+        svc._stop_listeners = set()
     return svc
 
 
@@ -405,9 +417,12 @@ class TestHandleStopConfirmation(unittest.TestCase):
     def test_error_in_data_is_logged(self):
         svc = _make_service()
         svc.bus.emit = MagicMock()
+        sess = Session("s")
+        sess.activate_skill("skill_a")
+        svc._targeted_stop("skill_a", "stop", sess, _round_message("uid-1"))
         msg = Message("skill_a.stop.response",
                       data={"skill_id": "skill_a", "error": "boom"},
-                      context={})
+                      context={"utterance_id": "uid-1", "session": sess.serialize()})
         with patch("ovos_core.intent_services.stop_service.LOG") as mock_log:
             svc.handle_stop_confirmation(msg)
         mock_log.error.assert_called_once()
@@ -420,10 +435,11 @@ class TestHandleStopConfirmation(unittest.TestCase):
         sess = Session("s")
         sess.activate_skill("skill_a")
         sess.enable_response_mode("skill_a")
+        svc._targeted_stop("skill_a", "stop", sess, _round_message("uid-1"))
 
         msg = Message("skill_a.stop.response",
                       data={"skill_id": "skill_a", "result": True},
-                      context={"session": sess.serialize()})
+                      context={"utterance_id": "uid-1", "session": sess.serialize()})
 
         with patch("ovos_core.intent_services.stop_service.SessionManager.get",
                    return_value=sess):
@@ -432,8 +448,9 @@ class TestHandleStopConfirmation(unittest.TestCase):
         emitted = [c[0][0].msg_type for c in svc.bus.emit.call_args_list]
         self.assertIn("mycroft.skills.abort_question", emitted)
 
-    def test_skill_id_extracted_from_msg_type_fallback(self):
-        """skill_id can be inferred from the message type if not in data/context."""
+    def test_no_utterance_id_is_a_no_op(self):
+        """A `.stop.response` with no `utterance_id` (a V0/direct-invocation
+        caller) has no snapshot to resolve against and must not raise."""
         svc = _make_service()
         svc.bus.emit = MagicMock()
         sess = Session("s")
@@ -446,6 +463,8 @@ class TestHandleStopConfirmation(unittest.TestCase):
                    return_value=sess):
             # Should not raise
             svc.handle_stop_confirmation(msg)
+
+        self.assertEqual(svc.bus.emit.call_args_list, [])
 
 
 class TestAbortQuestionReachable(unittest.TestCase):
@@ -465,13 +484,13 @@ class TestAbortQuestionReachable(unittest.TestCase):
 
         # simulate _targeted_stop's pre-drain snapshot + the dispatch carrying
         # the POST-drain session forward to the .stop.response handler.
-        match = svc._targeted_stop("skill_a", 1.0, "stop", sess)
+        match = svc._targeted_stop("skill_a", "stop", sess, _round_message("uid-1"))
         drained_sess = match.updated_session
         self.assertFalse(drained_sess.response_mode)  # sanity: already drained
 
         msg = Message("skill_a.stop.response",
                       data={"skill_id": "skill_a", "result": True},
-                      context={"session": drained_sess.serialize()})
+                      context={"utterance_id": "uid-1", "session": drained_sess.serialize()})
 
         with patch("ovos_core.intent_services.stop_service.SessionManager.get",
                    return_value=drained_sess):
@@ -491,12 +510,12 @@ class TestAbortQuestionReachable(unittest.TestCase):
         sess = Session("s")
         sess.activate_skill("skill_a")  # active, NOT response-mode
 
-        match = svc._targeted_stop("skill_a", 1.0, "stop", sess)
+        match = svc._targeted_stop("skill_a", "stop", sess, _round_message("uid-1"))
         drained_sess = match.updated_session
 
         msg = Message("skill_a.stop.response",
                       data={"skill_id": "skill_a", "result": True},
-                      context={"session": drained_sess.serialize()})
+                      context={"utterance_id": "uid-1", "session": drained_sess.serialize()})
 
         with patch("ovos_core.intent_services.stop_service.SessionManager.get",
                    return_value=drained_sess):
@@ -538,13 +557,15 @@ class TestMatchHigh(unittest.TestCase):
              patch.object(self.svc, "_collect_stop_skills", return_value=["skill_a"]), \
              patch("ovos_core.intent_services.stop_service.SessionManager.get",
                    return_value=Session("s")):
-            self.svc.bus.once = MagicMock()
             result = self.svc.match_high(["stop"], "en-US", Message("test"))
 
         self.assertIsNotNone(result)
         self.assertEqual(result.match_type, "skill_a:stop")
         self.assertEqual(result.skill_id, "skill_a")
-        self.assertTrue(result.suppress_activation)
+        # PIPELINE-1 §4.3 slots are string->string; the §7.1 push suppression
+        # for the reserved `stop` name is the orchestrator's registry lookup,
+        # not a Match field.
+        self.assertEqual(result.match_data, {"skill_id": "skill_a"})
         self.assertEqual(result.match_data["skill_id"], "skill_a")
 
     def test_global_stop_voc_triggers_global_stop(self):
@@ -604,7 +625,6 @@ class TestMatchLow(unittest.TestCase):
     def test_above_threshold_with_stoppable_skill(self):
         """A confident match with a stoppable skill → skill stop."""
         self.svc.config = {"min_conf": 0.5}
-        self.svc.bus.once = MagicMock()
         with patch.object(self.svc._locale, "voc_list", return_value=["stop"]), \
              patch("ovos_core.intent_services.stop_service.match_one",
                    return_value=("stop", 0.8)), \
@@ -617,7 +637,10 @@ class TestMatchLow(unittest.TestCase):
         self.assertIsNotNone(result)
         self.assertEqual(result.match_type, "skill_a:stop")
         self.assertEqual(result.skill_id, "skill_a")
-        self.assertTrue(result.suppress_activation)
+        # PIPELINE-1 §4.3 slots are string->string; the §7.1 push suppression
+        # for the reserved `stop` name is the orchestrator's registry lookup,
+        # not a Match field.
+        self.assertEqual(result.match_data, {"skill_id": "skill_a"})
         self.assertEqual(result.match_data["skill_id"], "skill_a")
 
 
@@ -632,10 +655,11 @@ class TestHandleStopConfirmationExtra(unittest.TestCase):
         sess.activate_skill("skill_a")
         # INTENT state (not RESPONSE) — should NOT trigger abort_question
         # but skill is still active → should trigger converse force_timeout
+        svc._targeted_stop("skill_a", "stop", sess, _round_message("uid-1"))
 
         msg = Message("skill_a.stop.response",
                       data={"skill_id": "skill_a", "result": True},
-                      context={"session": sess.serialize()})
+                      context={"utterance_id": "uid-1", "session": sess.serialize()})
 
         with patch("ovos_core.intent_services.stop_service.SessionManager.get",
                    return_value=sess):
@@ -653,10 +677,11 @@ class TestHandleStopConfirmationExtra(unittest.TestCase):
         sess = Session("s")
         sess.activate_skill("skill_a")
         sess.is_speaking = True
+        svc._targeted_stop("skill_a", "stop", sess, _round_message("uid-1"))
 
         msg = Message("skill_a.stop.response",
                       data={"skill_id": "skill_a", "result": True},
-                      context={"session": sess.serialize()})
+                      context={"utterance_id": "uid-1", "session": sess.serialize()})
 
         with patch("ovos_core.intent_services.stop_service.SessionManager.get",
                    return_value=sess):
@@ -900,7 +925,6 @@ class TestResponseModeHolderCandidate(unittest.TestCase):
         sess = Session("s")
         sess.enable_response_mode("skill_x")  # no active_handlers push
 
-        self.svc.bus.once = MagicMock()
         with patch.object(self.svc._locale, "voc_match",
                           side_effect=lambda utt, voc, lang, exact: voc == "stop"), \
              patch.object(StopService, "get_active_skills", return_value=[]), \
@@ -931,16 +955,20 @@ class TestResponseModeHolderCandidate(unittest.TestCase):
         self.assertEqual(candidates[0], "holder_skill")
         self.assertIn("old_skill", candidates)
 
-    def test_global_stop_still_reaches_response_mode_holder(self):
-        """Even when a stop DOES escalate to global (e.g. explicit 'stop
-        everything' vocabulary), the response_mode holder must still get its
-        targeted <skill_id>.stop so a blocked get_response is released — the
-        broadcast alone is invisible to the killable-event abort."""
+    def test_global_stop_emits_only_the_ovos_stop_broadcast(self):
+        """STOP-1 §5.3: the global-stop handler emits `ovos.stop` and nothing
+        else. A response_mode holder gets no topic of its own — §5.3 makes
+        every component with user-visible activity a subscriber of the
+        broadcast — and §4.3/PIPELINE-1 §8 leave the handler-lifecycle trio to
+        the orchestrator, so the handler emits no `.complete`/`.error` either.
+        """
         sess = Session("s")
         sess.enable_response_mode("blocked_skill")
 
-        match = self.svc._global_stop(1.0, "stop everything", sess)
-        self.assertEqual(match.match_data.get("response_mode_holder"), "blocked_skill")
+        match = self.svc._global_stop("stop everything", sess)
+        # PIPELINE-1 §4.3: slots are string->string. No `response_mode_holder`,
+        # no `conf`.
+        self.assertEqual(match.match_data, {})
 
         self.svc.bus.emit = MagicMock()
         msg = Message(GLOBAL_STOP, dict(match.match_data),
@@ -948,11 +976,10 @@ class TestResponseModeHolderCandidate(unittest.TestCase):
         self.svc.handle_global_stop(msg)
 
         emitted_types = [c[0][0].msg_type for c in self.svc.bus.emit.call_args_list]
-        self.assertIn("blocked_skill.stop", emitted_types)
-        self.assertIn(SpecMessage.STOP.value, emitted_types)
-        # targeted stop must reach the skill BEFORE the broadcast
-        self.assertLess(emitted_types.index("blocked_skill.stop"),
-                        emitted_types.index(SpecMessage.STOP.value))
+        self.assertNotIn("blocked_skill.stop", emitted_types)
+        self.assertEqual(
+            [t for t in emitted_types if ".skill.handler." not in t],
+            [SpecMessage.STOP.value])
 
 
 class TestStopSelectionDeterministic(unittest.TestCase):
@@ -1008,71 +1035,17 @@ class TestStopSelectionDeterministic(unittest.TestCase):
             f"first; got order {result_holder[0]!r}")
 
 
-class TestDispatcherLifecycleResolvedByStopRoundTrip(unittest.TestCase):
-    """The IntentDispatcher's §8 handler-lifecycle entry for a
-    `<skill_id>:stop` dispatch must be resolved by
-    `mycroft.skill.handler.complete`/`.error`, not left parked on the
-    dispatcher's 5-minute §8.3 timeout — the colon-topic has no direct
-    ovos-workshop listener (only the legacy bridge mirrors it onto the
-    dot-topic, bound with `handler_info=None`, which disables that
-    emission), so the stop round-trip (`.stop.response`) must resolve it
-    synchronously instead."""
+class TestStaleStopResponseDoesNotResolveUnrelatedEntry(unittest.TestCase):
+    """`_targeted_stop` records the `_pre_drain` snapshot and binds the
+    (permanent) `.stop.response` listener at MATCH-BUILD time -- allowed by
+    OVOS-PIPELINE-1 §4.2. If the orchestrator later DISCARDS this Match
+    (blacklisted intent, missing slots, etc: see service.py's blacklist
+    check) and never actually dispatches it, the snapshot is stale but keyed
+    by this round's own `utterance_id`, so it can only ever resolve a
+    `.stop.response` correlated to THIS round -- never an unrelated,
+    genuinely in-flight intent for the same skill_id in a different round."""
 
-    def test_stop_round_trip_resolves_dispatcher_entry_synchronously(self):
-        from ovos_core.intent_services.dispatcher import IntentDispatcher
-
-        svc = _make_service()
-        bus = svc.bus
-        # a real (long) timeout: if the fix regresses, this test would only
-        # catch it via the entry still being present -- it must NEVER need to
-        # actually fire for this test to pass.
-        disp = IntentDispatcher(bus, timeout=300)
-        self.addCleanup(disp.shutdown)
-
-        skill_id = "fake_skill"
-        sess = Session("sess1")
-        sess.activate_skill(skill_id)
-
-        # fake skill: answers the dispatched colon-topic directly with its
-        # .stop.response, exactly as a real stop() round-trip concludes.
-        bus.on(f"{skill_id}:stop",
-               lambda m: bus.emit(m.reply(f"{skill_id}.stop.response",
-                                          {"skill_id": skill_id, "result": True})))
-
-        match = svc._targeted_stop(skill_id, 1.0, "stop", sess)
-        reply = Message(match.match_type, dict(match.match_data),
-                        {"skill_id": skill_id,
-                         "session": match.updated_session.serialize()})
-
-        disp.dispatch(reply, skill_id, "stop")
-
-        with disp._lock:
-            entries = list(disp._in_flight.get(match.updated_session.session_id, []))
-        self.assertEqual(
-            entries, [],
-            "the dispatcher's in-flight entry for the <skill_id>:stop dispatch "
-            "must be resolved synchronously by the stop round-trip, not left "
-            "parked on the 5-minute §8.3 timeout")
-
-
-class TestStaleStopOnceDoesNotResolveUnrelatedEntry(unittest.TestCase):
-    """`_targeted_stop` registers
-    `bus.once(f"{skill_id}.stop.response", handle_stop_confirmation)`
-    at MATCH-BUILD time -- a side effect that survives even when the
-    orchestrator later DISCARDS the Match (blacklisted intent, missing
-    slots, etc: see service.py's blacklist check) and never actually
-    dispatches it. Before this fix, if that skill later emits ANY
-    `.stop.response` for an unrelated reason (e.g. a global stop's own
-    ping-pong round trip), the stale listener fires `handle_stop_confirmation`,
-    whose synthetic `mycroft.skill.handler.complete` popped the dispatcher's
-    in-flight entry for that skill_id regardless of which intent it actually
-    belonged to -- a still-running, unrelated intent handler got a premature
-    `ovos.utterance.handled` end-marker.
-
-    Mirrors the live auditor's attack.py::test_B_stale_once_pops_wrong_entry.
-    """
-
-    def test_stale_once_does_not_resolve_unrelated_running_intent(self):
+    def test_stale_snapshot_does_not_resolve_unrelated_running_intent(self):
         from ovos_core.intent_services.dispatcher import IntentDispatcher
 
         svc = _make_service()
@@ -1083,22 +1056,26 @@ class TestStaleStopOnceDoesNotResolveUnrelatedEntry(unittest.TestCase):
         sess = Session("sessB")
         sess.activate_skill("skillA")
 
-        # 1) a stop match is built (registers the bus.once side effect) but
-        #    is DISCARDED -- never handed to disp.dispatch().
-        svc._targeted_stop("skillA", 1.0, "stop", sess)
+        # 1) a stop match is built for round "uid-discarded" (records the
+        #    pre-drain snapshot + permanent listener) but is DISCARDED --
+        #    never handed to disp.dispatch().
+        svc._targeted_stop("skillA", "stop", sess, _round_message("uid-discarded"))
 
-        # 2) an ordinary, unrelated intent for the SAME skill is genuinely
-        #    in flight.
+        # 2) an ordinary, unrelated intent for the SAME skill, a DIFFERENT
+        #    round, is genuinely in flight.
         intent_msg = Message("skillA:my.intent", {},
-                             {"skill_id": "skillA", "session": sess.serialize()})
+                             {"skill_id": "skillA", "utterance_id": "uid-running",
+                              "session": sess.serialize()})
         disp.dispatch(intent_msg, "skillA", "my.intent")
 
         # 3) later, skillA answers .stop.response for an unrelated reason
-        #    (e.g. a global stop's ping-pong) -- this fires the stale
-        #    bus.once() listener from step 1.
+        #    (e.g. a global stop's ping-pong), carrying the RUNNING intent's
+        #    round id -- the discarded snapshot is keyed on "uid-discarded"
+        #    and can never match this.
         bus.emit(Message("skillA.stop.response",
                          {"skill_id": "skillA", "result": True},
-                         {"skill_id": "skillA", "session": sess.serialize()}))
+                         {"skill_id": "skillA", "utterance_id": "uid-running",
+                          "session": sess.serialize()}))
 
         with disp._lock:
             entries = list(disp._in_flight.get("sessB", []))
@@ -1106,50 +1083,50 @@ class TestStaleStopOnceDoesNotResolveUnrelatedEntry(unittest.TestCase):
             [(e.skill_id, e.intent_name) for e in entries],
             [("skillA", "my.intent")],
             "the still-running, unrelated intent's dispatcher entry must "
-            "survive a stale/foreign .stop.response for the same skill_id")
+            "survive a stale/foreign .stop.response for a different round")
 
 
-class TestFailedStopYieldsErrorTerminal(unittest.TestCase):
-    """A `.stop.response` carrying `error` (the skill's `stop()` raised)
-    must resolve via `_resolve_dispatch_lifecycle` as an `error` terminal,
-    not `complete` -- §8.2 requires this so a failed stop is distinguishable
-    from a successful one on the handler-lifecycle trio.
+class TestStopServiceEmitsNoHandlerTrio(unittest.TestCase):
+    """PIPELINE-1 §8: "The handler-lifecycle trio is emitted by the
+    orchestrator that invokes the handler... The handler itself does not emit
+    anything." STOP-1 §4.3 as amended: "the orchestrator alone emits
+    `.complete` on normal return or `.error` on exception... The stop handler
+    does not emit either event itself."
+
+    StopService used to synthesize `mycroft.skill.handler.complete`/`.error`
+    from a skill's `.stop.response` to close the dispatcher's in-flight entry
+    early. That is the orchestrator's event, and forging it reports a terminal
+    for a handler this component never invoked.
     """
 
-    def test_stop_response_with_error_yields_error_not_complete_terminal(self):
-        from ovos_core.intent_services.dispatcher import IntentDispatcher
-
+    def _run_round(self, stop_response_data: dict) -> list:
         svc = _make_service()
         bus = svc.bus
-        disp = IntentDispatcher(bus, timeout=300)
-        self.addCleanup(disp.shutdown)
-
         seen = []
-        for topic in (SpecMessage.INTENT_HANDLER_COMPLETE.value,
-                     SpecMessage.INTENT_HANDLER_ERROR.value):
-            bus.on(topic, lambda m, topic=topic: seen.append((topic, m.data)))
+        for topic in ("mycroft.skill.handler.complete",
+                      "mycroft.skill.handler.error",
+                      SpecMessage.INTENT_HANDLER_COMPLETE.value,
+                      SpecMessage.INTENT_HANDLER_ERROR.value):
+            bus.on(topic, lambda m, topic=topic: seen.append(topic))
 
         sess = Session("sE")
         sess.activate_skill("skillA")
+        svc._targeted_stop("skillA", "stop", sess, _round_message("uid-1"))
+        bus.emit(Message("skillA.stop.response", stop_response_data,
+                         {"skill_id": "skillA", "utterance_id": "uid-1",
+                          "session": sess.serialize()}))
+        return seen
 
-        # fake skill: its stop() handler raised -- reports an error, not a result.
-        bus.on("skillA:stop",
-               lambda m: bus.emit(m.reply("skillA.stop.response",
-                                          {"skill_id": "skillA",
-                                           "error": "stop() raised ValueError"})))
+    def test_successful_stop_response_emits_no_lifecycle_terminal(self):
+        self.assertEqual(
+            self._run_round({"skill_id": "skillA", "result": True}), [],
+            "StopService must not emit a handler-lifecycle terminal")
 
-        match = svc._targeted_stop("skillA", 1.0, "stop", sess)
-        reply = Message(match.match_type, dict(match.match_data),
-                        {"skill_id": "skillA",
-                         "session": match.updated_session.serialize()})
-        disp.dispatch(reply, "skillA", "stop")
-
-        self.assertTrue(
-            any(topic.endswith("error") for topic, _ in seen),
-            f"a failed stop() must resolve as an error terminal, got {seen!r}")
-        self.assertFalse(
-            any(topic.endswith("complete") for topic, _ in seen),
-            f"a failed stop() must NOT resolve as a complete terminal, got {seen!r}")
+    def test_failed_stop_response_emits_no_lifecycle_terminal(self):
+        self.assertEqual(
+            self._run_round({"skill_id": "skillA",
+                             "error": "stop() raised ValueError"}), [],
+            "StopService must not forge an error terminal either")
 
 
 class TestIntentNameFilterIsDataNotContext(unittest.TestCase):
@@ -1194,9 +1171,11 @@ class TestIntentNameFilterIsDataNotContext(unittest.TestCase):
             "regardless of what intent_name (if any) the client stamped on "
             "its own utterance context")
 
-    def test_targeted_stop_still_resolves_via_data_marker(self):
-        """Sanity: moving the marker to `data` must not regress the L1 fix
-        itself -- a genuine targeted stop must still resolve synchronously."""
+    def test_targeted_stop_resolves_when_its_handler_returns(self):
+        """PIPELINE-1 §8: the dispatched stop handler's own return is what
+        resolves the round. A stop handler wrapped in `HandlerLifecycle` like
+        any other dispatched handler closes the dispatcher's in-flight entry;
+        StopService contributes nothing to that."""
         from ovos_core.intent_services.dispatcher import IntentDispatcher
 
         svc = _make_service()
@@ -1206,13 +1185,18 @@ class TestIntentNameFilterIsDataNotContext(unittest.TestCase):
 
         sess = Session("s3")
         sess.activate_skill("skillA")
-        bus.on("skillA:stop",
-               lambda m: bus.emit(m.reply("skillA.stop.response",
-                                          {"skill_id": "skillA", "result": True})))
 
-        match = svc._targeted_stop("skillA", 1.0, "stop", sess)
+        def stop_handler(m):
+            with HandlerLifecycle(bus, m, skill_id="skillA",
+                                  data={"name": "skillA.stop"}):
+                bus.emit(m.reply("skillA.stop.response",
+                                 {"skill_id": "skillA", "result": True}))
+
+        bus.on("skillA:stop", stop_handler)
+
+        match = svc._targeted_stop("skillA", "stop", sess, _round_message("uid-1"))
         reply = Message(match.match_type, dict(match.match_data),
-                        {"skill_id": "skillA",
+                        {"skill_id": "skillA", "utterance_id": "uid-1",
                          "session": match.updated_session.serialize()})
         disp.dispatch(reply, "skillA", "stop")
 
@@ -1225,7 +1209,7 @@ class TestPreDrainSnapshotsDoNotLeakOnFailedStop(unittest.TestCase):
     """The pre-drain snapshot must be popped for every `.stop.response`,
     not only a successful one: an error, a decline (`result: False`), or a
     response for a dispatch that never completed must not leave
-    `(session_id, skill_id)` in `_pre_drain` forever, and must not leave the
+    `(utterance_id, skill_id)` in `_pre_drain` forever, and must not leave the
     `_resolve_dispatch_lifecycle` presence-gate open for that pair."""
 
     def test_fifty_failed_stops_leave_no_leaked_snapshot_keys(self):
@@ -1233,11 +1217,12 @@ class TestPreDrainSnapshotsDoNotLeakOnFailedStop(unittest.TestCase):
         for i in range(50):
             sess = Session(f"sess{i}")
             sess.activate_skill("skillA")
-            svc._targeted_stop("skillA", 1.0, "stop", sess)
+            svc._targeted_stop("skillA", "stop", sess, _round_message(f"uid-{i}"))
             svc.handle_stop_confirmation(Message(
                 "skillA.stop.response",
                 {"skill_id": "skillA", "error": "boom"},
-                {"skill_id": "skillA", "session": sess.serialize()}))
+                {"skill_id": "skillA", "utterance_id": f"uid-{i}",
+                 "session": sess.serialize()}))
         self.assertEqual(len(svc._pre_drain), 0)
 
     def test_fifty_declined_stops_leave_no_leaked_snapshot_keys(self):
@@ -1245,11 +1230,12 @@ class TestPreDrainSnapshotsDoNotLeakOnFailedStop(unittest.TestCase):
         for i in range(50):
             sess = Session(f"x{i}")
             sess.activate_skill("skillA")
-            svc._targeted_stop("skillA", 1.0, "stop", sess)
+            svc._targeted_stop("skillA", "stop", sess, _round_message(f"uid-{i}"))
             svc.handle_stop_confirmation(Message(
                 "skillA.stop.response",
                 {"skill_id": "skillA", "result": False},
-                {"skill_id": "skillA", "session": sess.serialize()}))
+                {"skill_id": "skillA", "utterance_id": f"uid-{i}",
+                 "session": sess.serialize()}))
         self.assertEqual(len(svc._pre_drain), 0)
 
     def test_successful_stop_still_clears_snapshot(self):
@@ -1257,17 +1243,17 @@ class TestPreDrainSnapshotsDoNotLeakOnFailedStop(unittest.TestCase):
         svc = _make_service()
         sess = Session("ok")
         sess.activate_skill("skillA")
-        svc._targeted_stop("skillA", 1.0, "stop", sess)
+        svc._targeted_stop("skillA", "stop", sess, _round_message("uid-1"))
         svc.handle_stop_confirmation(Message(
             "skillA.stop.response",
             {"skill_id": "skillA", "result": True},
-            {"skill_id": "skillA", "session": sess.serialize()}))
+            {"skill_id": "skillA", "utterance_id": "uid-1", "session": sess.serialize()}))
         self.assertEqual(len(svc._pre_drain), 0)
 
 
 class TestPreDrainGateBlocksUnknownPair(unittest.TestCase):
     """`handle_stop_confirmation` must only emit a synthetic
-    handler.complete/.error for a (session_id, skill_id) pair it actually
+    handler.complete/.error for a (utterance_id, skill_id) pair it actually
     has a pre-drain snapshot for. A `.stop.response` for a pair with NO
     pre-drain snapshot at all (never went through `_targeted_stop`) must
     emit no `mycroft.skill.handler.complete`/`.error` whatsoever."""
@@ -1279,18 +1265,19 @@ class TestPreDrainGateBlocksUnknownPair(unittest.TestCase):
 
         sess = Session("unknown-sess")
         # deliberately skip _targeted_stop -- no pre-drain snapshot exists
-        # for ("unknown-sess", "skillA").
+        # for ("uid-unknown", "skillA").
         svc.handle_stop_confirmation(Message(
             "skillA.stop.response",
             {"skill_id": "skillA", "result": True},
-            {"skill_id": "skillA", "session": sess.serialize()}))
+            {"skill_id": "skillA", "utterance_id": "uid-unknown",
+             "session": sess.serialize()}))
 
         handler_signals = [t for t in emitted
                            if t in ("mycroft.skill.handler.complete",
                                     "mycroft.skill.handler.error")]
         self.assertEqual(
             handler_signals, [],
-            "a .stop.response for a (session, skill) pair with no pre-drain "
+            "a .stop.response for a (round, skill) pair with no pre-drain "
             f"snapshot must never emit a synthetic handler signal, got {emitted!r}")
 
 
@@ -1302,25 +1289,44 @@ class TestShutdown(unittest.TestCase):
         svc.shutdown()
         calls = {c[0][0] for c in svc.bus.remove.call_args_list}
         self.assertIn(GLOBAL_STOP, calls)
+        self.assertIn(SpecMessage.UTTERANCE_HANDLED.value, calls)
         # the legacy listeners are removed by the (mocked) bridge
         svc._legacy.shutdown.assert_called_once()
 
+    def test_shutdown_removes_one_listener_per_skill_regardless_of_dispatch_count(self):
+        """50 targeted-stop dispatches for the SAME skill_id must bind the
+        `.stop.response` listener exactly once -- shutdown() must remove
+        exactly that one registration, not 50."""
+        svc = _make_service()
+        for i in range(50):
+            sess = Session(f"s{i}")
+            sess.activate_skill("skillA")
+            svc._targeted_stop("skillA", "stop", sess, _round_message(f"uid-{i}"))
+        self.assertEqual(svc._stop_listeners, {"skillA"})
 
-class TestPreDrainSnapshotsAreSessionScoped(unittest.TestCase):
-    """`_pre_drain` is keyed by ``(session_id, skill_id)``, not bare
+        svc.bus.remove = MagicMock()
+        svc.shutdown()
+        stop_response_removals = [c for c in svc.bus.remove.call_args_list
+                                  if c[0][0] == "skillA.stop.response"]
+        self.assertEqual(len(stop_response_removals), 1)
+        self.assertEqual(svc._stop_listeners, set())
+
+
+class TestPreDrainSnapshotsAreRoundScoped(unittest.TestCase):
+    """`_pre_drain` is keyed by ``(utterance_id, skill_id)``, not bare
     ``skill_id``: two concurrent targeted stops for the same skill_id in
-    different sessions must not collide or consume each other's snapshot."""
+    different rounds must not collide or consume each other's snapshot."""
 
-    def test_interleaved_targeted_stops_same_skill_different_sessions(self):
+    def test_interleaved_targeted_stops_same_skill_different_rounds(self):
         svc = _make_service()
         svc.bus.emit = MagicMock()
 
-        # Session A: skill_a is blocked in get_response (RESPONSE state) ->
+        # Round A: skill_a is blocked in get_response (RESPONSE state) ->
         # its confirmation must trigger abort_question.
         sess_a = Session("session_a")
         sess_a.enable_response_mode("skill_a")
 
-        # Session B: skill_a is merely active via converse (INTENT state) ->
+        # Round B: skill_a is merely active via converse (INTENT state) ->
         # its confirmation must trigger converse.force_timeout, NOT
         # abort_question.
         sess_b = Session("session_b")
@@ -1328,21 +1334,21 @@ class TestPreDrainSnapshotsAreSessionScoped(unittest.TestCase):
 
         # interleave: A's pre-drain snapshot, then B's pre-drain snapshot,
         # both for the same skill_id, BEFORE either confirmation arrives.
-        match_a = svc._targeted_stop("skill_a", 1.0, "stop", sess_a)
-        match_b = svc._targeted_stop("skill_a", 1.0, "stop", sess_b)
+        match_a = svc._targeted_stop("skill_a", "stop", sess_a, _round_message("uid-a"))
+        match_b = svc._targeted_stop("skill_a", "stop", sess_b, _round_message("uid-b"))
         drained_a = match_a.updated_session
         drained_b = match_b.updated_session
 
         self.assertEqual(
             len(svc._pre_drain), 2,
-            "both sessions' snapshots must coexist, keyed independently")
+            "both rounds' snapshots must coexist, keyed independently")
 
         msg_a = Message("skill_a.stop.response",
                         data={"skill_id": "skill_a", "result": True},
-                        context={"session": drained_a.serialize()})
+                        context={"utterance_id": "uid-a", "session": drained_a.serialize()})
         msg_b = Message("skill_a.stop.response",
                         data={"skill_id": "skill_a", "result": True},
-                        context={"session": drained_b.serialize()})
+                        context={"utterance_id": "uid-b", "session": drained_b.serialize()})
 
         # A's confirmation arrives first, then B's.
         with patch("ovos_core.intent_services.stop_service.SessionManager.get",
@@ -1350,10 +1356,10 @@ class TestPreDrainSnapshotsAreSessionScoped(unittest.TestCase):
             svc.handle_stop_confirmation(msg_a)
         emitted_after_a = [c[0][0].msg_type for c in svc.bus.emit.call_args_list]
         self.assertIn("mycroft.skills.abort_question", emitted_after_a,
-                      "session A's own RESPONSE-state snapshot must drive its "
-                      "confirmation, not session B's")
+                      "round A's own RESPONSE-state snapshot must drive its "
+                      "confirmation, not round B's")
         self.assertNotIn("ovos.skills.converse.force_timeout", emitted_after_a,
-                         "session A was never converse-active; only its own "
+                         "round A was never converse-active; only its own "
                          "snapshot (RESPONSE-state) should be consulted")
 
         svc.bus.emit.reset_mock()
@@ -1362,14 +1368,383 @@ class TestPreDrainSnapshotsAreSessionScoped(unittest.TestCase):
             svc.handle_stop_confirmation(msg_b)
         emitted_after_b = [c[0][0].msg_type for c in svc.bus.emit.call_args_list]
         self.assertIn("ovos.skills.converse.force_timeout", emitted_after_b,
-                      "session B's own converse-active snapshot must drive "
-                      "its confirmation, not session A's (already-consumed) one")
+                      "round B's own converse-active snapshot must drive "
+                      "its confirmation, not round A's (already-consumed) one")
         self.assertNotIn("mycroft.skills.abort_question", emitted_after_b,
-                         "session B was never in RESPONSE state; the bug would "
-                         "have it consume session A's leftover/absent snapshot")
+                         "round B was never in RESPONSE state; the bug would "
+                         "have it consume round A's leftover/absent snapshot")
 
         self.assertEqual(len(svc._pre_drain), 0)
 
 
+class TestPreDrainEvictedByUtteranceHandled(unittest.TestCase):
+    """The ONLY `_pre_drain` eviction is `ovos.utterance.handled` (§9.5): the
+    universal, exactly-once-per-round end marker. A discarded Match's
+    snapshot dies with its own round's end marker; a barge-in for a NEW
+    utterance in the SAME session must never evict a different round's
+    still-pending (dispatched) snapshot."""
+
+    def test_discarded_match_snapshot_evicted_by_its_own_end_marker(self):
+        svc = _make_service()
+        svc.bus.emit = MagicMock()
+
+        sess = Session("discarded-sess")
+        sess.activate_skill("skillA")
+
+        # match() builds the Match and records the snapshot, but the
+        # orchestrator discards it (e.g. blacklist, missing slots, a
+        # higher-priority Match wins) -- never dispatched.
+        svc._targeted_stop("skillA", "stop", sess, _round_message("uid-discarded"))
+        self.assertEqual(len(svc._pre_drain), 1)
+
+        # this round's own §9.5 end marker fires regardless of whether a
+        # Match from it was ever dispatched.
+        svc._on_utterance_handled(Message(
+            SpecMessage.UTTERANCE_HANDLED.value, {},
+            {"utterance_id": "uid-discarded"}))
+
+        self.assertEqual(len(svc._pre_drain), 0,
+                         "the discarded Match's snapshot must be evicted by "
+                         "its own round's end marker")
+
+        # skillA later answers a genuine, unrelated .stop.response carrying a
+        # DIFFERENT round id (e.g. a global stop's own ping-pong round trip
+        # in a later utterance) -- no snapshot is left to resolve against.
+        svc.handle_stop_confirmation(Message(
+            "skillA.stop.response",
+            {"skill_id": "skillA", "result": True},
+            {"skill_id": "skillA", "utterance_id": "uid-later",
+             "session": sess.serialize()}))
+
+        emitted = [c[0][0].msg_type for c in svc.bus.emit.call_args_list]
+        self.assertEqual(
+            emitted, [],
+            "a discarded Match's evicted snapshot must not fire kill signals "
+            f"for a stop it never caused, got {emitted!r}")
+
+    def test_barge_in_same_session_does_not_evict_a_different_dispatched_round(self):
+        """A NEW utterance (a barge-in) in the SAME session must not evict a
+        still-running, dispatched stop's snapshot from an EARLIER round --
+        only that earlier round's own end marker may."""
+        svc = _make_service()
+        svc.bus.emit = MagicMock()
+
+        sess = Session("bargein-sess")
+        sess.activate_skill("skillA")
+
+        # round 1: a targeted stop is dispatched (genuinely, not discarded)
+        # and is still awaiting its .stop.response.
+        match = svc._targeted_stop("skillA", "stop", sess, _round_message("uid-1"))
+        self.assertEqual(len(svc._pre_drain), 1)
+
+        # round 2: a NEW utterance barges in on the SAME session and
+        # concludes (its own end marker fires) before round 1's stop() ever
+        # answers.
+        svc._on_utterance_handled(Message(
+            SpecMessage.UTTERANCE_HANDLED.value, {},
+            {"utterance_id": "uid-2", "session": sess.serialize()}))
+
+        self.assertEqual(len(svc._pre_drain), 1,
+                         "a different round's end marker must not evict "
+                         "round 1's still-pending snapshot")
+
+        # round 1's stop() finally answers -- it must still resolve.
+        svc.handle_stop_confirmation(Message(
+            "skillA.stop.response",
+            {"skill_id": "skillA", "result": True},
+            {"skill_id": "skillA", "utterance_id": "uid-1",
+             "session": match.updated_session.serialize()}))
+
+        emitted = [c[0][0].msg_type for c in svc.bus.emit.call_args_list]
+        self.assertIn("ovos.skills.converse.force_timeout", emitted,
+                      "round 1's dispatched stop must still resolve after "
+                      "surviving the barge-in in round 2")
+        self.assertEqual(len(svc._pre_drain), 0)
+
+        # round 1's own (belated) end marker is a no-op -- already consumed.
+        svc._on_utterance_handled(Message(
+            SpecMessage.UTTERANCE_HANDLED.value, {}, {"utterance_id": "uid-1"}))
+        self.assertEqual(len(svc._pre_drain), 0)
+
+    def test_dispatched_match_still_registers_and_resolves(self):
+        """Sanity companion: a Match that IS dispatched and confirmed
+        resolves correctly and clears its own snapshot."""
+        svc = _make_service()
+        svc.bus.emit = MagicMock()
+
+        sess = Session("dispatched-sess")
+        sess.enable_response_mode("skillA")
+
+        match = svc._targeted_stop("skillA", "stop", sess, _round_message("uid-1"))
+        self.assertEqual(len(svc._pre_drain), 1)
+
+        svc.handle_stop_confirmation(Message(
+            "skillA.stop.response",
+            {"skill_id": "skillA", "result": True},
+            {"skill_id": "skillA", "utterance_id": "uid-1",
+             "session": match.updated_session.serialize()}))
+
+        emitted = [c[0][0].msg_type for c in svc.bus.emit.call_args_list]
+        self.assertIn("mycroft.skills.abort_question", emitted)
+        self.assertEqual(len(svc._pre_drain), 0)
+
+
+class TestPreDrainCrossSessionIsolationOnDispatch(unittest.TestCase):
+    """Two sessions targeting the same skill_id must both be resolved
+    correctly over the real bus: the listener is a single PERMANENT
+    `bus.on` per skill_id (not a fresh `bus.once` per dispatch, which pyee
+    dedupes by (topic, function) and would silently drop a second
+    concurrent session's confirmation for the same skill_id)."""
+
+    def test_two_sessions_same_skill_both_resolve_over_the_bus(self):
+        svc = _make_service()
+        bus = svc.bus
+        emitted = []
+        orig_emit = bus.emit
+
+        def capture(m):
+            emitted.append(m)
+            return orig_emit(m)
+
+        bus.emit = capture
+
+        sess_1 = Session("sess-1")
+        sess_1.enable_response_mode("skillA")  # RESPONSE state
+        sess_2 = Session("sess-2")
+        sess_2.activate_skill("skillA")  # INTENT state (converse-active)
+
+        match_1 = svc._targeted_stop("skillA", "stop", sess_1, _round_message("uid-1"))
+        match_2 = svc._targeted_stop("skillA", "stop", sess_2, _round_message("uid-2"))
+        self.assertEqual(len(svc._pre_drain), 2)
+
+        # both sessions' skillA answer on the SAME topic, over the real bus
+        # (the single permanent listener bound for "skillA").
+        bus.emit(Message("skillA.stop.response",
+                         {"skill_id": "skillA", "result": True},
+                         {"skill_id": "skillA", "utterance_id": "uid-1",
+                          "session": match_1.updated_session.serialize()}))
+        bus.emit(Message("skillA.stop.response",
+                         {"skill_id": "skillA", "result": True},
+                         {"skill_id": "skillA", "utterance_id": "uid-2",
+                          "session": match_2.updated_session.serialize()}))
+
+        emitted_types = [m.msg_type for m in emitted]
+        self.assertIn("mycroft.skills.abort_question", emitted_types,
+                      "round 1's RESPONSE-state snapshot must still fire "
+                      "abort_question")
+        self.assertIn("ovos.skills.converse.force_timeout", emitted_types,
+                      "round 2's converse-active snapshot must still fire "
+                      "force_timeout, not be dropped by a once() dedupe")
+        self.assertEqual(len(svc._pre_drain), 0,
+                         "both rounds' snapshots must be consumed")
+
+
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestRecencyIsActivatedAtOrdered(unittest.TestCase):
+    """PIPELINE-1 §7.1 defines the recency order for `active_handlers` once,
+    normatively, and forbids consumers from defining their own: "`activated_at`
+    is authoritative: the entry with the highest `activated_at` is the most
+    recently activated", and head position is only the tie-break. STOP-1 §4.1's
+    recency rule defers to it. Reading the list in its stored order alone
+    stops the wrong skill whenever the two disagree."""
+
+    def test_highest_activated_at_wins_over_list_position(self):
+        sess = Session("s")
+        sess.active_handlers = [
+            {"skill_id": "stale_head", "activated_at": 100.0},
+            {"skill_id": "genuinely_recent", "activated_at": 900.0},
+        ]
+        with patch("ovos_core.intent_services.stop_service.SessionManager.get",
+                   return_value=sess):
+            self.assertEqual(
+                StopService.get_active_skills(Message("test"))[0],
+                "genuinely_recent")
+
+    def test_equal_activated_at_breaks_toward_the_head(self):
+        sess = Session("s")
+        sess.active_handlers = [
+            {"skill_id": "pushed_last", "activated_at": 500.0},
+            {"skill_id": "pushed_first", "activated_at": 500.0},
+        ]
+        with patch("ovos_core.intent_services.stop_service.SessionManager.get",
+                   return_value=sess):
+            self.assertEqual(
+                StopService.get_active_skills(Message("test")),
+                ["pushed_last", "pushed_first"])
+
+
+class TestCandidateFilterExcludesSelf(unittest.TestCase):
+    """STOP-1 §4.1 candidate filter: an `active_handlers` entry is skipped
+    when "its `skill_id` equals the stop plugin's own `pipeline_id` — the
+    entry PIPELINE-1 §7.1 stamps for a preceding `global_stop` dispatch. The
+    stop plugin is never its own stop target." §5.2 makes that entry the
+    ordinary post-global-stop state, so without the filter the very next
+    generic stop targets the stop plugin itself."""
+
+    def test_own_pipeline_id_is_never_a_candidate(self):
+        svc = _make_service()
+        sess = Session("s")
+        sess.active_handlers = [
+            {"skill_id": StopService.pipeline_id, "activated_at": 900.0},
+            {"skill_id": "music.skill", "activated_at": 100.0},
+        ]
+        with patch("ovos_core.intent_services.stop_service.SessionManager.get",
+                   return_value=sess):
+            candidates = svc._stop_candidates(Message("test"))
+        self.assertEqual(candidates, ["music.skill"])
+
+    def test_only_own_entry_leaves_no_candidates(self):
+        """§4.1 step 1 treats such a list as empty, so the utterance resolves
+        to `global_stop` again rather than to the stop plugin itself."""
+        svc = _make_service()
+        sess = Session("s")
+        sess.active_handlers = [
+            {"skill_id": StopService.pipeline_id, "activated_at": 900.0}]
+        with patch("ovos_core.intent_services.stop_service.SessionManager.get",
+                   return_value=sess):
+            self.assertEqual(svc._stop_candidates(Message("test")), [])
+
+    def test_blacklisted_holder_and_handlers_are_filtered(self):
+        svc = _make_service()
+        sess = Session("s")
+        sess.blacklisted_skills = ["holder_skill", "banned.skill"]
+        sess.enable_response_mode("holder_skill")
+        sess.active_handlers = [
+            {"skill_id": "banned.skill", "activated_at": 900.0},
+            {"skill_id": "ok.skill", "activated_at": 100.0},
+        ]
+        with patch("ovos_core.intent_services.stop_service.SessionManager.get",
+                   return_value=sess):
+            self.assertEqual(svc._stop_candidates(Message("test")), ["ok.skill"])
+
+
+class TestPongCanHandleIsStrictlyBoolean(unittest.TestCase):
+    """STOP-1 §4.2: a pong is valid only when it carries "a `can_handle`
+    boolean"; the plugin treats the responder as not stoppable when
+    `can_handle` "is present but not a JSON boolean — a truthy non-boolean
+    value MUST NOT be coerced to `true`".
+
+    Each case pits a truthy NON-boolean pong from the most recent candidate
+    against a real `True` from an older one. Coercion makes the recent
+    non-boolean responder a positive responder and §4.1 step 4 hands it the
+    stop; the spec makes it invisible, so the older genuine responder wins.
+    """
+
+    def _select(self, recent_can_handle):
+        svc = _make_service()
+        sess = Session("s")
+        sess.active_handlers = [
+            {"skill_id": "recent", "activated_at": 900.0},
+            {"skill_id": "older", "activated_at": 100.0},
+        ]
+
+        ack_handler = None
+
+        def capture_on(event, handler):
+            nonlocal ack_handler
+            if event == SpecMessage.STOP_PONG.value:
+                ack_handler = handler
+
+        svc.bus.emit = lambda m: None
+        svc.bus.on = capture_on
+        svc.bus.remove = MagicMock()
+
+        with patch("ovos_core.intent_services.stop_service.SessionManager.get",
+                   return_value=sess):
+            holder = []
+
+            def run():
+                holder.append(svc._collect_stop_skills(Message("test")))
+
+            t = threading.Thread(target=run)
+            t.start()
+            time.sleep(0.05)
+            ack_handler(Message(SpecMessage.STOP_PONG.value,
+                                {"skill_id": "recent",
+                                 "can_handle": recent_can_handle}))
+            ack_handler(Message(SpecMessage.STOP_PONG.value,
+                                {"skill_id": "older", "can_handle": True}))
+            t.join(timeout=2)
+        return holder[0]
+
+    def test_string_yes_is_not_a_positive_pong(self):
+        self.assertEqual(self._select("yes")[0], "older")
+
+    def test_integer_one_is_not_a_positive_pong(self):
+        self.assertEqual(self._select(1)[0], "older")
+
+    def test_non_empty_dict_is_not_a_positive_pong(self):
+        self.assertEqual(self._select({"why": "not"})[0], "older")
+
+    def test_real_boolean_true_is_a_positive_pong(self):
+        """The control: with a genuine boolean the recent skill DOES win, so
+        the cases above fail for the coercion rule and not for some unrelated
+        reason."""
+        self.assertEqual(self._select(True)[0], "recent")
+
+
+class TestStopPingBroadcast(unittest.TestCase):
+    """STOP-1 §4.1 step 2 / §4.2: the cascade emits `ovos.stop.ping` as a
+    BROADCAST, derived via `reply` from the inbound utterance Message so it
+    carries the inbound session_id and the utterance emitter's routing
+    metadata. The pre-spec per-skill `<skill_id>.stop.ping` is emitted
+    alongside it for one deprecation cycle."""
+
+    def _ping_round(self, active):
+        svc = _make_service()
+        sess = Session("s")
+        emitted = []
+        svc.bus.emit = lambda m: emitted.append(m)
+        svc.bus.on = lambda *a: None
+        svc.bus.remove = MagicMock()
+        with patch.object(StopService, "get_active_skills", return_value=active), \
+             patch("ovos_core.intent_services.stop_service.SessionManager.get",
+                   return_value=sess):
+            svc._collect_stop_skills(Message("test"))
+        return emitted
+
+    def test_exactly_one_spec_broadcast_per_round(self):
+        emitted = self._ping_round(["skill_a", "skill_b"])
+        pings = [m for m in emitted if m.msg_type == SpecMessage.STOP_PING.value]
+        self.assertEqual(len(pings), 1)
+
+    def test_legacy_per_skill_pings_still_go_out(self):
+        emitted = self._ping_round(["skill_a", "skill_b"])
+        self.assertEqual(
+            sorted(m.msg_type for m in emitted if m.msg_type.endswith(".stop.ping")
+                   and m.msg_type != SpecMessage.STOP_PING.value),
+            ["skill_a.stop.ping", "skill_b.stop.ping"])
+
+    def test_no_ping_at_all_without_candidates(self):
+        self.assertEqual(self._ping_round([]), [])
+
+
+class TestMatchDataCarriesNoInternalKeys(unittest.TestCase):
+    """PIPELINE-1 §4.3: `Match.slots` is a `{string: string}` mapping, and
+    the orchestrator forwards it verbatim as the dispatch `slots` and the §9.2
+    `ovos.intent.matched` payload. Plugin-internal bookkeeping (`conf`, the
+    pre-drain holder) is not a slot and must not ride out on the wire."""
+
+    FORBIDDEN = ("conf", "response_mode_holder")
+
+    def test_targeted_stop_slots(self):
+        svc = _make_service()
+        sess = Session("s")
+        sess.activate_skill("skill_a")
+        match = svc._targeted_stop("skill_a", "stop", sess, _round_message("uid-1"))
+        for key in self.FORBIDDEN:
+            self.assertNotIn(key, match.match_data)
+        self.assertTrue(all(isinstance(k, str) and isinstance(v, str)
+                            for k, v in match.match_data.items()))
+
+    def test_global_stop_slots(self):
+        svc = _make_service()
+        sess = Session("s")
+        sess.enable_response_mode("blocked_skill")
+        match = svc._global_stop("stop everything", sess)
+        for key in self.FORBIDDEN:
+            self.assertNotIn(key, match.match_data)
+        self.assertFalse(any(k.startswith("_pre_drain") for k in match.match_data))


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 5 (claude-opus-5) via Claude Code — NOT human-reviewed. Verify before acting.

The stop pipeline had drifted from OVOS-STOP-1 and OVOS-PIPELINE-1 in ways that pick the wrong skill to stop, put plugin-internal bookkeeping on the wire, and forge lifecycle events the orchestrator owns. This brings it back to the specs, clause by clause.

Activation-push suppression was keyed solely on the producing `pipeline_id`, which PIPELINE-1 §7.1 rules out directly: suppression "MUST be keyed on the Match's `intent_name` and its registry row — never on the producing `pipeline_id`". The §7.3 registry gives the answer per row, so `converse`, `response`, `stop` and `common_query` suppress the push while `fallback` performs it. The old pipeline_id table had `fallback` suppressing, which is the exact inversion of the registry and, in the spec's own words, "would leave the handler unreachable by OVOS-STOP-1" — a long-running language-model fallback could not be stopped.

The intent_name rule alone is not enough in practice, though, and that is worth being explicit about. None of the shipped producers emits a spec-shaped `intent_name` yet: the converse plugin emits `converse:skill` and `<skill_id>.converse.get_response`, and the common-query plugin emits `question:action.<skill_id>`. Keying on `intent_name` alone would therefore silently drop the suppression those rounds are owed, re-stamping a skill's activation on every `get_response` and every common-query answer. So the pipeline_id table stays as a transitional second gate, covering exactly those two roles, with a comment naming the producers that must migrate and the computed removal version. The fallback plugin is deliberately no longer in that table, and `FallbackService` now sets `Match.skill_id` — §7.1 keys the push on that field, so without it the fallback handler never pushed on either branch and the §7.3 push the spec requires could not happen at all. STOP-1 §5.2 falls out of the same rule: `global_stop` is not a reserved name, so the stop plugin is pushed onto `active_handlers` after a global stop. `Match.suppress_activation` is no longer read anywhere in core.

Target selection ignored `activated_at` entirely and read `active_handlers` in stored order. PIPELINE-1 §7.1 defines recency once and forbids consumers from inventing their own: `activated_at` is authoritative and head position is only the tie-break. The §4.1 candidate filter also now skips the stop plugin's own `pipeline_id` — "The stop plugin is never its own stop target" — which matters because §5.2 makes that entry the ordinary state right after a global stop, so without the filter the next "stop" targets the stop plugin. A pong now counts only when `can_handle` is literally `True`; §4.2 is explicit that "a truthy non-boolean value MUST NOT be coerced to `true`", and a skill answering `"yes"` used to outrank a genuinely stoppable one.

The §4.1 step 2 `ovos.stop.ping` broadcast was never emitted at all — only the pre-spec per-skill topic. Both go out now, with the legacy one behind a one-cycle deprecation notice whose removal version is derived from `version.py`.

Two things the plugin was emitting have been removed. The global-stop handler sent a per-skill `<holder>.stop` before the broadcast; §5.3 names exactly one emission and makes every component with user-visible activity a subscriber of `ovos.stop`. And StopService synthesized `mycroft.skill.handler.complete`/`.error` from a skill's `.stop.response`, which PIPELINE-1 §8 and STOP-1 §4.3 reserve for the orchestrator — "The stop handler does not emit either event itself." With the holder no longer needed at dispatch time, `response_mode_holder` and `conf` leave `match_data`, which §4.3 defines as a string→string slot map the orchestrator forwards verbatim. Separately, a skill registering an intent named `stop` was warned about and then indexed anyway; §9 makes declining to index an orchestrator MUST.

This folds in and closes #929: the pre-drain snapshot is keyed by `(utterance_id, skill_id)` instead of session, so a barge-in in the same session can no longer evict a still-running dispatched stop; the `.stop.response` listener is bound once per skill rather than per dispatch; and §9.5's `ovos.utterance.handled` is the sole evictor. #929's `service.py` hunk is deliberately **not** taken — it predates #930 and would revert the malformed-carrier end marker.

Removing the forged terminal only works against an ovos-workshop that emits a real one, so the floor moves to `ovos-workshop>=9.6.9a1`. That release registers the stop handler with `handler_info` and `intent_name="stop"`, which gives `IntentDispatcher._resolve_entry` the three things it reads: `data["intent_name"]`, `context["skill_id"]` and the dispatch session. Without `intent_name` the dispatcher falls back to LIFO-by-`skill_id`, and an unrelated skill's done-signal cross-resolves the stop entry while the real round is left to expire.

A MiniCroft e2e covers the whole round trip against a real workshop skill: a genuine `<skill_id>:stop` dispatch must resolve with exactly one `ovos.intent.handler.complete` and the round must produce exactly one `ovos.utterance.handled` per utterance. The exactly-once half is the load-bearing part, since the skill now sends a real done-signal and core no longer synthesizes one — they must add up to one terminal, not two and not none. Against 9.6.7a1 that test fails (the count round is parked and only one end marker arrives, the cross-resolution above); against 9.6.9a1 it passes in 8.5 s, where the unresolved path would have waited out the five-minute §8.3 timeout.

Two smaller follow-ups, neither fixable here. Removing the per-skill `<holder>.stop` means ovos-workshop's killable-event abort no longer sees a global stop; per §5.3 that should become a workshop-side subscription to `ovos.stop`. And `IntentHandlerMatch.suppress_activation` lives in ovos-plugin-manager and needs a separate PR to drop the now-unused field. `_detect_translator_bridging` in `stop_service_legacy.py` is left as is, out of scope.

One behaviour change worth calling out for review: `{skill_id}.activate` now follows the same §7.3 gate as the push, where it previously fired on its own. Emitting the activation callback while suppressing the activation is incoherent, and `.activate` is a pre-spec surface no spec defines, but the practical effect is that a `converse`, `response` or `common_query` dispatch no longer fires it. The converse and activate e2e expectations are updated accordingly.

Fail-before was done by reverting only the three source files and keeping the tests: 43 of the touched tests fail, including all four §7.3 suppression subtests (`'test.skill' unexpectedly found in ['test.skill']` for `converse`/`response`/`stop`/`common_query`), the recency and self-exclusion assertions, the `can_handle` coercion cases, the ping broadcast, the slot-map checks and the manifest indexing. Restoring the source turns all 200 green. Reverting only the transitional pipeline_id gate and the fallback `skill_id` fails the four real-producer shapes and the fallback assertion, which is the regression this correction closes. The §7.3 tests now assert the match_types the real producers emit today rather than invented `<skill_id>:<reserved_name>` strings, so the suite can no longer be green while the behaviour is absent from every live round. Full `test/unittests` plus all of `test/end2end` is 573 passed / 6 xfailed, against a dev baseline of 546 passed / 6 xfailed measured in a clean worktree on the same rebased base and the same workshop build.

