### PR TITLE
fix: write/read session.converse_handlers per OVOS-CONVERSE-1

### DIFF
--- a/ovos_core/intent_services/converse_service.py
+++ b/ovos_core/intent_services/converse_service.py
@@ -109,8 +109,15 @@ class ConverseService(PipelinePlugin):
     @staticmethod
     def get_active_skills(message: Optional[Message] = None,
                           session: Optional[Session] = None) -> List[str]:
-        """Active skill ids ordered by converse priority
-        this represents the order in which converse will be called
+        """Converse-eligible skill ids, head-first by recency.
+
+        OVOS-CONVERSE-1 §2.1: "session.converse_handlers is this
+        specification's converse eligibility list — the set of intent
+        owners the converse plugin (§4) will poll. It is distinct from
+        session.active_handlers (OVOS-PIPELINE-1 §7.1), which is the
+        dispatch-recency record used by the stop cascade." This is the
+        candidate set both the broadcast poll leg and the legacy
+        per-skill ping leg read (§4.2).
 
         Args:
             message: bus message to resolve a session from when ``session``
@@ -124,7 +131,7 @@ class ConverseService(PipelinePlugin):
             active_skills (list): ordered list of skill_ids
         """
         session = session or SessionManager.get(message)
-        return [h["skill_id"] for h in session.active_handlers]
+        return [h["skill_id"] for h in session.converse_handlers]
 
     def deactivate_skill(self, skill_id: str, source_skill: Optional[str] = None,
                          message: Optional[Message] = None) -> Optional[Session]:
@@ -145,9 +152,19 @@ class ConverseService(PipelinePlugin):
         if self._deactivate_allowed(skill_id, source_skill):
             message = message or Message("")
             session = round_session(message)
-            if session.is_active(skill_id):
+            was_converse_candidate = skill_id in [h["skill_id"] for h in session.converse_handlers]
+            if session.is_active(skill_id) or was_converse_candidate:
                 # update converse session
-                session.deactivate_skill(skill_id)
+                if session.is_active(skill_id):
+                    session.deactivate_skill(skill_id)
+                # OVOS-CONVERSE-1 §2.1's converse_handlers list is
+                # independent of active_handlers, but "Remove a skill from
+                # being targetable by converse" (this method's own contract)
+                # means both lists must drop the skill together, or a
+                # skill that deactivates itself from within converse()
+                # stays a converse candidate forever.
+                if was_converse_candidate:
+                    session.remove_converse_handler(skill_id)
 
                 # keep message.context
                 message.context["session"] = session.serialize()  # update session active skills
@@ -398,19 +415,32 @@ class ConverseService(PipelinePlugin):
         # order. Under a parallel broadcast round the arrival order is a race.
         return [skill_id for skill_id in active_skills if skill_id in claimed]
 
-    def _check_converse_timeout(self, message: Message):
-        """Drop active handlers whose converse window has expired.
+    def _prune_converse_handlers(self, message: Message):
+        """OVOS-CONVERSE-1 §3.2 TTL prune, run at both §9.1 boundaries
+        (pre-converse, before the poll iteration; pre-list-emission, before
+        answering the active-skills introspection request).
 
-        The filter is a write, so it goes on the round's own session; resolved
-        from the message rather than threaded because every caller sits in the
-        same round and gets the same object either way.
+        "the orchestrator reads activated_at from the inbound session and
+        prunes any entry whose age (now - activated_at) exceeds T". This
+        reuses the existing ``converse.timeout`` deployment window (default
+        300s, matching the pre-OVOS-CONVERSE-1 behaviour this replaces) and
+        its ``converse.skill_timeouts`` per-skill overrides, rather than
+        introducing a second TTL surface that means the same thing.
+
+        The §2.1 exemption applies: "The owner named by a present,
+        non-expired session.response_mode MUST NOT be evicted ... nor
+        pruned by the §3.2 TTL."
         """
         timeouts = self.config.get("skill_timeouts") or {}
         def_timeout = self.config.get("timeout", 300)
         session = round_session(message)
