### PR TITLE
fix: retire ovos-core's own ovos.session.sync merge (OVOS-SESSION-2 §2.7/§7)

### DIFF
--- a/docs/prerelease-quirks.md
+++ b/docs/prerelease-quirks.md
@@ -9,6 +9,17 @@ This file resets at the next stable release. At that point its contents
 become upgrade notes for the `2.1.1 -> next-stable` jump, and a new, empty
 quirks log starts.
 
+## #935 (alpha of 2026-09-06)
+
+The floor on `ovos-bus-client` moves to 2.11.13a1. Core no longer subscribes
+`ovos.session.sync` itself — the handler and its named-session merge into an
+in-flight round are gone, since OVOS-SESSION-2 §2.7 defines no topic on which
+one participant pushes a session at another. A pre-spec peer that still emits
+`ovos.session.sync` for the default session is folded by ovos-bus-client's own
+`SessionManager.handle_session_sync`, a one-cycle compat shim kept there
+rather than in core; a push naming a named session it does not hold is
+ignored. The floor pin is what keeps that shim available.
+
 ## #915 (alpha of 2026-09-03)
 
 Floors moved to `ovos-bus-client` 2.11.1a1 and `ovos-spec-tools` 1.10.1a1,
@@ -30,9 +41,6 @@ treatment; `ovos-workshop`'s `set_context` producer still does.
 
 `ovos.utterance.handled` on the no-match path now carries the decayed
 `intent_context`, which for a named session is the only channel it has.
-`ovos.session.sync` is consumed for its §2.7 whole-session snapshot on
-`Message.data["session"]`, in addition to SessionManager's §5.3
-`intent_context` merge on the same topic.
 
 Core takes one arrival per utterance, but `MessageBusClient` still folds
 every inbound default-session message at the transport layer. Narrowing that

--- a/ovos_core/intent_services/service.py
+++ b/ovos_core/intent_services/service.py
@@ -30,7 +30,7 @@ from ovos_config.config import Configuration
 from ovos_config.locale import get_valid_languages
 from ovos_spec_tools import closest_lang, standardize_lang, SpecMessage
 from ovos_spec_tools.context import resolve_key
-from ovos_spec_tools.session import merge_carrier, resolve_session_id
+from ovos_spec_tools.session import resolve_session_id
 from ovos_utils.log import LOG
 from ovos_utils.metrics import Stopwatch
 from ovos_utils.process_utils import ProcessStatus, StatusCallbackMap
@@ -40,7 +40,7 @@ from ovos_core.transformers import MetadataTransformersService, UtteranceTransfo
 from ovos_core.intent_services.dispatcher import IntentDispatcher, DEFAULT_HANDLER_TIMEOUT
 from ovos_core.intent_services.manifest import IntentManifest
 from ovos_core.intent_services.working_session import (
-    close_round, open_round, pruned_entries, record_pruned, round_session, working_session,
+    close_round, open_round, pruned_entries, record_pruned, round_session,
 )
 from ovos_core.version import OVOS_VERSION_STR, VERSION_MAJOR
 from ovos_plugin_manager.pipeline import OVOSPipelineFactory
