### PR TITLE
feat(manifest): ovos.intent.list can attach each row's definition

### DIFF
--- a/docs/bus-events.md
+++ b/docs/bus-events.md
@@ -28,6 +28,10 @@ All events use the OVOS `Message` format: `{type, data, context}`.
 | `intent.service.skills.deactivate` | skill → core | Remove a skill from the active list |
 | `intent.service.active_skills.get` | * → core | Query the current active skill list |
 | `mycroft.intents.is_ready` | * → core | Health-check: is IntentService ready? |
+| `ovos.intent.list` | * → core | Query the intent manifest (INTENT-4 §10); optional filters `skill_id`, `lang`, `session_id`; `include_definitions: true` attaches each row's registration payload |
+| `ovos.intent.list.response` | core → * | Response to `ovos.intent.list`: `{ok, intents: [{skill_id, intent_name, lang, method, enabled, session_id[, definition]}]}` |
+| `ovos.intent.describe` | * → core | Fetch the registration payload(s) behind one intent: `skill_id`, `intent_name`, `lang` (optional `method`) |
+| `ovos.intent.describe.response` | core → * | Response to `ovos.intent.describe`: `{ok, definitions: [{method, definition}]}` or `{ok: false, error}` |
 
 ## Skill Manager
 

--- a/docs/bus-events.md
+++ b/docs/bus-events.md
@@ -30,8 +30,8 @@ All events use the OVOS `Message` format: `{type, data, context}`.
 | `mycroft.intents.is_ready` | * → core | Health-check: is IntentService ready? |
 | `ovos.intent.list` | * → core | Query the intent manifest (INTENT-4 §10); optional filters `skill_id`, `lang`, `session_id`; `include_definitions: true` attaches each row's registration payload |
 | `ovos.intent.list.response` | core → * | Response to `ovos.intent.list`: `{ok, intents: [{skill_id, intent_name, lang, method, enabled, session_id[, definition]}]}` |
-| `ovos.intent.describe` | * → core | Fetch the registration payload(s) behind one intent: `skill_id`, `intent_name`, `lang` (optional `method`) |
-| `ovos.intent.describe.response` | core → * | Response to `ovos.intent.describe`: `{ok, definitions: [{method, definition}]}` or `{ok: false, error}` |
+| `ovos.intent.describe` | * → core | Fetch the registration payload(s) behind one intent: `skill_id`, `intent_name`, `lang`; optional filters `method`, `session_id` |
+| `ovos.intent.describe.response` | core → * | Response to `ovos.intent.describe`: `{ok, definitions: [{method, session_id, definition}]}`, ordered `default` first then by session and method, or `{ok: false, error}` |
 
 ## Skill Manager
 

--- a/ovos_core/intent_services/manifest.py
+++ b/ovos_core/intent_services/manifest.py
@@ -30,6 +30,13 @@ class IntentManifest:
     ``ovos.intent.list`` / ``ovos.intent.describe`` pull-queries.
     The manifest is keyed by the quintuple
     ``(session_id, skill_id, intent_name, lang, method)`` per §11.1.