-        session.active_handlers = [
-            h for h in session.active_handlers
-            if time.time() - h["activated_at"] <= timeouts.get(h["skill_id"], def_timeout)]
+        now = time.time()
+        rm = session.response_mode
+        holder = rm.get("skill_id") if rm and rm.get("expires_at", 0) > now else None
+        session.converse_handlers = [
+            h for h in session.converse_handlers
+            if h["skill_id"] == holder
+            or now - h["activated_at"] <= timeouts.get(h["skill_id"], def_timeout)]
 
     def match(self, utterances: List[str], lang: str, message: Message) -> Optional[IntentHandlerMatch]:
         """
@@ -447,6 +477,11 @@ class ConverseService(PipelinePlugin):
         # we call flatten in case someone is sending the old style list of tuples
         utterances = flatten_list(utterances)
 
+        # OVOS-CONVERSE-1 §4.1 step 1: the §2.2 identity invariant (checked
+        # by the gr_skills filter below) is verified "after the §3.2 TTL
+        # prune (when configured)", so the prune runs first.
+        self._prune_converse_handlers(message)
+
         # note: this is sorted by priority already
         gr_skills = [skill_id for skill_id in self.get_active_skills(message, session=session)
                      if session.response_mode and session.response_mode.get("skill_id") == skill_id]
@@ -464,9 +499,6 @@ class ConverseService(PipelinePlugin):
                 utterance=utterances[0],
                 updated_session=session
             )
-
-        # filter allowed skills
-        self._check_converse_timeout(message)
 
         # check if any skill wants to converse
         for skill_id in self._collect_converse_skills(message, session=session):
@@ -537,6 +569,9 @@ class ConverseService(PipelinePlugin):
         Argument:
             message: query message to reply to.
         """
+        # OVOS-CONVERSE-1 §3.2 pre-list-emission TTL prune (§9.1's second
+        # boundary), so the reported list matches what a fresh poll would see.
+        self._prune_converse_handlers(message)
         self.bus.emit(message.reply("intent.service.active_skills.reply",
                                     {"skills": self.get_active_skills(message)}))
 

--- a/ovos_core/intent_services/service.py
+++ b/ovos_core/intent_services/service.py
@@ -547,6 +547,13 @@ class IntentService:
             for skill_id in self._deactivations.pop(live.session_id, None) or []:
                 if live.is_active(skill_id):
                     live.deactivate_skill(skill_id)
+                # OVOS-CONVERSE-1 §2.1: a tracked deactivation drops the
+                # skill from converse_handlers too, re-applied here for the
+                # same reason the active_handlers removal above is —
+                # a mid-dispatch self-deactivation (ConverseService.
+                # deactivate_skill) must survive to the round's own close,
+                # not just the snapshot it mutated in passing.
+                live.remove_converse_handler(skill_id)
             msg.context["session"] = live.serialize()
         self.bus.emit(msg)
 
@@ -740,6 +747,18 @@ class IntentService:
                         sess.activate_skill(match.skill_id)
                     # emit event for skills callback -> self.handle_activate
                     self.bus.emit(reply.forward(f"{match.skill_id}.activate"))
+
+                # OVOS-CONVERSE-1 §3.1 automatic activation on dispatch: "The
+                # orchestrator MUST stamp session.converse_handlers whenever
+                # it dispatches to an owner via the OVOS-PIPELINE-1 §7
+                # dispatch topic <skill_id>:<intent_name>. This rule is
+                # uniform — it applies to every dispatch including reserved
+                # intent_names converse (§4.3) and response (§5.2)." Unlike
+                # the §7.1 active_handlers push above, this stamp is never
+                # suppressed for reserved names or for a suppressed
+                # activation: "the two lists have independent stamping
+                # rules."
+                sess.add_converse_handler(match.skill_id)
 
             # OVOS-CONTEXT-1 §5.1: matcher-captured entries reach the session
             # via ``match.updated_session`` + the §5.3 ``ovos.session.sync``

--- a/test/end2end/test_activate.py
+++ b/test/end2end/test_activate.py
@@ -1,3 +1,4 @@
+import threading
 from unittest import TestCase
 
 from ovos_bus_client.message import Message
@@ -170,10 +171,27 @@ class TestDeactivate(TestCase):
         session = Session("123")
         session.lang = "en-US"
         session.activate_skill(self.skill_id) # start with skill active
+        # OVOS-CONVERSE-1 §2.1: converse candidacy is read from
+        # converse_handlers, a list independent of active_handlers -- seed
+        # it too so the skill is offered the poll below.
+        session.add_converse_handler(self.skill_id)
 