@@ -136,9 +136,8 @@ def _replace_intent_context(sess, new_ctx: dict) -> None:
 
     ``Session.intent_context`` dict identity must be preserved; see the
     ovos-bus-client ``_CONTEXT_LOCK`` contract (every live view — the adapt
-    frame-stack projection, a mid-round ``ovos.session.sync`` merge — holds
-    the same map object). It also stays a dict, never ``None``: an empty
-    context is an empty dict.
+    frame-stack projection among them — holds the same map object). It also
+    stays a dict, never ``None``: an empty context is an empty dict.
     """
     with _CONTEXT_LOCK:
         if sess.intent_context is None:
@@ -220,11 +219,6 @@ class IntentService:
 
         self.bus.on(SpecMessage.UTTERANCE, self.handle_utterance)
 
-        # OVOS-SESSION-2 §6.2: honour a synced session snapshot. The §5.3
-        # intent_context half of this topic is SessionManager's and is already
-        # subscribed there; this handler takes the whole-session snapshot.
-        self.bus.on(SpecMessage.SESSION_SYNC, self.handle_session_sync)
-
         # Context related handlers
         self.bus.on('add_context', self.handle_add_context)
         self.bus.on('remove_context', self.handle_remove_context)
@@ -241,32 +235,6 @@ class IntentService:
         self.status.set_alive()
         if preload_pipelines:
             self.bus.emit(Message('intent.service.pipelines.reload'))
-
-    def handle_session_sync(self, message: Message):
-        """OVOS-SESSION-2 §2.7 — take a synced session snapshot into the
-        session it is for.
-
-        §2.7 puts the snapshot in ``Message.data["session"]`` and leaves
-        ``Message.context["session"]`` as the ambient carrier saying *which*
-        session the sync is about, so the content comes from the data and the
-        identity from the context. The merge is §5.1's: a field the snapshot
-        carries replaces, a field it omits leaves the current value alone.
-
-        For the default session the merge lands in the store, which
-        ``SessionManager`` owns. For a named session there is no store (§2.2)
-        and §2.7 directs the update at the session of the utterance in
-        progress — so it applies while that round is open, and a sync arriving
-        outside one has no session to revise and is dropped.
-        """
-        payload = message.data.get("session") or {}
-        if not payload:
-            return
-        sess = working_session(message)
-        if sess is not None and not sess.is_default:
-            sess.update_from(
-                Session.deserialize(merge_carrier(sess, payload)))
-            return
-        SessionManager.handle_sync(message)
 
     def handle_reload_pipelines(self, message: Message) -> None:
         pipeline_plugins = OVOSPipelineFactory.get_installed_pipeline_ids()
@@ -780,8 +748,8 @@ class IntentService:
                 sess.add_converse_handler(match.skill_id)
 
             # OVOS-CONTEXT-1 §5.1: matcher-captured entries reach the session
-            # via ``match.updated_session`` + the §5.3 ``ovos.session.sync``
-            # merge — IntentHandlerMatch carries no ``intent_context`` field.
+            # only via ``match.updated_session`` — IntentHandlerMatch carries
+            # no ``intent_context`` field of its own.
 
             # OVOS-CONTEXT-1 §7: fill unfilled slots from live context
             self._apply_context_slots(match, sess, reply)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,9 @@ dependencies = [
     "python-dateutil>=2.6, <3.0",
     "combo-lock>=0.2.2, <0.4",
     "ovos-utils>=0.13.9a1,<1.0.0",
-    # OVOS-SESSION-2 §5.1 arrival merge: SessionManager.fold_inbound / handle_sync
-    "ovos_bus_client>=2.11.1a1,<3.0.0",
+    # OVOS-SESSION-2 §5.1 arrival merge (SessionManager.fold_inbound) plus the
+    # one-cycle ovos.session.sync compat shim (SessionManager.handle_session_sync)
+    "ovos_bus_client>=2.11.13a1,<3.0.0",
     "ovos-plugin-manager>=2.11.1a1,<3.0.0",
     "ovos-config>=2.1.4a5,<4.0.0",
     "ovos-workshop>=9.6.9a1,<10.0.0",

--- a/test/unittests/test_intent_context.py
+++ b/test/unittests/test_intent_context.py
@@ -20,8 +20,6 @@ import unittest
 from collections import defaultdict
 from unittest.mock import MagicMock
 
-import pytest
-
 from ovos_bus_client.message import Message
 from ovos_bus_client.session import DEFAULT_SESSION_ID, Session, SessionManager
 from ovos_utils.fakebus import FakeBus
@@ -32,21 +30,9 @@ from ovos_spec_tools.context import (
     normalize_declaration,
     gate_satisfied,
     context_supplied_slots,
-    decrement,
     INTENT_CONTEXT_FIELD,
 )
 from ovos_core.intent_services.service import IntentService
-
-
-# OVOS-SESSION-2 §2.7: the session snapshot's PRIMARY carrier is
-# ``Message.data["session"]``; ``Message.context["session"]`` is the legacy
-# carrier, accepted as a fallback. ovos-bus-client#278 teaches
-# ``SessionManager.handle_session_sync`` to read the data carrier (preferring
-# it when both are present); until it ships, the data-carrier path is a
-# no-match on the fallback-only handler in bus-client dev.
-_NEEDS_BUS_CLIENT_278 = (
-    "requires ovos-bus-client#278 (SESSION-2 §2.7 data carrier); XPASS means "
-    "#278 shipped - drop the marker and bump the floor pin")
 
 
 def _sync_msg(snap: dict, carrier: str = "data") -> Message:
@@ -227,11 +213,12 @@ class TestSlotFill(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
-# live FakeBus integration through the REAL SessionManager
+# live FakeBus integration through the REAL SessionManager and IntentService
 # ---------------------------------------------------------------------------
 
-class TestLiveSessionManagerSync(unittest.TestCase):
-    """Drive ``ovos.session.sync`` through the real SessionManager (§5.3)."""
+class TestLiveIntentServiceRound(unittest.TestCase):
+    """Drive a real ``IntentService`` round over a ``FakeBus`` against the
+    real ``SessionManager`` (§4.2 decay, §5 working-session binding)."""
 
     def setUp(self):
         # isolate the singleton between tests
@@ -241,24 +228,6 @@ class TestLiveSessionManagerSync(unittest.TestCase):
     def tearDown(self):
         SessionManager.sessions = {"default": Session("default")}
         SessionManager.bus = None
-
-    @pytest.mark.xfail(strict=True, reason=_NEEDS_BUS_CLIENT_278)
-    def test_real_sessionmanager_merges_sync(self):
-        sess = Session("live-sess")
-        sess.intent_context = {"keep": {"value": "k"}}
-        SessionManager.update(sess)
-
-        # a skill emits ovos.session.sync with an updated session snapshot
-        snap = sess.serialize()
-        snap[INTENT_CONTEXT_FIELD] = {
-            "tea.skill:confirming_milk": {"value": None, "turns_remaining": 1},
-            "keep": None,  # delete
-        }
-        SessionManager.handle_session_sync(_sync_msg(snap))
-
-        merged = SessionManager.sessions["live-sess"].intent_context
-        self.assertIn("tea.skill:confirming_milk", merged)
-        self.assertNotIn("keep", merged)
 
     def test_orchestrator_decays_a_named_session_over_the_wire(self):
         """§4.2 decay on a named session, which the orchestrator holds no