+
+    ``ovos.intent.list`` accepts ``{"include_definitions": true}``: each
+    result row then also carries ``definition``, the stored registration
+    payload that ``ovos.intent.describe`` would return for it, so a client
+    that wants every intent's sentences needs one round trip per language
+    instead of one describe per intent. Without the flag the reply is the
+    plain §10.1 row.
     """
 
     def __init__(self, bus: Union[MessageBusClient, FakeBus]):
@@ -205,6 +212,10 @@ class IntentManifest:
         f_skill = message.data.get("skill_id")
         f_lang = message.data.get("lang")
         f_session = message.data.get("session_id")
+        # Opt-in: attach each row's registration payload (what
+        # ``ovos.intent.describe`` returns as ``definition``) so a client
+        # gets the sentences for a whole language in this one reply.
+        include_definitions = bool(message.data.get("include_definitions", False))
         if f_lang:
             f_lang = standardize_lang(f_lang)
 
@@ -215,8 +226,11 @@ class IntentManifest:
                 continue
             if f_lang and entry["lang"] != f_lang:
                 continue
-            results.append({k: entry[k] for k in
-                            ("skill_id", "intent_name", "lang", "method", "enabled", "session_id")})
+            row = {k: entry[k] for k in
+                   ("skill_id", "intent_name", "lang", "method", "enabled", "session_id")}
+            if include_definitions:
+                row["definition"] = entry["definition"]
+            results.append(row)
 
         self.bus.emit(message.reply("ovos.intent.list.response", {"ok": True, "intents": results}))
 

--- a/test/unittests/test_intent_manifest.py
+++ b/test/unittests/test_intent_manifest.py
@@ -25,10 +25,14 @@ def _manifest() -> IntentManifest:
     return IntentManifest(FakeBus())
 
 
-def _reg(skill_id, intent_name, lang="en-US", method="keyword", session_id="default"):
+def _reg(skill_id, intent_name, lang="en-US", method="keyword", session_id="default",
+         **definition):
+    """A registration broadcast; extra kwargs are the rest of the payload
+    (``samples`` for a template intent, ``required`` for a keyword one)."""
     topic = f"ovos.intent.register.{method}"
     return Message(topic,
-                   data={"skill_id": skill_id, "intent_name": intent_name, "lang": lang},
+                   data={"skill_id": skill_id, "intent_name": intent_name, "lang": lang,
+                         **definition},
                    context={"session": {"session_id": session_id}, "skill_id": skill_id})
 
 
@@ -214,6 +218,104 @@ class TestIntentListQuery(unittest.TestCase):
         resp = self._query(lang="de-DE")
         self.assertEqual(len(resp["intents"]), 1)
         self.assertEqual(resp["intents"][0]["skill_id"], "skill.b")
+
+
+class TestIntentListDefinitions(unittest.TestCase):
+    """``ovos.intent.list`` with ``include_definitions``: one round trip per
+    language instead of one ``ovos.intent.describe`` per intent."""
+
+    ROW_FIELDS = {"skill_id", "intent_name", "lang", "method", "enabled", "session_id"}
+    EN_SAMPLES = ["what is the weather", "what is the weather in {location}"]
+    DE_SAMPLES = ["wie ist das wetter", "wie ist das wetter in {location}"]
+
+    def setUp(self):
+        self.m = _manifest()
+        self.m._on_register(_reg("skill.weather", "current.weather", lang="en-US",
+                                 method="template", samples=self.EN_SAMPLES))
+        self.m._on_register(_reg("skill.weather", "current.weather", lang="de-DE",
+                                 method="template", samples=self.DE_SAMPLES))
+        self.m._on_register(_reg("skill.weather", "current.weather", lang="en-US",
+                                 method="keyword", required=["WeatherKeyword"]))
+
+    def _list(self, **kwargs):
+        replies = []
+        self.m.bus.on("ovos.intent.list.response", lambda msg: replies.append(msg))
+        self.m._on_list(Message("ovos.intent.list", data=kwargs))
+        return replies[-1].data
+
+    def _describe(self, **kwargs):
+        replies = []
+        self.m.bus.on("ovos.intent.describe.response", lambda msg: replies.append(msg))
+        self.m._on_describe(Message("ovos.intent.describe", data=kwargs))
+        return replies[-1].data
+
+    @staticmethod
+    def _row(resp, method, lang):
+        rows = [r for r in resp["intents"] if r["method"] == method and r["lang"] == lang]
+        assert len(rows) == 1, rows
+        return rows[0]
+
+    def test_default_reply_carries_no_definition(self):
+        resp = self._list(lang="en-US")
+        self.assertTrue(resp["ok"])
+        self.assertEqual(len(resp["intents"]), 2)
+        for row in resp["intents"]:
+            self.assertEqual(set(row), self.ROW_FIELDS)
+
+    def test_include_definitions_false_is_the_default(self):
+        self.assertEqual(self._list(lang="en-US", include_definitions=False),
+                         self._list(lang="en-US"))
+
+    def test_include_definitions_attaches_the_describe_payload(self):
+        resp = self._list(lang="en-US", include_definitions=True)
+        self.assertTrue(resp["ok"])
+        row = self._row(resp, "template", "en-US")
+        self.assertEqual(set(row), self.ROW_FIELDS | {"definition"})
+        self.assertEqual(row["definition"]["samples"], self.EN_SAMPLES)
+        # Exactly what a describe of the same registration returns.
+        described = self._describe(skill_id="skill.weather", intent_name="current.weather",
+                                   lang="en-US", method="template")
+        self.assertEqual(row["definition"], described["definitions"][0]["definition"])
+
+    def test_each_registration_carries_its_own_payload(self):
+        resp = self._list(lang="en-US", include_definitions=True)
+        keyword = self._row(resp, "keyword", "en-US")["definition"]
+        template = self._row(resp, "template", "en-US")["definition"]
+        self.assertEqual(keyword["required"], ["WeatherKeyword"])
+        self.assertNotIn("samples", keyword)
+        self.assertEqual(template["samples"], self.EN_SAMPLES)
+        self.assertNotIn("required", template)
+
+    def test_definitions_follow_the_language_filter(self):
+        # "de-de" is folded to the stored "de-DE"; the English rows stay out.
+        resp = self._list(lang="de-de", include_definitions=True)
+        self.assertEqual(len(resp["intents"]), 1)
+        row = resp["intents"][0]
+        self.assertEqual(row["lang"], "de-DE")
+        self.assertEqual(row["definition"]["samples"], self.DE_SAMPLES)
+
+    def test_definitions_without_a_language_cover_every_row(self):
+        resp = self._list(include_definitions=True)
+        self.assertEqual(len(resp["intents"]), 3)
+        self.assertTrue(all("definition" in row for row in resp["intents"]))
+        self.assertEqual(self._row(resp, "template", "de-DE")["definition"]["samples"],
+                         self.DE_SAMPLES)
+
+    def test_definitions_come_from_the_session_effective_pool(self):
+        # A satellite re-registering the intent for its own session wins over
+        # the default one (§11.2) and its payload is the satellite's.
+        sat_samples = ["how is the weather"]
+        self.m._on_register(_reg("skill.weather", "current.weather", lang="en-US",
+                                 method="template", session_id="sat-1",
+                                 samples=sat_samples))
+        resp = self._list(lang="en-US", session_id="sat-1", include_definitions=True)
+        template = self._row(resp, "template", "en-US")
+        self.assertEqual(template["session_id"], "sat-1")
+        self.assertEqual(template["definition"]["samples"], sat_samples)
+        # The default-session keyword registration is inherited, payload intact.
+        keyword = self._row(resp, "keyword", "en-US")
+        self.assertEqual(keyword["session_id"], "default")
+        self.assertEqual(keyword["definition"]["required"], ["WeatherKeyword"])
 
 
 class TestIntentDescribeQuery(unittest.TestCase):


### PR DESCRIPTION
## Why

The intent manifest already stores each intent's registration payload — `_on_register` keeps `message.data` as `definition`, and `ovos.intent.describe` hands it back. That payload is where a template intent's `samples` live: the sentences a person actually says, as the skill's `locale/<lang>/<name>.intent` file wrote them.

So a client that wants to show a user what their device can be asked has the data available, but only one intent at a time. `ovos.intent.list` gives it the names; then it must send one `ovos.intent.describe` per intent per language. On a device with ~70 intents in two languages that is around 140 request/response pairs on the bus for something one reply per language could carry.

## What

`ovos.intent.list` accepts `{"include_definitions": true}`. Each result row then also carries `definition`, exactly what `ovos.intent.describe` would return for that registration.

Without the flag the reply is unchanged — the same §10.1 row keys, in the same order — so no existing consumer sees a difference. The `skill_id`, `lang` and `session_id` filters compose with it as before, and the §11.2 session pool still applies.

```python
bus.emit(Message("ovos.intent.list", {"lang": "en-US", "include_definitions": True}))
# ovos.intent.list.response
# {"ok": True, "intents": [
#     {"skill_id": ..., "intent_name": ..., "lang": "en-US", "method": "template",
#      "enabled": True, "session_id": "default",
#      "definition": {"skill_id": ..., "intent_name": ..., "lang": "en-US",
#                     "samples": ["what is the weather", "what is the weather in {location}"]}},
# ]}
```

## Tests

Seven added to `test/unittests/test_intent_manifest.py`: the default reply carries no `definition`; `include_definitions: false` equals the default; an attached definition equals what `ovos.intent.describe` returns for the same registration; keyword and template rows each carry their own payload; the `lang` filter still folds (`de-de` → `de-DE`); no `lang` covers every row; and the session effective pool still prefers the session's own registration and payload.

Five of the seven fail against `dev` without the change. `test/unittests/test_intent_manifest.py` goes from 35 to 42 passing, and `test_intent_service.py` is unaffected.

Nothing is version- or changelog-touched, since those are generated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an optional `include_definitions` option to intent listing, allowing clients to receive each intent’s registration details in the same response.
  - Intent definitions respect language and session filters, ensuring results reflect the selected context.
  - Added support for querying intent lists and descriptions through the documented intent service events.

- **Documentation**
  - Documented intent listing and description events, including supported filters, options, response formats, and the ordering of returned definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->