-        message = Message(utt_topic,
+        message1 = Message(utt_topic,
                           {"utterances": ["deactivate skill from within converse"], "lang": session.lang},
                           {"session": session.serialize(), "source": "A", "destination": "B"})
+        # OVOS-CONVERSE-1 §2.1/B1: a skill that deactivates itself from
+        # within converse() must leave converse_handlers too, not just
+        # active_handlers -- otherwise it hijacks every later utterance in
+        # the session. This third utterance (following the session's own
+        # earlier activation and this scenario's converse-and-deactivate
+        # turn) must NOT be polled at all: converse_handlers is empty, so
+        # ConverseService.match() returns None without ever emitting a ping.
+        # NOTE: no session in context -- End2EndTest threads the round's
+        # own session forward from message1, same as test_converse.py's
+        # multi-turn scenarios.
+        message2 = Message(utt_topic,
+                          {"utterances": ["are you still there"], "lang": session.lang},
+                          {"source": "A", "destination": "B"})
 
         # the skill deactivates itself inside converse, so the session ends
         # with the skill inactive (no re-activation — the skill explicitly
@@ -185,9 +203,9 @@ class TestDeactivate(TestCase):
         test = End2EndTest(
             minicroft=minicroft,
             skill_ids=[self.skill_id],
-            source_message=message,
+            source_message=[message1, message2],
             final_session=final_session,
-            activation_points=[message.msg_type], # starts activated
+            activation_points=[message1.msg_type], # starts activated
             flip_points=[utt_topic],
             entry_points=[utt_topic],
             deactivation_points=["intent.service.skills.deactivated"],
@@ -204,7 +222,7 @@ class TestDeactivate(TestCase):
                 #f"{self.skill_id}.activate", # TODO
             ],
             expected_messages=[
-                message,
+                message1,
                 # OVOS-CONVERSE-1 §4.2: one broadcast poll per round, emitted
                 # before the legacy per-skill pings (dual-emit compat window).
                 Message("ovos.converse.ping",
@@ -269,8 +287,18 @@ class TestDeactivate(TestCase):
                         context={"skill_id": self.skill_id}),
                 Message(SpecMessage.UTTERANCE_HANDLED,
                         data={},
-                        context={"skill_id": self.skill_id})
+                        context={"skill_id": self.skill_id}),
 
+                # --- message2: the skill must not be a converse candidate
+                # any more. No ovos.converse.ping / {skill_id}.converse.ping
+                # appear at all -- ConverseService._collect_converse_skills
+                # short-circuits on an empty candidate set (§4.2) before
+                # ever broadcasting -- so nothing else in the pipeline
+                # matches this utterance either.
+                message2,
+                Message("mycroft.audio.play_sound", data={"uri": "snd/error.mp3"}),
+                Message(SpecMessage.INTENT_UNMATCHED),
+                Message(SpecMessage.UTTERANCE_HANDLED),
             ]
         )
 
@@ -283,3 +311,71 @@ class TestDeactivate(TestCase):
         for namespace in NAMESPACE_PATHS:
             with self.subTest(namespace=namespace):
                 self._run_deactivate_inside_converse(namespace)
+
+
+class TestActiveHandlersOnlyIsNotPolled(TestCase):
+    """OVOS-CONVERSE-1 §2.1: "session.converse_handlers ... is distinct from
+    session.active_handlers (OVOS-PIPELINE-1 §7.1)". The converse plugin's
+    candidate set (ConverseService.get_active_skills) MUST be read from
+    converse_handlers, never active_handlers -- a skill present only on
+    active_handlers must not be offered a converse turn.
+
+    This fails against unfixed ovos-core (get_active_skills reads
+    active_handlers, so the skill is polled and claims); it passes here
+    (get_active_skills reads converse_handlers, which was never populated
+    for this skill)."""
+
+    skill_id = "ovos-skill-parrot.openvoiceos"
+
+    def setUp(self):
+        LOG.set_level("DEBUG")
+
+    def tearDown(self):
+        LOG.set_level("CRITICAL")
+
+    def test_active_handlers_only_skill_is_not_polled(self):
+        minicroft = get_minicroft([self.skill_id], modernize=False, emit_legacy=False)
+        try:
+            session = Session("789")
+            session.lang = "en-US"
+            session.pipeline = ["ovos-converse-pipeline-plugin",
+                                "ovos-padatious-pipeline-plugin-high"]
+            # candidacy source under test: active_handlers ONLY.
+            # converse_handlers is left empty.
+            session.activate_skill(self.skill_id)
+            self.assertEqual(session.converse_handlers, [])
+
+            message = Message(SpecMessage.UTTERANCE.value,
+                              {"utterances": ["echo test"], "lang": session.lang},
+                              {"session": session.serialize(),
+                               "source": "A", "destination": "B"})
+
+            captured = []
+            done = threading.Event()
+
+            def _capture(msg):
+                captured.append(msg.msg_type)
+
+            def _finish(msg):
+                done.set()
+
+            minicroft.bus.on("ovos.converse.ping", _capture)
+            minicroft.bus.on(f"{self.skill_id}.converse.ping", _capture)
+            minicroft.bus.on(SpecMessage.UTTERANCE_HANDLED.value, _finish)
+            try:
+                minicroft.bus.emit(message)
+                done.wait(timeout=10)
+            finally:
+                minicroft.bus.remove("ovos.converse.ping", _capture)
+                minicroft.bus.remove(f"{self.skill_id}.converse.ping", _capture)
+                minicroft.bus.remove(SpecMessage.UTTERANCE_HANDLED.value, _finish)
+
+            self.assertTrue(done.is_set(), "utterance round never completed")
+            self.assertNotIn("ovos.converse.ping", captured,
+                            f"{self.skill_id} was polled via the broadcast leg "
+                            f"despite being absent from converse_handlers")
+            self.assertNotIn(f"{self.skill_id}.converse.ping", captured,
+                            f"{self.skill_id} was polled via the legacy leg "
+                            f"despite being absent from converse_handlers")
+        finally:
+            minicroft.stop()