@@ -345,66 +314,6 @@ class TestLiveSessionManagerSync(unittest.TestCase):
         svc.handle_utterance(msg)
         self.assertIs(seen["bound"], SessionManager.get_default_session())
 
-    @pytest.mark.xfail(strict=True, reason=_NEEDS_BUS_CLIENT_278)
-    def test_midispatch_sync_survives_decay(self):
-        # §4.1: a mid-dispatch entry is not decremented by the round it arrived in
-        sess = Session("mid-sess")
-        sess.intent_context = {"old.skill:flag": {"value": None,
-                                                  "turns_remaining": 1}}
-        SessionManager.update(sess)
-
-        pre_match_keys = set(sess.intent_context.keys())
-
-        # mid-dispatch sync merges a disjoint new key
-        snap = sess.serialize()
-        snap[INTENT_CONTEXT_FIELD] = {
-            "new.skill:flag": {"value": None, "turns_remaining": 1}}
-        SessionManager.handle_session_sync(_sync_msg(snap))
-
-        managed = SessionManager.sessions["mid-sess"]
-        post_ctx = dict(managed.intent_context or {})
-        decrement(post_ctx, only_keys=pre_match_keys)
-        managed.intent_context = post_ctx or None
-        SessionManager.update(managed)
-
-        ctx = SessionManager.sessions["mid-sess"].intent_context
-        self.assertEqual(ctx["old.skill:flag"]["turns_remaining"], 0)
-        self.assertEqual(ctx["new.skill:flag"]["turns_remaining"], 1)
-
-    @pytest.mark.xfail(strict=True, reason=_NEEDS_BUS_CLIENT_278)
-    def test_midispatch_sync_refresh_of_existing_key_not_decremented(self):
-        # §4.1: a mid-dispatch sync refreshing an existing key must be
-        # compared by entry value, not key presence, to avoid decrementing it
-        bus = FakeBus()
-        SessionManager.connect_to_bus(bus)
-        svc = _make_service()
-        svc.bus = bus
-
-        sess = Session("refresh-sess")
-        sess.intent_context = {"tea.skill:flag": {"value": "a",
-                                                  "turns_remaining": 1}}
-        SessionManager.update(sess)
-
-        def _mid_dispatch_refresh(utterances, lang, message):
-            # a skill refreshes the SAME key mid-dispatch via a real sync
-            snap = SessionManager.sessions["refresh-sess"].serialize()
-            snap[INTENT_CONTEXT_FIELD] = {
-                "tea.skill:flag": {"value": "b", "turns_remaining": 5}}
-            SessionManager.handle_session_sync(_sync_msg(snap))
-            return None  # no match, decay still runs to completion
-
-        svc.get_pipeline = lambda session: [("fake", _mid_dispatch_refresh)]
-
-        msg = Message("recognizer_loop:utterance",
-                      data={"utterances": ["hello"]},
-                      context={"session":
-                               SessionManager.sessions["refresh-sess"].serialize()})
-        svc.handle_utterance(msg)
-
-        ctx = SessionManager.sessions["refresh-sess"].intent_context
-        self.assertEqual(ctx["tea.skill:flag"]["turns_remaining"], 5)
-        self.assertEqual(ctx["tea.skill:flag"]["value"], "b")
-
 
 class TestDispatchMatchRejectsMismatchedUpdatedSession(unittest.TestCase):
     """OVOS-PIPELINE-1 §4.2 / OVOS-SESSION-2 §5.1: ``updated_session`` is
@@ -462,9 +371,13 @@ class TestSessionSyncCarrier(unittest.TestCase):
     tearDown = setUp
 
     def _tracked(self, sid):
+        # OVOS-SESSION-2 §2.2: the registry holds only the default session;
+        # SessionManager.update() on a named session is a no-op by contract
+        # (§2.5) and never records it. Seed the registry directly instead,
+        # the pattern ovos-bus-client's own tests use.
         sess = Session(sid)
         sess.intent_context = {"keep": {"value": "k"}}
-        SessionManager.update(sess)
+        SessionManager.sessions[sid] = sess
         return sess
 
     def _snap(self, sess, entries):
@@ -484,26 +397,6 @@ class TestSessionSyncCarrier(unittest.TestCase):
         SessionManager.handle_session_sync(_sync_msg(snap, carrier="context"))
         merged = SessionManager.get_default_session().intent_context
         self.assertEqual(merged.get("from.ctx"), {"value": "ctx"})
-
-    @pytest.mark.xfail(strict=True, reason=_NEEDS_BUS_CLIENT_278)
-    def test_data_carrier_is_honoured(self):
-        """§2.7 primary carrier: the snapshot rides ``data['session']``."""
-        sess = self._tracked("carrier-data")
-        snap = self._snap(sess, {"from.data": {"value": "data"}})
-        SessionManager.handle_session_sync(_sync_msg(snap))
-        merged = SessionManager.sessions["carrier-data"].intent_context
-        self.assertEqual(merged.get("from.data"), {"value": "data"})
-
-    @pytest.mark.xfail(strict=True, reason=_NEEDS_BUS_CLIENT_278)
-    def test_data_carrier_wins_over_context_carrier(self):
-        """§2.7: when both carriers are present, ``data`` is authoritative;
-        the ``context`` decoy must not be merged."""
-        sess = self._tracked("carrier-both")
-        snap = self._snap(sess, {"from.data": {"value": "data"}})
-        SessionManager.handle_session_sync(_sync_msg(snap, carrier="both"))
-        merged = SessionManager.sessions["carrier-both"].intent_context
-        self.assertEqual(merged.get("from.data"), {"value": "data"})
-        self.assertNotIn("carrier.probe", merged)
 
 
 class TestDecayIgnoresUnknownSession(unittest.TestCase):
@@ -553,6 +446,7 @@ from unittest.mock import patch  # noqa: E402
 from ovos_plugin_manager.templates.pipeline import IntentHandlerMatch  # noqa: E402
 from ovos_core.intent_services.manifest import IntentManifest  # noqa: E402
 from ovos_core.intent_services.dispatcher import IntentDispatcher  # noqa: E402
+from ovos_core.intent_services.working_session import working_session  # noqa: E402
 
 
 class TestOrchestratorGate(unittest.TestCase):
@@ -789,25 +683,13 @@ class TestDecayPropagatesToTerminalEmissions(unittest.TestCase):
         self.assertEqual(
             turn2_session[INTENT_CONTEXT_FIELD]["person"]["turns_remaining"], 1)
 
-    @pytest.mark.xfail(strict=True, reason=_NEEDS_BUS_CLIENT_278)
-    def test_same_dispatch_exemption_still_holds(self):
-        # A key synced mid-round must not be decremented by the very round
-        # that produced it.
-        sess = Session("exempt-sess")
-        sess.intent_context = {"person": {"value": "Bob", "turns_remaining": 3}}
-        SessionManager.update(sess)
-
-        def _mid_round_sync(utts, lang, msg):
-            snap = SessionManager.sessions["exempt-sess"].serialize()
-            snap[INTENT_CONTEXT_FIELD] = {
-                "new.skill:flag": {"value": None, "turns_remaining": 1}}
-            SessionManager.handle_session_sync(_sync_msg(snap))
-            return None  # this matcher itself does not match
-
-        match = IntentHandlerMatch(match_type="lights.skill:on",
-                                   match_data={"conf": 1.0},
-                                   skill_id="lights.skill", utterance="turn on")
-
+    def test_key_written_in_round_is_not_decremented_by_that_round(self):
+        """§4.1: an entry a pipeline plugin writes onto the round's own
+        working session mid-dispatch is compared by value against its
+        pre-match snapshot, so this round's decay does not touch it -- an
+        entry it plants fresh and one whose value it changes are both
+        exempt. The write goes through ``working_session``, the §2.6-legal
+        in-round mutation path, not a bus push."""
         bus = FakeBus()
         SessionManager.connect_to_bus(bus)
         svc = _make_service()
@@ -817,33 +699,41 @@ class TestDecayPropagatesToTerminalEmissions(unittest.TestCase):
         svc.intent_manifest = IntentManifest(bus)
         svc.intent_dispatcher = IntentDispatcher(
             bus, timeout=0, on_terminal=svc._emit_utterance_handled)
+
+        match = IntentHandlerMatch(match_type="lights.skill:on",
+                                   match_data={"conf": 1.0},
+                                   skill_id="lights.skill", utterance="turn on")
+
+        def _writer(utts, lang, msg):
+            sess = working_session(msg)
+            sess.intent_context["new.skill:flag"] = {"value": None,
+                                                     "turns_remaining": 1}
+            sess.intent_context["person"] = {"value": "Ann", "turns_remaining": 3}
+            return None
+
         svc.get_pipeline = lambda session: [
-            ("mid-round-sync", _mid_round_sync),
-            ("fake-high", lambda utts, lang, msg: match)]
+            ("writer", _writer), ("fake-high", lambda u, l, m: match)]
 
-        handled_frames = []
-        bus.on("ovos.utterance.handled", handled_frames.append)
+        received, handled = [], []
+        bus.on("lights.skill:on", received.append)
+        bus.on("ovos.utterance.handled", handled.append)
 
-        received = []
-
-        def _fake_handler(message):
-            SessionManager.get(message)
-            received.append(message)
-        bus.on("lights.skill:on", _fake_handler)
-
-        msg = Message("recognizer_loop:utterance",
-                      data={"utterances": ["turn on"]},
-                      context={"session": SessionManager.sessions["exempt-sess"].serialize()})
-        svc.handle_utterance(msg)
-
+        carrier = Session("exempt-sess")
+        carrier.intent_context = {"person": {"value": "Bob", "turns_remaining": 3}}
+        svc.handle_utterance(Message("recognizer_loop:utterance",
+                                     {"utterances": ["turn on"]},
+                                     {"session": carrier.serialize()}))
         self.assertEqual(len(received), 1, "handler was never dispatched")
-        bus.emit(Message("mycroft.skill.handler.complete",
-                         {}, {"skill_id": "lights.skill",
-                              "session": received[0].context.get("session")}))
+        bus.emit(Message("mycroft.skill.handler.complete", {},
+                         {"skill_id": "lights.skill",
+                          "session": received[0].context.get("session")}))
 
-        ctx = handled_frames[0].context["session"][INTENT_CONTEXT_FIELD]
-        self.assertEqual(ctx["person"]["turns_remaining"], 2)
+        ctx = handled[0].context["session"][INTENT_CONTEXT_FIELD]
+        # written during the round -> exempt from this round's decay
         self.assertEqual(ctx["new.skill:flag"]["turns_remaining"], 1)
+        # value CHANGED during the round -> also exempt (value comparison)
+        self.assertEqual(ctx["person"]["turns_remaining"], 3)
+        self.assertEqual(ctx["person"]["value"], "Ann")
 
 
 # ---------------------------------------------------------------------------

--- a/test/unittests/test_session2_intake.py
+++ b/test/unittests/test_session2_intake.py
@@ -170,50 +170,62 @@ class TestArrivalHappensOnceAnUtterance(SessionIntakeTestCase):
         self.assertIn("Kitchen", stored.intent_context or {})
 
 
-class TestSessionSyncConsumer(SessionIntakeTestCase):
-    """§2.7 / §6.2 — ``ovos.session.sync`` carries a snapshot in
-    ``Message.data["session"]`` and the orchestrator honours it."""
+class TestSessionSyncIsRetired(SessionIntakeTestCase):
+    """OVOS-SESSION-2 §2.7 defines no topic on which any participant pushes
+    a session at another, and §7 defines no bus topic at all. IntentService
+    MUST NOT subscribe ``ovos.session.sync`` nor own a merge for it."""
 
-    def _sync(self, snapshot, carrier=None):
-        context = {} if carrier is None else {"session": carrier}
-        return Message(SpecMessage.SESSION_SYNC, {"session": snapshot}, context)
-
-    def test_sync_merges_the_data_carrier_into_the_store(self):
-        svc = _make_service(self.bus)
-        stored = SessionManager.get_default_session()
-        stored.blacklisted_intents = ["skill_x"]
-
-        synced = Session(DEFAULT_SESSION_ID)
-        synced.intent_context = {"tea.skill:brewing": {"value": "yes"}}
-        svc.handle_session_sync(self._sync(synced.serialize()))
-
-        stored = SessionManager.get_default_session()
-        self.assertIn("tea.skill:brewing", stored.intent_context or {})
-        # §5.1: what the snapshot omits keeps its stored value
-        self.assertEqual(stored.blacklisted_intents, ["skill_x"])
-
-    def test_sync_for_an_unknown_named_session_is_dropped(self):
-        """§2.2: no round is open for it, so there is nothing to revise — and
-        certainly not the default store."""
-        svc = _make_service(self.bus)
-
-        synced = Session("nobody-here")
-        synced.intent_context = {"tea.skill:brewing": {"value": "yes"}}
-        svc.handle_session_sync(
-            self._sync(synced.serialize(), carrier=synced.serialize()))
-
-        self.assertEqual(SessionManager.sessions.get("nobody-here"), None)
+    def test_init_does_not_subscribe_session_sync(self):
+        """A real ``IntentService`` (constructed through ``__init__``, not
+        ``_make_service``'s ``__new__`` bypass) must add no listener of its
+        own on ``ovos.session.sync``. ``SessionManager.connect_to_bus`` is
+        run first, exactly as ``IntentService.__init__`` itself would trigger
+        it, so the only listener before and after construction must be
+        ovos-bus-client's own retained shim, by identity -- never one added
+        by ``IntentService``."""
+        SessionManager.connect_to_bus(self.bus)
+        before = list(self.bus.ee.listeners(SpecMessage.SESSION_SYNC))
         self.assertEqual(
-            SessionManager.get_default_session().intent_context or {}, {})
+            before, [SessionManager.handle_session_sync],
+            "sanity check failed: expected only ovos-bus-client's own "
+            "SessionManager.handle_session_sync listening before "
+            "IntentService exists")
 
-    def test_sync_reaches_the_named_session_of_an_open_round(self):
-        """§2.7 directs a named-session sync at the utterance in progress."""
+        IntentService(self.bus, preload_pipelines=False)
+
+        after = list(self.bus.ee.listeners(SpecMessage.SESSION_SYNC))
+        self.assertEqual(
+            after, before,
+            "IntentService.__init__ added its own ovos.session.sync "
+            "listener; OVOS-SESSION-2 §2.7/§7 define no such topic")
+
+    def test_intent_service_has_no_session_sync_handler(self):
+        """The method itself must not exist: this is a retirement, not a
+        no-op stub."""
+        svc = _make_service(self.bus)
+        self.assertFalse(hasattr(svc, "handle_session_sync"))
+
+    def test_pushed_named_session_does_not_mutate_the_open_round(self):
+        """Even if something on the bus still emits the retired topic, no
+        subscriber of IntentService's own reacts to it — the open round's
+        session is untouched.
+
+        Constructed through ``IntentService(bus, ...)`` (``__init__``), not
+        ``_make_service``'s ``__new__`` bypass: the bypass never registers
+        any bus listener at all, named-session merge or not, so emitting
+        ``ovos.session.sync`` against it would reach no subscriber
+        regardless of whether the retired handler exists -- a vacuous test.
+        Constructing through ``__init__`` means the emitted sync actually
+        reaches whatever the real subscription set contains.
+        """
         received = []
         self.bus.on("lights.skill:on", received.append)
         match = IntentHandlerMatch(match_type="lights.skill:on",
                                    match_data={"conf": 1.0},
                                    skill_id="lights.skill", utterance="turn on")
-        svc = _make_service(self.bus, match=match)
+        svc = IntentService(self.bus, preload_pipelines=False)
+        svc.get_pipeline = lambda session: (
+            [("fake-high", lambda utts, lang, msg: match)])
 
         carrier = Session("client-1")
         message = _utterance(carrier.serialize(), utterance="turn on")
@@ -222,19 +234,19 @@ class TestSessionSyncConsumer(SessionIntakeTestCase):
         svc.handle_utterance(message)
         self.assertEqual(len(received), 1, "handler was never dispatched")
 
-        # the skill syncs a context entry mid-round, on its own dispatch frame
+        # a would-be pusher tries to sync a context entry into the open round
         synced = Session("client-1")
         synced.intent_context = {"lights.skill:room": {"value": "kitchen"}}
-        svc.handle_session_sync(
-            Message(SpecMessage.SESSION_SYNC, {"session": synced.serialize()},
-                    dict(received[0].context)))
+        self.bus.emit(Message(SpecMessage.SESSION_SYNC,
+                              {"session": synced.serialize()},
+                              dict(received[0].context)))
 
         self.bus.emit(Message("mycroft.skill.handler.complete", {},
                               {"skill_id": "lights.skill",
                                "session": received[0].context.get("session")}))
         self.assertEqual(len(handled), 1)
-        self.assertIn("lights.skill:room",
-                      handled[0].context["session"].get(INTENT_CONTEXT_FIELD) or {})
+        self.assertNotIn("lights.skill:room",
+                         handled[0].context["session"].get(INTENT_CONTEXT_FIELD) or {})
 
 
 class TestNamedSessionThreading(SessionIntakeTestCase):


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5.1 (claude-fable-5-1) via Claude Code — NOT human-reviewed. Verify before acting.

OVOS-SESSION-2 §2.7 states there is no topic on which any participant pushes a session at another, and §7 states the specification defines no bus topic. OVOS-CONTEXT-1 §5.0 states there is no context-mutation topic. The architecture repo's divergences appendix marks `ovos.session.sync` retired. `IntentService.handle_session_sync` subscribed that non-spec topic and, for a named session, merged a pushed snapshot straight into the live working round of an in-flight utterance — the cross-participant push these clauses forbid. This deletes the handler, its subscription, and the imports only it used. The default-session store path stays covered by ovos-bus-client's own `SessionManager.handle_session_sync`, wired unconditionally by `connect_to_bus` and kept there as a pre-spec compat shim for one release cycle; ovos-core owns no part of that shim, and `docs/prerelease-quirks.md` carries a `## #935` entry saying so in place of the earlier, now-incorrect claim that core itself still consumed the data-carrier snapshot.

The ovos-bus-client floor pin moves to `>=2.11.13a1`, which ships the shim's data-carrier fold. The pyproject comment above that pin now names what actually drives it — the §5.1 arrival merge and the one-cycle sync shim — since `handle_sync` has no call sites left in this repo.

`test_intent_context.py` carried six tests marked `xfail(strict=True)` pending the bus-client floor. Three of them asserted only on `SessionManager.sessions[sid]`, duplicating carrier-precedence and shim-merge coverage ovos-bus-client's own test suite already has and exercising nothing in core; they are deleted rather than kept green. Two more drove a mid-round `ovos.session.sync` push and asserted on that same registry object — but the round's actual working session lives only in a per-utterance cache the push never reaches, so neither could be rewritten to assert on the round's own terminal frame without becoming a different test entirely, and both are deleted too. The sixth asserted the identical retired push-into-the-round premise and is likewise gone.

In its place, a new test drives the round through the legal in-round mutation path — a pipeline stage writing directly onto the round's own working session — and asserts on the `ovos.utterance.handled` terminal frame. It passes at this head and fails when the OVOS-CONTEXT-1 §4.1 same-dispatch exemption's value-comparison set is gutted to include every key, confirmed by making that exact mutation locally and watching the new test go red before reverting it.

`test/unittests` runs 541 passed, 0 failed, 0 xfailed. An unmodified `origin/dev` checkout in the same environment (ovos-bus-client 2.11.13a1, ovos-plugin-manager 2.11.6a2) collects five more test items (546) — the five deleted bus-client-internals tests, the sixth deleted push-based test, and the one added round-based replacement account for the difference — and runs 540 passed, 6 xfailed. `test/end2end` runs 42 passed on both.

CI's `ovoscope` and `build_tests (3.14)` jobs were red on the previous head. Both failures reproduce on unrelated, untouched files (`test/stop_service.py`'s recency-race test and `test/end2end/test_context1_reachability.py`'s xdist-parallel skill-directory race), pass consistently in repeated local runs against this branch, and went green on a plain re-run of the same CI job at the same commit — confirming infrastructure flakiness rather than a defect this change introduces.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated session synchronization handling to prevent unrelated named-session updates from affecting an active interaction.
  * Improved session context handling, including named-session tracking, validation, decay, and end-of-round propagation.

* **Documentation**
  * Added release notes describing the updated session synchronization behavior and compatibility handling.

* **Chores**
  * Updated the bus client compatibility requirement to support the revised session synchronization flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->