### PR TITLE
feat(manifest): ovos.intent.describe can answer for a whole skill

### DIFF
--- a/docs/bus-events.md
+++ b/docs/bus-events.md
@@ -28,6 +28,10 @@ All events use the OVOS `Message` format: `{type, data, context}`.
 | `intent.service.skills.deactivate` | skill → core | Remove a skill from the active list |
 | `intent.service.active_skills.get` | * → core | Query the current active skill list |
 | `mycroft.intents.is_ready` | * → core | Health-check: is IntentService ready? |
+| `ovos.intent.list` | * → core | Query what the intent manifest holds (INTENT-4 §10.1); optional filters `skill_id`, `lang`, `session_id` |
+| `ovos.intent.list.response` | core → * | Response to `ovos.intent.list`: `{ok, intents: [{skill_id, intent_name, lang, method, enabled, session_id}]}` |
+| `ovos.intent.describe` | * → core | Fetch stored registration payloads (INTENT-4 §10.2); `skill_id` is required and bounds the reply, `intent_name`, `lang`, `method` and `session_id` are optional filters |
+| `ovos.intent.describe.response` | core → * | Response to `ovos.intent.describe`: `{ok, definitions: [{skill_id, intent_name, lang, method, session_id, definition}]}`, ordered `default` session first then by session, intent, language and method, or `{ok: false, error}` |
 
 ## Skill Manager
 

--- a/ovos_core/intent_services/manifest.py
+++ b/ovos_core/intent_services/manifest.py
@@ -30,6 +30,13 @@ class IntentManifest:
     ``ovos.intent.list`` / ``ovos.intent.describe`` pull-queries.
     The manifest is keyed by the quintuple
     ``(session_id, skill_id, intent_name, lang, method)`` per §11.1.