--- a/test/unittests/test_converse_service.py
+++ b/test/unittests/test_converse_service.py
@@ -53,6 +53,122 @@ def _make_service() -> ConverseService:
 
 
 # ---------------------------------------------------------------------------
+# get_active_skills
+# ---------------------------------------------------------------------------
+
+class TestGetActiveSkillsCandidateSet(unittest.TestCase):
+    """OVOS-CONVERSE-1 §2.1: "session.converse_handlers is this
+    specification's converse eligibility list ... It is distinct from
+    session.active_handlers (OVOS-PIPELINE-1 §7.1), which is the
+    dispatch-recency record used by the stop cascade." The converse
+    plugin's candidate set MUST be read from converse_handlers."""
+
+    def test_reads_converse_handlers_not_active_handlers(self):
+        sess = Session("s")
+        sess.activate_skill("stopped_skill")  # active_handlers only
+        sess.add_converse_handler("converse_skill")  # converse_handlers only
+
+        result = ConverseService.get_active_skills(session=sess)
+
+        self.assertEqual(result, ["converse_skill"])
+        self.assertNotIn("stopped_skill", result)
+
+    def test_targeted_stop_survivor_stays_a_candidate(self):
+        """§2.1: "A skill removed from active_handlers by a targeted stop
+        remains in converse_handlers and may still be offered converse
+        turns." """
+        sess = Session("s")
+        sess.add_converse_handler("skill_a")
+        sess.deactivate_skill("skill_a")  # targeted-stop-style removal
+
+        result = ConverseService.get_active_skills(session=sess)
+
+        self.assertEqual(result, ["skill_a"])
+
+
+# ---------------------------------------------------------------------------
+# _prune_converse_handlers
+# ---------------------------------------------------------------------------
+
+class TestPruneConverseHandlers(unittest.TestCase):
+    """OVOS-CONVERSE-1 §3.2 TTL prune, reusing the existing
+    ``converse.timeout`` / ``converse.skill_timeouts`` deployment surface
+    (default 300s) rather than a second TTL key."""
+
+    def test_expired_entry_pruned_before_polling(self):
+        """§3.2: "prunes any entry whose age (now - activated_at) exceeds T"
+        at the "Pre-converse" boundary, "immediately before a converse
+        plugin (§4) begins its poll iteration for the current utterance."
+        """
+        svc = _make_service()
+        svc.config = {"timeout": 60}
+        sess = Session("s")
+        now = time.time()
+        sess.add_converse_handler("stale_skill", activated_at=now - 120)
+        sess.add_converse_handler("fresh_skill", activated_at=now - 5)
+
+        with patch("ovos_core.intent_services.converse_service.SessionManager.get",
+                   return_value=sess):
+            svc._prune_converse_handlers(Message("test"))
+
+        remaining = ConverseService.get_active_skills(session=sess)
+        self.assertNotIn("stale_skill", remaining)
+        self.assertIn("fresh_skill", remaining)
+
+    def test_default_300s_timeout_applied_when_unconfigured(self):
+        """No ``converse.timeout`` configured falls back to the existing
+        300s default -- a deployment without any converse config still gets
+        a real window, unlike a second, empty TTL key would."""
+        svc = _make_service()
+        sess = Session("s")
+        now = time.time()
+        sess.add_converse_handler("old_skill", activated_at=now - 400)
+        sess.add_converse_handler("recent_skill", activated_at=now - 10)
+
+        with patch("ovos_core.intent_services.converse_service.SessionManager.get",
+                   return_value=sess):
+            svc._prune_converse_handlers(Message("test"))
+
+        remaining = ConverseService.get_active_skills(session=sess)
+        self.assertNotIn("old_skill", remaining)
+        self.assertIn("recent_skill", remaining)
+
+    def test_per_skill_timeout_override_respected(self):
+        """A ``converse.skill_timeouts`` per-skill override takes precedence
+        over the default window."""
+        svc = _make_service()
+        svc.config = {"skill_timeouts": {"short_skill": 5}, "timeout": 300}
+        sess = Session("s")
+        now = time.time()
+        sess.add_converse_handler("short_skill", activated_at=now - 10)
+        sess.add_converse_handler("long_skill", activated_at=now - 10)
+
+        with patch("ovos_core.intent_services.converse_service.SessionManager.get",
+                   return_value=sess):
+            svc._prune_converse_handlers(Message("test"))
+
+        remaining = ConverseService.get_active_skills(session=sess)
+        self.assertNotIn("short_skill", remaining)
+        self.assertIn("long_skill", remaining)
+
+    def test_response_mode_holder_exempt_from_prune(self):
+        """§2.1: the response-mode holder MUST NOT be pruned by the §3.2
+        TTL, even when its entry is otherwise stale."""
+        svc = _make_service()
+        svc.config = {"timeout": 60}
+        sess = Session("s")
+        now = time.time()
+        sess.add_converse_handler("holder_skill", activated_at=now - 120)
+        sess.response_mode = {"skill_id": "holder_skill", "expires_at": now + 60}
+
+        with patch("ovos_core.intent_services.converse_service.SessionManager.get",
+                   return_value=sess):
+            svc._prune_converse_handlers(Message("test"))
+
+        self.assertIn("holder_skill", ConverseService.get_active_skills(session=sess))
+
+
+# ---------------------------------------------------------------------------
 # _collect_converse_skills
 # ---------------------------------------------------------------------------
 
