### PR TITLE
fix: manifest requests with non-string fields get an error reply instead of silence

### DIFF
--- a/ovos_core/intent_services/manifest.py
+++ b/ovos_core/intent_services/manifest.py
@@ -85,6 +85,17 @@ class IntentManifest:
         return list(seen.values())
 
     @staticmethod
+    def _invalid_filter(data: dict, *fields: str) -> Optional[str]:
+        """§10.1/§10.2 — every provided filter must be a string.
+        Returns the name of the first offending field, or ``None`` if all
+        of *fields* are either absent or strings."""
+        for field in fields:
+            value = data.get(field)
+            if value is not None and not isinstance(value, str):
+                return field
+        return None
+
+    @staticmethod
     def _session_id_of(message: Message) -> Optional[str]:
         """Mutation scope per §11.1/§11.3 — always ``context.session.session_id``,
         NEVER ``Message.data``. A ``data.session_id`` on a mutation is not a
@@ -209,6 +220,11 @@ class IntentManifest:
     # ------------------------------------------------------------------
 
     def _on_list(self, message: Message):
+        bad_field = self._invalid_filter(message.data, "skill_id", "lang", "session_id")
+        if bad_field:
+            self.bus.emit(message.reply("ovos.intent.list.response",
+                                        {"ok": False, "error": f"{bad_field} must be a string"}))
+            return
         f_skill = message.data.get("skill_id")
         f_lang = message.data.get("lang")
         f_session = message.data.get("session_id")
@@ -228,6 +244,12 @@ class IntentManifest:
         self.bus.emit(message.reply("ovos.intent.list.response", {"ok": True, "intents": results}))
 
     def _on_describe(self, message: Message):
+        bad_field = self._invalid_filter(message.data, "skill_id", "intent_name",
+                                         "lang", "method", "session_id")
+        if bad_field:
+            self.bus.emit(message.reply("ovos.intent.describe.response",
+                                        {"ok": False, "error": f"{bad_field} must be a string"}))
+            return
         skill_id = message.data.get("skill_id")
         intent_name = message.data.get("intent_name")
         lang = message.data.get("lang")

--- a/test/unittests/test_intent_manifest.py
+++ b/test/unittests/test_intent_manifest.py
@@ -201,7 +201,7 @@ class TestIntentListQuery(unittest.TestCase):
     def _query(self, **kwargs):
         replies = []
         self.m.bus.on("ovos.intent.list.response", lambda msg: replies.append(msg))
-        self.m._on_list(Message("ovos.intent.list", data=kwargs))
+        self.m.bus.emit(Message("ovos.intent.list", data=kwargs))
         return replies[-1].data if replies else None
 
     def test_no_filters_returns_all(self):
@@ -219,6 +219,24 @@ class TestIntentListQuery(unittest.TestCase):
         self.assertEqual(len(resp["intents"]), 1)
         self.assertEqual(resp["intents"][0]["skill_id"], "skill.b")
 
+    def test_list_non_string_lang_returns_error_reply(self):
+        resp = self._query(lang=5)
+        self.assertIsNotNone(resp)
+        self.assertFalse(resp["ok"])
+        self.assertEqual(resp["error"], "lang must be a string")
+
+    def test_list_non_string_skill_id_returns_error_reply(self):
+        resp = self._query(skill_id=[])
+        self.assertIsNotNone(resp)
+        self.assertFalse(resp["ok"])
+        self.assertEqual(resp["error"], "skill_id must be a string")
+
+    def test_list_non_string_session_id_returns_error_reply(self):
+        resp = self._query(session_id=7)
+        self.assertIsNotNone(resp)
+        self.assertFalse(resp["ok"])
+        self.assertEqual(resp["error"], "session_id must be a string")
+
 
 class TestIntentDescribeQuery(unittest.TestCase):
     def setUp(self):
@@ -229,7 +247,7 @@ class TestIntentDescribeQuery(unittest.TestCase):
     def _query(self, **kwargs):
         replies = []
         self.m.bus.on("ovos.intent.describe.response", lambda msg: replies.append(msg))
-        self.m._on_describe(Message("ovos.intent.describe", data=kwargs))
+        self.m.bus.emit(Message("ovos.intent.describe", data=kwargs))
         return replies[-1].data if replies else None
 
     def test_describe_both_methods_ordered(self):
@@ -252,6 +270,45 @@ class TestIntentDescribeQuery(unittest.TestCase):
         resp = self._query(intent_name="play", lang="en-US")
         self.assertFalse(resp["ok"])
         self.assertEqual(resp["error"], "skill_id is required")
+
+    def test_describe_non_string_lang_returns_error_reply(self):
+        resp = self._query(skill_id="skill.a", lang=5)
+        self.assertIsNotNone(resp)
+        self.assertFalse(resp["ok"])
+        self.assertEqual(resp["error"], "lang must be a string")
+
+    def test_describe_none_skill_id_returns_error_reply(self):
+        # caught by the pre-existing "skill_id is required" check, not the
+        # type-validation guard — None never reaches _invalid_filter's
+        # isinstance check because it is treated as "absent".
+        resp = self._query(skill_id=None, intent_name="play")
+        self.assertIsNotNone(resp)
+        self.assertFalse(resp["ok"])
+        self.assertEqual(resp["error"], "skill_id is required")
+
+    def test_describe_non_string_intent_name_returns_error_reply(self):
+        resp = self._query(skill_id="skill.a", intent_name=[])
+        self.assertIsNotNone(resp)
+        self.assertFalse(resp["ok"])
+        self.assertEqual(resp["error"], "intent_name must be a string")
+
+    def test_describe_non_string_session_id_returns_error_reply(self):
+        resp = self._query(skill_id="skill.a", session_id=7)
+        self.assertIsNotNone(resp)
+        self.assertFalse(resp["ok"])
+        self.assertEqual(resp["error"], "session_id must be a string")
+
+    def test_describe_non_string_method_returns_error_reply(self):
+        resp = self._query(skill_id="skill.a", method=1)
+        self.assertIsNotNone(resp)
+        self.assertFalse(resp["ok"])
+        self.assertEqual(resp["error"], "method must be a string")
+
+    def test_describe_all_valid_fields_still_works(self):
+        resp = self._query(skill_id="skill.a", intent_name="play",
+                           lang="en-US", method="keyword", session_id="default")
+        self.assertIsNotNone(resp)
+        self.assertTrue(resp["ok"])
 
 
 class TestIntentDescribeSkillWide(unittest.TestCase):


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5.1 (claude-fable-5-1) via Claude Code — NOT human-reviewed. Verify before acting.

A non-string `lang`, `skill_id`, `intent_name`, `method`, or `session_id` in an `ovos.intent.describe` or `ovos.intent.list` request reaches `standardize_lang`'s `tag.lower()` and raises. The bus handler swallows exceptions raised inside handlers, so no `.response` is ever emitted and the caller waits forever.

Per OVOS-INTENT-4 §10.1/§10.2, "the spec's error path is a reply, never silence." This adds a single validation pass at the top of both handlers: every provided filter field must be a string, otherwise the handler replies `{ok: false, error: "<field> must be a string"}` and returns. `standardize_lang` itself is untouched, and the existing missing-`skill_id` and unknown-skill error strings are unchanged.

Tests were added in `test/unittests/test_intent_manifest.py` for both handlers: non-string `lang`, `skill_id`, and `session_id` on `ovos.intent.list`, and non-string `lang`, `skill_id=None`, `intent_name`, `session_id`, `method` on `ovos.intent.describe`, plus a control case with every field valid. Every new test asserts the exact error string, so it discriminates the new guard from paths that already happened to reply `ok: false` on dev for unrelated reasons — `skill_id=None` is still caught by the pre-existing "skill_id is required" check rather than the new guard, and the test asserts that string specifically. Both query helpers now dispatch through `bus.emit` rather than calling the handler directly, so a crash is caught the same way it is in production (swallowed, no reply) instead of propagating straight into the test.

Verified with a patch-revert: reverting only `manifest.py` while keeping the new tests made the `lang`/`intent_name` describe cases and the `lang` list case fail with "unexpectedly None" (no reply was captured — the exception was swallowed exactly as in production), and made the `skill_id`/`session_id` list cases fail because they got `ok: true` instead of `ok: false`. Restoring the fix makes all 53 tests in `test_intent_manifest.py` pass, and the full `test/unittests` suite passes at 559 tests (550 pre-existing plus 9 new).