+
+    ``ovos.intent.list`` answers what is loaded and stays small. The stored
+    registration payloads live behind ``ovos.intent.describe``, which takes
+    ``skill_id`` and treats ``intent_name`` and ``lang`` as optional filters,
+    so one query covers a whole skill. A client that wants every intent's
+    sentences asks once per skill instead of once per intent per language,
+    and the reply is still bounded by the skill it named.
     """
 
     def __init__(self, bus: Union[MessageBusClient, FakeBus]):
@@ -232,35 +239,49 @@ class IntentManifest:
         # exact-match filter over the raw index, NOT the §11.2 effective
         # pool used by ovos.intent.list (§10.1).
         session_filter = message.data.get("session_id")
-        if not (skill_id and intent_name and lang):
+        # ``skill_id`` stays REQUIRED: it is what bounds the reply. ``intent_name``
+        # and ``lang`` join ``method`` and ``session_id`` as OPTIONAL filters, so
+        # one describe can cover a whole skill instead of one intent in one
+        # language. A client showing a user what the device understands walks the
+        # skills from ``ovos.intent.list`` and asks once per skill, rather than
+        # once per intent per language; no reply ever exceeds a single skill.
+        if not skill_id:
             self.bus.emit(message.reply("ovos.intent.describe.response",
-                                        {"ok": False,
-                                         "error": "skill_id, intent_name and lang are required"}))
+                                        {"ok": False, "error": "skill_id is required"}))
             return
-        lang = standardize_lang(lang)
+        if lang:
+            lang = standardize_lang(lang)
         definitions = []
         for entry in self._index.values():
-            if entry["skill_id"] != skill_id or entry["intent_name"] != intent_name or entry["lang"] != lang:
+            if entry["skill_id"] != skill_id:
+                continue
+            if intent_name and entry["intent_name"] != intent_name:
+                continue
+            if lang and entry["lang"] != lang:
                 continue
             if method_filter and entry["method"] != method_filter:
                 continue
             if session_filter is not None and entry["session_id"] != session_filter:
                 continue
-            definitions.append({"method": entry["method"],
-                                 "session_id": entry["session_id"],
-                                 "definition": entry["definition"]})
-        # §10.2 RECOMMENDED ordering: "default" first, then by session_id,
-        # then by method (keyword, template).
+            row = {k: entry[k] for k in
+                   ("skill_id", "intent_name", "lang", "method", "session_id")}
+            row["definition"] = entry["definition"]
+            definitions.append(row)
+        # §10.2 RECOMMENDED ordering: "default" first, then by session_id, then by
+        # method (keyword, template). Intent and language sort between the two, so
+        # a single-intent single-language query keeps exactly the old order.
         definitions.sort(key=lambda d: (0 if d["session_id"] == "default" else 1,
                                          d["session_id"],
+                                         d["intent_name"],
+                                         d["lang"],
                                          0 if d["method"] == "keyword" else 1))
         if definitions:
             self.bus.emit(message.reply("ovos.intent.describe.response",
                                         {"ok": True, "definitions": definitions}))
         else:
+            target = f"{skill_id}:{intent_name or '*'}:{lang or '*'}"
             self.bus.emit(message.reply("ovos.intent.describe.response",
-                                        {"ok": False,
-                                         "error": f"unknown intent {skill_id}:{intent_name}:{lang}"}))
+                                        {"ok": False, "error": f"unknown intent {target}"}))
 
     # OVOS-CONTEXT-1: orchestrator lookups for declared context gates / slots
 

--- a/test/unittests/test_intent_manifest.py
+++ b/test/unittests/test_intent_manifest.py
@@ -25,10 +25,14 @@ def _manifest() -> IntentManifest:
     return IntentManifest(FakeBus())
 
 
-def _reg(skill_id, intent_name, lang="en-US", method="keyword", session_id="default"):
+def _reg(skill_id, intent_name, lang="en-US", method="keyword", session_id="default",
+         **definition):
+    """A registration broadcast; extra kwargs are the rest of the payload
+    (``samples`` for a template intent, ``required`` for a keyword one)."""
     topic = f"ovos.intent.register.{method}"
     return Message(topic,
-                   data={"skill_id": skill_id, "intent_name": intent_name, "lang": lang},
+                   data={"skill_id": skill_id, "intent_name": intent_name, "lang": lang,
+                         **definition},
                    context={"session": {"session_id": session_id}, "skill_id": skill_id})
 
 
@@ -243,9 +247,129 @@ class TestIntentDescribeQuery(unittest.TestCase):
         resp = self._query(skill_id="skill.a", intent_name="nonexistent", lang="en-US")
         self.assertFalse(resp["ok"])
 
-    def test_describe_missing_fields_returns_error(self):
-        resp = self._query(skill_id="skill.a")
+    def test_describe_without_a_skill_id_returns_error(self):
+        # skill_id is what bounds the reply, so it stays required.
+        resp = self._query(intent_name="play", lang="en-US")
         self.assertFalse(resp["ok"])
+        self.assertEqual(resp["error"], "skill_id is required")
+
+
+class TestIntentDescribeSkillWide(unittest.TestCase):
+    """§10.2 — ``intent_name`` and ``lang`` are optional filters, so one
+    describe can cover a whole skill. That is what makes the manifest usable
+    for "what can I ask this device": the client walks the skills it got from
+    ``ovos.intent.list`` and asks once per skill, instead of once per intent
+    per language, and no reply is ever larger than a single skill."""
+
+    ROW_FIELDS = {"skill_id", "intent_name", "lang", "method", "session_id", "definition"}
+    EN_WEATHER = ["what is the weather", "what is the weather in {location}"]
+    DE_WEATHER = ["wie ist das wetter", "wie ist das wetter in {location}"]
+    EN_FORECAST = ["what is the forecast"]
+
+    def setUp(self):
+        self.m = _manifest()
+        self.m._on_register(_reg("skill.weather", "current.weather", lang="en-US",
+                                 method="template", samples=self.EN_WEATHER))
+        self.m._on_register(_reg("skill.weather", "current.weather", lang="de-DE",
+                                 method="template", samples=self.DE_WEATHER))
+        self.m._on_register(_reg("skill.weather", "current.weather", lang="en-US",
+                                 method="keyword", required=["WeatherKeyword"]))
+        self.m._on_register(_reg("skill.weather", "forecast", lang="en-US",
+                                 method="template", samples=self.EN_FORECAST))
+        self.m._on_register(_reg("skill.timer", "set.timer", lang="en-US",
+                                 method="template", samples=["set a timer"]))
+
+    def _query(self, **kwargs):
+        replies = []
+        self.m.bus.on("ovos.intent.describe.response", lambda msg: replies.append(msg))
+        self.m._on_describe(Message("ovos.intent.describe", data=kwargs))
+        return replies[-1].data if replies else None
+
+    @staticmethod
+    def _keys(resp):
+        return {(d["intent_name"], d["lang"], d["method"]) for d in resp["definitions"]}
+
+    def test_skill_id_alone_returns_every_registration_of_that_skill(self):
+        resp = self._query(skill_id="skill.weather")
+        self.assertTrue(resp["ok"])
+        self.assertEqual(self._keys(resp),
+                         {("current.weather", "en-US", "template"),
+                          ("current.weather", "de-DE", "template"),
+                          ("current.weather", "en-US", "keyword"),
+                          ("forecast", "en-US", "template")})
+
+    def test_the_reply_stops_at_the_skill(self):
+        # The bound is what keeps a describe small: another skill's intents
+        # never ride along.
+        resp = self._query(skill_id="skill.weather")
+        self.assertNotIn("skill.timer", {d["skill_id"] for d in resp["definitions"]})
+
+    def test_every_row_identifies_its_intent_and_language(self):
+        # Without these a multi-intent reply could not be taken apart.
+        resp = self._query(skill_id="skill.weather")
+        for row in resp["definitions"]:
+            self.assertEqual(set(row), self.ROW_FIELDS)
+            self.assertEqual(row["skill_id"], "skill.weather")
+        by_key = {(d["intent_name"], d["lang"], d["method"]): d["definition"]
+                  for d in resp["definitions"]}
+        self.assertEqual(by_key[("current.weather", "en-US", "template")]["samples"],
+                         self.EN_WEATHER)
+        self.assertEqual(by_key[("current.weather", "de-DE", "template")]["samples"],
+                         self.DE_WEATHER)
+        self.assertEqual(by_key[("current.weather", "en-US", "keyword")]["required"],
+                         ["WeatherKeyword"])
+
+    def test_a_language_filter_narrows_and_still_folds(self):
+        # "de-de" folds to the stored "de-DE"; the English rows stay out.
+        resp = self._query(skill_id="skill.weather", lang="de-de")
+        self.assertEqual(self._keys(resp), {("current.weather", "de-DE", "template")})
+
+    def test_an_intent_without_a_language_covers_every_language(self):
+        resp = self._query(skill_id="skill.weather", intent_name="current.weather")
+        self.assertEqual({d["lang"] for d in resp["definitions"]}, {"en-US", "de-DE"})
+        self.assertNotIn("forecast", {d["intent_name"] for d in resp["definitions"]})
+
+    def test_method_and_session_filters_still_compose(self):
+        self.m._on_register(_reg("skill.weather", "current.weather", lang="en-US",
+                                 method="template", session_id="sat-1",
+                                 samples=["how is the weather"]))
+        resp = self._query(skill_id="skill.weather", method="template", session_id="sat-1")
+        self.assertEqual(len(resp["definitions"]), 1)
+        self.assertEqual(resp["definitions"][0]["definition"]["samples"],
+                         ["how is the weather"])
+
+    def test_one_skill_wide_query_equals_the_per_intent_queries(self):
+        # The claim the change rests on: asking once per skill returns exactly
+        # what asking once per intent per language returns.
+        wide = self._query(skill_id="skill.weather")
+        narrow = []
+        for intent_name, lang in (("current.weather", "en-US"), ("current.weather", "de-DE"),
+                                  ("forecast", "en-US")):
+            narrow += self._query(skill_id="skill.weather", intent_name=intent_name,
+                                  lang=lang)["definitions"]
+        self.assertEqual(wide["definitions"], sorted(
+            narrow, key=lambda d: (d["intent_name"], d["lang"],
+                                   0 if d["method"] == "keyword" else 1)))
+
+    def test_ordering_is_deterministic_across_intents_and_languages(self):
+        self.m._on_register(_reg("skill.weather", "forecast", lang="en-US",
+                                 method="template", session_id="sat-1",
+                                 samples=["forecast please"]))
+        resp = self._query(skill_id="skill.weather")
+        order = [(d["session_id"], d["intent_name"], d["lang"], d["method"])
+                 for d in resp["definitions"]]
+        self.assertEqual(order, [
+            ("default", "current.weather", "de-DE", "template"),
+            ("default", "current.weather", "en-US", "keyword"),
+            ("default", "current.weather", "en-US", "template"),
+            ("default", "forecast", "en-US", "template"),
+            ("sat-1", "forecast", "en-US", "template"),
+        ])
+
+    def test_an_unknown_skill_names_the_wildcarded_target(self):
+        resp = self._query(skill_id="skill.nope")
+        self.assertFalse(resp["ok"])
+        self.assertEqual(resp["error"], "unknown intent skill.nope:*:*")
 
 
 class TestIntentDescribeSessionScope(unittest.TestCase):


### PR DESCRIPTION
Replaces #937, which asked `ovos.intent.list` to carry definitions. That was the wrong lever: @JarbasAl is right that the listing must stay small and that the training data belongs behind describe. This keeps that split and attacks the round-trips instead.

## Why

Rendering "what can I ask this device" means reading every intent's `samples` — the sentences a person actually says, as the skill's `locale/<lang>/<name>.intent` wrote them. Those live in the stored registration payload, which `ovos.intent.describe` already hands back, but only one intent in one language per request.

On our device that is 69 intents over two languages: 138 request/response pairs, 276 events on the bus, for one screen. Nothing is broken — a client can batch them, ours does — it is just a lot of traffic for a very ordinary question.

## What

`intent_name` and `lang` become optional filters, joining `method` and `session_id`, which describe already treats that way. `skill_id` stays **required**, because it is what bounds the reply.

```python
bus.emit(Message("ovos.intent.describe", {"skill_id": "skill.weather"}))
# every registration of that skill, all intents, all languages
bus.emit(Message("ovos.intent.describe", {"skill_id": "skill.weather", "lang": "de-DE"}))
# the same, narrowed
```

So a client walks the skills it got from `ovos.intent.list` and asks once per skill. The traffic collapses from one request per intent per language to one per skill, and a reply can never grow past a single skill's registrations — the size ceiling the flag in #937 did not have.

Each definition row now also carries `skill_id`, `intent_name` and `lang` next to the `method` and `session_id` it already had, so a multi-intent reply can be taken apart. The §10.2 ordering gains intent and language between session and method, which leaves a single-intent single-language query in exactly the order it has today.

The one behaviour change for an existing caller: `{"skill_id": ...}` alone used to answer `ok: false, "skill_id, intent_name and lang are required"` and now returns that skill. `ovos.intent.list` is untouched.

## Tests

Ten in `test/unittests/test_intent_manifest.py`, all failing against `dev` first: skill_id alone returns every registration of the skill; the reply stops at that skill; rows identify their intent and language and carry the right payload; a `lang` filter narrows and still folds `de-de` → `de-DE`; an `intent_name` without a `lang` covers every language; `method` and `session_id` still compose; the ordering is deterministic across intents, languages and sessions; an unknown skill reports `unknown intent skill.nope:*:*`; a query with no `skill_id` is still an error; and — the claim the change rests on — one skill-wide query returns exactly what the per-intent queries return.

`test/unittests` goes from 530 to 540 passing, nothing xfailed changes.

Version and changelog are generated, so untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Intent Service API events for listing registered intents and describing their stored registration details.
  * Intent descriptions can now be retrieved for an entire skill or narrowed by intent, language, method, and session.
  * Responses include registration metadata and definition payloads, with documented ordering and error responses.
  * Added support for normalized language filtering and deterministic result ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->