@@ -229,58 +345,6 @@ class TestCollectConverseSkills(unittest.TestCase):
         emitted_types = [c[0][0].msg_type for c in svc.bus.emit.call_args_list]
         self.assertTrue(any("skill_a" in t for t in emitted_types))
         self.assertFalse(any("skill_b" in t for t in emitted_types))
-
-
-# ---------------------------------------------------------------------------
-# _check_converse_timeout
-# ---------------------------------------------------------------------------
-
-class TestCheckConverseTimeout(unittest.TestCase):
-    """Tests for the timestamp-based skill timeout filtering."""
-
-    def test_skills_within_default_timeout_stay(self):
-        """Skills whose timestamp is recent enough survive the filter."""
-        svc = _make_service()
-        sess = Session("s")
-        now = time.time()
-        sess.active_skills = [("skill_a", now - 10)]  # 10 s ago — within 300 s default
-
-        with patch("ovos_core.intent_services.converse_service.SessionManager.get",
-                   return_value=sess):
-            svc._check_converse_timeout(Message("test"))
-
-        self.assertEqual(len(sess.active_skills), 1)
-        self.assertEqual(sess.active_skills[0][0], "skill_a")
-
-    def test_skills_past_default_timeout_removed(self):
-        """Skills older than the default timeout (300 s) are removed."""
-        svc = _make_service()
-        sess = Session("s")
-        now = time.time()
-        sess.active_skills = [("old_skill", now - 400)]  # 400 s ago — beyond default
-
-        with patch("ovos_core.intent_services.converse_service.SessionManager.get",
-                   return_value=sess):
-            svc._check_converse_timeout(Message("test"))
-
-        self.assertEqual(sess.active_skills, [])
-
-    def test_per_skill_timeout_override_respected(self):
-        """A per-skill timeout override takes precedence over the default."""
-        svc = _make_service()
-        svc.config = {"skill_timeouts": {"short_skill": 5}, "timeout": 300}
-        sess = Session("s")
-        now = time.time()
-        # short_skill has a 5-second timeout; 10 seconds old → should be removed
-        sess.active_skills = [("short_skill", now - 10), ("long_skill", now - 10)]
-
-        with patch("ovos_core.intent_services.converse_service.SessionManager.get",
-                   return_value=sess):
-            svc._check_converse_timeout(Message("test"))
-
-        remaining = [s[0] for s in sess.active_skills]
-        self.assertNotIn("short_skill", remaining)
-        self.assertIn("long_skill", remaining)
 
 
 # ---------------------------------------------------------------------------
@@ -555,7 +619,7 @@ class TestMatch(unittest.TestCase):
              patch("ovos_core.intent_services.converse_service.SessionManager.get",
                    return_value=sess), \
              patch.object(svc, "_collect_converse_skills", return_value=["skill_a"]), \
-             patch.object(svc, "_check_converse_timeout"):
+             patch.object(svc, "_prune_converse_handlers"):
             result = svc.match(["hello"], "en-US", Message("test", context={}))
 
         self.assertIsNotNone(result)
@@ -574,7 +638,7 @@ class TestMatch(unittest.TestCase):
              patch("ovos_core.intent_services.converse_service.SessionManager.get",
                    return_value=sess), \
              patch.object(svc, "_collect_converse_skills", return_value=[]), \
-             patch.object(svc, "_check_converse_timeout"):
+             patch.object(svc, "_prune_converse_handlers"):
             result = svc.match(["hello"], "en-US", Message("test", context={}))
 
         self.assertIsNone(result)
@@ -590,7 +654,7 @@ class TestMatch(unittest.TestCase):
              patch("ovos_core.intent_services.converse_service.SessionManager.get",
                    return_value=sess), \
              patch.object(svc, "_collect_converse_skills", return_value=["skill_a"]), \
-             patch.object(svc, "_check_converse_timeout"):
+             patch.object(svc, "_prune_converse_handlers"):
             result = svc.match(["hello"], "en-US", Message("test", context={}))
 
         self.assertIsNone(result)
@@ -604,7 +668,7 @@ class TestMatch(unittest.TestCase):
              patch("ovos_core.intent_services.converse_service.SessionManager.get",
                    return_value=sess), \
              patch.object(svc, "_collect_converse_skills", return_value=[]), \
-             patch.object(svc, "_check_converse_timeout"):
+             patch.object(svc, "_prune_converse_handlers"):
             result = svc.match(["hello"], "en-US", Message("test", context={}))
 
         self.assertIsNone(result)
@@ -623,7 +687,7 @@ class TestMatch(unittest.TestCase):
              patch("ovos_core.intent_services.converse_service.SessionManager.get",
                    return_value=sess), \
              patch.object(svc, "_collect_converse_skills", return_value=["skill_a"]), \
-             patch.object(svc, "_check_converse_timeout"):
+             patch.object(svc, "_prune_converse_handlers"):
             result = svc.match(["hello"], "en-US", Message("test", context={}))
 
         self.assertIsNone(result)
@@ -635,12 +699,12 @@ class TestMatch(unittest.TestCase):
 
 class TestMatchFoldChainSurvival(unittest.TestCase):
     """`match()` folds `message` ONCE (legitimate lifecycle entry) and must
-    thread that resolved session through `_check_converse_timeout` and
+    thread that resolved session through `_prune_converse_handlers` and
     `_collect_converse_skills` rather than letting either re-resolve via
     `SessionManager.get(message)` - a second fold of the SAME (now stale
-    relative to the timeout filter) message would undo the timeout filter's
-    write. These tests exercise the REAL registry end to end (no mocking of
-    SessionManager.get / _check_converse_timeout / _collect_converse_skills)
+    relative to the TTL prune) message would undo the prune's write. These
+    tests exercise the REAL registry end to end (no mocking of
+    SessionManager.get / _prune_converse_handlers / _collect_converse_skills)
     so they catch a regression to per-step re-folding."""
 
     def setUp(self):
@@ -652,16 +716,18 @@ class TestMatchFoldChainSurvival(unittest.TestCase):
         SessionManager.sessions.update(self._saved_sessions)
 
     def test_timeout_filtered_skill_stays_filtered_through_collect_converse(self):
-        """A skill removed by the timeout filter must not reappear because
+        """A skill removed by the TTL prune must not reappear because
         `_collect_converse_skills` re-folded the same stale message and
-        restored the client's originally-declared (pre-filter) active_skills
-        list."""
+        restored the client's originally-declared (pre-prune)
+        converse_handlers list."""
         bus = FakeBus()
         svc = _make_service()
         now = time.time()
         sess = Session("named-match-1")
-        # both skills are active on the round; skill_old is long expired
-        sess.active_skills = [("skill_old", now - 400), ("skill_new", now - 1)]
+        # both skills are converse candidates on the round; skill_old is
+        # long expired (past the 300s default converse.timeout)
+        sess.add_converse_handler("skill_old", activated_at=now - 400)
+        sess.add_converse_handler("skill_new", activated_at=now - 1)
 
         msg = _round("recognizer_loop:utterance",
                      {"utterances": ["hello"]}, sess)
@@ -669,10 +735,10 @@ class TestMatchFoldChainSurvival(unittest.TestCase):
         # no skill is listening on skill.converse.pong, so _collect_converse_skills
         # will time out its 0.5s wait with an empty want_converse - match()
         # returns None, which is fine, we only care about the working
-        # session's active_skills state afterward.
+        # session's converse_handlers state afterward.
         svc.match(["hello"], "en-US", msg)
 
-        remaining = [s[0] for s in sess.active_skills]
+        remaining = [h["skill_id"] for h in sess.converse_handlers]
         self.assertNotIn("skill_old", remaining)
         self.assertIn("skill_new", remaining)
         close_round(msg)
@@ -1288,6 +1354,26 @@ class TestBroadcastContest(unittest.TestCase):
         result = self._round(svc, sess, ["new_skill", "old_skill"])
 
         self.assertEqual(result, ["old_skill"])
+
+    def test_broadcast_candidates_are_converse_handlers_not_active_handlers(self):
+        """§2.1/§4.2: the broadcast leg's candidate set is
+        session.converse_handlers, read via the real (unpatched)
+        get_active_skills -- a skill present only in converse_handlers
+        (never activated on active_handlers) is polled and can claim."""
+        svc = _make_service()
+        sess = Session("s")
+        sess.add_converse_handler("skill_a")
+        skill = _FakeSkill(svc.bus, "skill_a", claims=True,
+                           candidates=["skill_a"])
+        msg = Message("test", {"utterances": ["hello"], "lang": "en-US"},
+                      {"utterance_id": "round-1", "session": sess.serialize()})
+
+        with patch("ovos_core.intent_services.converse_service.SessionManager.get",
+                   return_value=sess):
+            result = svc._collect_converse_skills(msg)
+
+        self.assertEqual(result, ["skill_a"])
+        self.assertIn("ovos.converse.ping", skill.pings_seen)
 
     # -- DEFECT: a candidate answering twice was counted twice -----------
 

--- a/test/unittests/test_intent_service_extended.py
+++ b/test/unittests/test_intent_service_extended.py
@@ -1141,6 +1141,25 @@ class TestEmitMatchMessage(unittest.TestCase):
         types = [m.msg_type for m in emitted]
         self.assertFalse(any("activate" in t for t in types))
 
+    def test_dispatch_stamps_converse_handlers(self):
+        """OVOS-CONVERSE-1 §3.1: every dispatch to an owner via
+        <skill_id>:<intent_name> MUST stamp session.converse_handlers, with
+        the §3.1 {skill_id, activated_at} shape."""
+        svc = _make_service()
+        svc.bus.emit = MagicMock()
+        sess = Session("s")
+        match = _make_match(session=sess)
+        msg = Message("recognizer_loop:utterance",
+                      data={"utterances": ["hello"]},
+                      context={"session": sess.serialize()})
+        with patch("ovos_core.intent_services.service.SessionManager.get",
+                   return_value=sess):
+            svc._dispatch_match(match, msg, "en-US")
+        synced_session = Session.deserialize(svc.bus.emit.call_args_list[-1][0][0].context["session"])
+        handlers = {h["skill_id"]: h for h in synced_session.converse_handlers}
+        self.assertIn(match.skill_id, handlers)
+        self.assertIsInstance(handlers[match.skill_id]["activated_at"], float)
+
     def test_intent_transformer_applied(self):
         """intent_plugins.transform is called before emitting the reply."""
         svc = _make_service()


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Sonnet 5 (claude-sonnet-5) via Claude Code — NOT human-reviewed. Verify before acting.

ovos-core dispatches every matched intent onto `session.active_handlers` (OVOS-PIPELINE-1 §7.1) but never wrote `session.converse_handlers`, while the converse plugin's candidate set — `ConverseService.get_active_skills`, used by both the broadcast-poll leg and the legacy per-skill ping leg — was read from `active_handlers` instead. OVOS-CONVERSE-1 §2.1 requires the two lists to be independent: "session.converse_handlers is this specification's converse eligibility list ... It is distinct from session.active_handlers (OVOS-PIPELINE-1 §7.1), which is the dispatch-recency record used by the stop cascade." `IntentService._dispatch_match` now calls `Session.add_converse_handler(match.skill_id)` unconditionally next to the existing (conditionally-suppressed) `active_handlers` push, per §3.1's "uniform ... independent stamping rules," and `ConverseService.get_active_skills` reads `session.converse_handlers` instead.

Switching only the read side, without a matching removal path, turns converse candidacy into a permanent property of the session. A skill that calls `self.deactivate()` from inside its own `converse()` — a supported, already-tested pattern in `test/end2end/test_activate.py`'s `TestSkill` — removed itself from `active_handlers`, which nothing reads for candidacy any more, while remaining in `converse_handlers` forever and hijacking every later utterance in the session. Two write paths now also remove from `converse_handlers`: `ConverseService.deactivate_skill` (the immediate, in-band removal a self-deactivating skill triggers), and `IntentService._emit_utterance_handled`'s existing end-of-round re-application of tracked deactivations — which already re-applies the `active_handlers` removal defensively, in case the in-flight session object the skill mutated does not survive to the round's close — now extended to re-apply the `converse_handlers` removal there too, so it survives to the round boundary the same way.

The §3.2 TTL prune reads the existing `converse.timeout` / `converse.skill_timeouts` deployment surface (default 300s) instead of introducing a second, empty TTL key. An earlier version of this fix added a `converse_handlers_ttl` config key that exists in no deployment's config, silently disabling the 300-second window `converse.timeout` has always provided and leaving `converse_handlers` to age out only via the 64-entry size cap — precisely the failure §3.2 names ("a stale owner would be polled on every utterance forever"). `_check_converse_timeout` (which filtered `active_handlers`, a list nothing reads for candidacy any more) is retired; `_prune_converse_handlers` is the one mechanism that owns the window now, respecting the §2.1 response-mode holder exemption. Per §9.1 the prune runs at both boundaries — pre-converse, moved ahead of the §4.1 step 1 response-mode branch to match the step order the spec gives, and pre-list-emission, ahead of `handle_get_active_skills`' introspection reply.

`stop_service.py` is untouched (in flight in #932): its own `converse_handlers` mutations via `Match.updated_session` on stop dispatches are orthogonal to the write/removal paths fixed here.

Every regression test was verified fail-before/pass-after via patch-revert of the corresponding source change. `test_dispatch_stamps_converse_handlers` fails with `'test.skill' not found in {}` against the unfixed write path. The `converse_service.py` unit tests (candidate-set source and targeted-stop survival, four TTL-prune tests including the per-skill override and the response-mode exemption, and a real `_collect_converse_skills` round proving the broadcast leg's candidates come from `converse_handlers`) all fail against the unfixed file with empty/wrong lists or a stale config key. Most importantly, `test/end2end/test_activate.py::test_deactivate_inside_converse` was extended to a second utterance after the self-deactivating one: with only the two `remove_converse_handler` calls stripped back out, the skill is re-polled and re-claims that utterance (got 33 messages, expected 22 — `ovos.converse.ping` fires again), reproducing the live hijack this fix closes. A new `TestActiveHandlersOnlyIsNotPolled` seeds a session with the target skill on `active_handlers` only; it fails when `get_active_skills` reads `active_handlers` and passes against the fixed read.

Full local run: `test/unittests` 505 passed / 6 xfailed, `test/end2end` 41 passed / 48 subtests — 546 total, matching the stated dev baseline of 540 plus the 6 net new tests this PR adds, with no other regressions.

This lands alongside ovos-workshop#590 (draft), which switches the skill-side candidacy check from `active_handlers` to `converse_handlers`. Until that merges, ovos-workshop's broadcast-leg pong handler still checks `active_handlers`, so a skill activated only via a `converse`/`response` reserved-name dispatch (never a plain intent) would be polled by core but decline from the skill side because it isn't yet checking the right field. The common case — activation via a plain intent — populates both lists identically today and is unaffected either way.

Retiring the converse timeout filter also removes the only time bound on `session.active_handlers`: the stop cascade now sees every dispatched handler until OVOS-STOP-1 §4.4 self-pruning or the global-stop drain removes it, so `converse.timeout` no longer bounds stop targeting as a side effect (PIPELINE-1 §7.1 defines no TTL for that list).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved conversational follow-up handling by tracking skills that participated in the current conversation.
  * Skills that deactivate themselves are no longer queried for additional conversational turns.
  * Conversational candidates now expire automatically after their time limit, while active response modes remain available.
  * Active-skill results are refreshed before being reported for more accurate status information.
  * Improved compatibility and reliability when multiple skills compete to respond.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->