### PR TITLE
feat: typed-slots transformer stage (OVOS-TRANSFORM-1 §3.7)

### DIFF
--- a/ovos_core/intent_services/manifest.py
+++ b/ovos_core/intent_services/manifest.py
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List, Optional, Tuple, Union
+from typing import FrozenSet, List, Optional, Tuple, Union
 
 from ovos_bus_client.client import MessageBusClient
 from ovos_bus_client.message import Message
-from ovos_spec_tools import standardize_lang
+from ovos_spec_tools import REGISTERED_TYPES, standardize_lang
+from ovos_spec_tools import declared_slot_types as template_slot_types
 from ovos_utils.fakebus import FakeBus
 from ovos_utils.log import LOG
 
@@ -127,6 +128,27 @@ class IntentManifest:
                 if slot not in slots:
                     slots.append(slot)
         return slots
+
+    def declared_slot_types(self, session_id: str) -> FrozenSet[str]:
+        """OVOS-TRANSFORM-1 §3.7 — the types registered intents declare.
+
+        The typed-slots stage is handed this set, never the registry, so a
+        transformer computes only the types something will read. Both places
+        a declaration can appear in an OVOS-INTENT-4 §6.1 registration count:
+        the optional ``slot_types`` map, and the ``{type:name}`` placeholders
+        of the ``samples`` it is derived from, since a producer may send
+        either one alone. Unregistered
+        type names are not declarations — they degrade to untyped slots
+        (OVOS-INTENT-1 §3.6) — and are left out.
+        """
+        types = set()
+        for entry in self._effective_pool(session_id):
+            definition = entry.get("definition") or {}
+            for slot_type in (definition.get("slot_types") or {}).values():
+                if slot_type in REGISTERED_TYPES:
+                    types.add(slot_type)
+            types.update(template_slot_types(definition.get("samples") or []).values())
+        return frozenset(types)
 
     # ------------------------------------------------------------------
     # registration broadcasts  §§5–8

--- a/ovos_core/intent_services/service.py
+++ b/ovos_core/intent_services/service.py
@@ -28,7 +28,9 @@ from ovos_bus_client.session import (SessionManager, Session, MalformedSession,
 from ovos_bus_client.util import get_message_lang
 from ovos_config.config import Configuration
 from ovos_config.locale import get_valid_languages
-from ovos_spec_tools import closest_lang, standardize_lang, SpecMessage
+from ovos_spec_tools import (closest_lang, drop_unregistered_typed_slots,
+                             standardize_lang, validate_typed_slots,
+                             MalformedTypedSlots, SpecMessage)
 from ovos_spec_tools.context import resolve_key
 from ovos_spec_tools.session import resolve_session_id
 from ovos_utils.log import LOG
@@ -36,7 +38,10 @@ from ovos_utils.metrics import Stopwatch
 from ovos_utils.process_utils import ProcessStatus, StatusCallbackMap
 from ovos_utils.thread_utils import create_daemon
 
-from ovos_core.transformers import MetadataTransformersService, UtteranceTransformersService, IntentTransformersService
+from ovos_core.transformers import (IntentTransformersService,
+                                    MetadataTransformersService,
+                                    TypedSlotsTransformersService,
+                                    UtteranceTransformersService)
 from ovos_core.intent_services.dispatcher import IntentDispatcher, DEFAULT_HANDLER_TIMEOUT
 from ovos_core.intent_services.manifest import IntentManifest
 from ovos_core.intent_services.working_session import (
@@ -197,6 +202,7 @@ class IntentService:
         self.utterance_plugins: UtteranceTransformersService = UtteranceTransformersService(bus)
         self.metadata_plugins: MetadataTransformersService = MetadataTransformersService(bus)
         self.intent_plugins: IntentTransformersService = IntentTransformersService(bus)
+        self.typed_slots_plugins: TypedSlotsTransformersService = TypedSlotsTransformersService(bus)
 
         handler_timeout = self.config.get("handler_timeout", DEFAULT_HANDLER_TIMEOUT)
         self.intent_dispatcher: IntentDispatcher = IntentDispatcher(
@@ -281,12 +287,22 @@ class IntentService:
         Utterances may be modified by any parser and context overwritten
         """
         lang = get_message_lang(message)  # per query lang or default Configuration lang
-        original = utterances = message.data.get('utterances', [])
+        utterances = message.data.get('utterances', [])
+        # OVOS-TRANSFORM-1 §3.2 makes in-place mutation of the input list
+        # conformant, so the entry text has to be snapshotted: aliasing it
+        # would make the rewrite check below compare a list against itself.
+        original = list(utterances)
         message.context["lang"] = lang
         utterances, message.context = self.utterance_plugins.transform(utterances, message.context)
         if original != utterances:
             message.data["utterances"] = utterances
             LOG.debug(f"utterances transformed: {original} -> {utterances}")
+            # OVOS-TRANSFORM-1 §3.2: a typed-slot entry's span and surface are
+            # anchored to the text they were computed from, so a rewrite
+            # invalidates any map a producer put on the entry Message.
+            if message.data.pop("typed_slots", None) is not None:
+                LOG.debug("discarding producer typed_slots: the utterance "
+                          "chain rewrote the text its spans indexed")
         message.context = self.metadata_plugins.transform(message.context)
         return message
 
@@ -640,6 +656,47 @@ class IntentService:
         SessionManager.update(sess)
         return sess
 
+    def _run_typed_slots_stage(self, message: Message, sess: Session) -> None:
+        """OVOS-TRANSFORM-1 §3.7 typed-slots stage, run before the first matcher.
+
+        Exactly one transformer runs, and the map it returns replaces any map
+        already on the Message. The closed-set drop applies to whatever map
+        survives, the stage's own output and a producer's alike, so a
+        deployment running no transformer still filters what it carries. What
+        remains rides ``message.data`` to dispatch (OVOS-PIPELINE-1 §7.1).
+        """
+        # the declared-type set costs a scan of every registered intent, so it
+        # is only worth computing when a transformer is there to receive it
+        if self.typed_slots_plugins.selected is not None:
+            produced = self.typed_slots_plugins.transform(
+                message.data.get("utterances", []),
+                self.intent_manifest.declared_slot_types(sess.session_id),
+                sess)
+            if produced is not None:
+                message.data["typed_slots"] = produced
+
+        typed_slots = message.data.get("typed_slots")
+        if typed_slots is None:
+            return
+        if not isinstance(typed_slots, dict):
+            LOG.warning(f"discarding malformed typed_slots "
+                        f"(expected a map, got {type(typed_slots).__name__})")
+            message.data.pop("typed_slots")
+            return
+
+        kept = drop_unregistered_typed_slots(typed_slots)
+        for slot_type in typed_slots:
+            if slot_type not in kept:
+                LOG.warning(f"dropping typed_slots key {slot_type!r}: not a "
+                            f"type registered by OVOS-INTENT-1 §5.6")
+        try:
+            validate_typed_slots(kept)
+        except MalformedTypedSlots as e:
+            LOG.warning(f"discarding malformed typed_slots: {e}")
+            message.data.pop("typed_slots")
+            return
+        message.data["typed_slots"] = kept
+
     def _dispatch_match(self, match: IntentHandlerMatch, message: Message, lang: str,
                         pipeline_id: Optional[str] = None,
                         pre_match_entries: Optional[dict] = None) -> None:
@@ -958,6 +1015,8 @@ class IntentService:
         _replace_intent_context(sess, intent_ctx)
         SessionManager.update(sess)
         message.context["session"] = sess.serialize()
+
+        self._run_typed_slots_stage(message, sess)
 
         # match
         match = None

--- a/ovos_core/transformers.py
+++ b/ovos_core/transformers.py
@@ -1,13 +1,17 @@
-from typing import Optional
+from typing import Dict, FrozenSet, List, Optional
 
 from ovos_config import Configuration
 from ovos_plugin_manager.intent_transformers import find_intent_transformer_plugins
 from ovos_plugin_manager.metadata_transformers import find_metadata_transformer_plugins
+from ovos_plugin_manager.templates.transformers import TypedSlotsTransformer
 from ovos_plugin_manager.text_transformers import find_utterance_transformer_plugins
 from ovos_plugin_manager.transformer_services import (
     IntentTransformersService as _IntentTransformersService,
     MetadataTransformersService as _MetadataTransformersService,
+    TransformersService as _TransformersService,
     UtteranceTransformersService as _UtteranceTransformersService)
+from ovos_plugin_manager.typed_slots_transformers import find_typed_slots_transformer_plugins
+from ovos_utils.log import LOG
 
 
 class UtteranceTransformersService(_UtteranceTransformersService):
@@ -47,3 +51,70 @@ class IntentTransformersService(_IntentTransformersService):
     @classmethod
     def find_plugins(cls):
         return find_intent_transformer_plugins().items()
+
+
+class TypedSlotsTransformersService(_TransformersService):
+    """Runs the OVOS-TRANSFORM-1 §3.7 typed-slots stage.
+
+    The stage produces one map, so §4's ordering selects a single plugin
+    instead of sequencing them: the first entry of an explicit order list
+    where the deployment configures one, otherwise the lowest priority
+    number loaded.
+    """
+    transformer_type = "typed_slots"
+    config_section = "typed_slots_transformers"
+    plugin_finder = staticmethod(find_typed_slots_transformer_plugins)
+
+    def __init__(self, bus, config: Optional[dict] = None):
+        self._selected = None
+        config = config or Configuration()
+        super().__init__(bus=bus, config=config)
+
+    @classmethod
+    def find_plugins(cls):
+        return find_typed_slots_transformer_plugins().items()
+
+    @property
+    def selected(self) -> Optional[TypedSlotsTransformer]:
+        """The one transformer §4's ordering places first, if any is loaded.
+
+        Resolved once and kept, so an unresolvable tie is reported at
+        selection time rather than on every utterance. A reload clears the
+        sorted-plugin cache, which is the signal to select again.
+        """
+        if self._sorted_plugins is None:
+            self._selected = None
+        plugins = self.plugins
+        if self._selected is None and plugins:
+            self._selected = plugins[0]
+            if (not isinstance(self.config.get("order"), list) and len(plugins) > 1
+                    and plugins[1].priority == self._selected.priority):
+                LOG.warning(
+                    f"typed-slots transformers {self._selected.name!r} and "
+                    f"{plugins[1].name!r} share priority {self._selected.priority}; "
+                    f"the choice is stable but unspecified, configure an explicit "
+                    f"'order' list (OVOS-TRANSFORM-1 §3.7)")
+        return self._selected
+
+    def transform(self, utterances: List[str], declared_types: FrozenSet[str],
+                  session) -> Optional[Dict[str, List[dict]]]:
+        """Compute the typed-slots map, or ``None`` when none was computed.
+
+        ``None`` and an empty map are different answers: OVOS-INTENT-1 §5.6
+        reads an absent map as "not computed" and an empty one as "computed
+        and nothing found". A plugin that raises or returns the wrong shape
+        is treated as having produced nothing (§7).
+        """
+        module = self.selected
+        if module is None:
+            return None
+        try:
+            typed_slots = module.transform(utterances, declared_types, session)
+        except Exception as e:
+            LOG.warning(f"{module.name} transform exception: {e}")
+            return None
+        if not isinstance(typed_slots, dict):
+            LOG.warning(f"{module.name} returned wrong shape (expected a "
+                        f"typed-slots map): {type(typed_slots)}; ignoring its output")
+            return None
+        return typed_slots

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,11 +19,11 @@ dependencies = [
     # OVOS-SESSION-2 §5.1 arrival merge (SessionManager.fold_inbound) plus the
     # one-cycle ovos.session.sync compat shim (SessionManager.handle_session_sync)
     "ovos_bus_client>=2.11.13a1,<3.0.0",
-    "ovos-plugin-manager>=2.11.1a1,<3.0.0",
+    "ovos-plugin-manager>=2.12.0a1,<3.0.0",
     "ovos-config>=2.1.4a5,<4.0.0",
     "ovos-workshop>=9.6.9a1,<10.0.0",
     "rapidfuzz>=3.6,<4.0",
-    "ovos-spec-tools[langcodes]>=1.10.4a1,<2.0.0",
+    "ovos-spec-tools[langcodes]>=1.11.0a1,<2.0.0",
 ]
 
 [project.urls]

--- a/test/unittests/test_dispatcher.py
+++ b/test/unittests/test_dispatcher.py
@@ -245,6 +245,11 @@ class TestDispatchFromMatch(unittest.TestCase):
         svc.metadata_plugins = mt
         it = MagicMock(); it.transform.side_effect = lambda i: i
         svc.intent_plugins = it
+
+        # OVOS-TRANSFORM-1 §3.7: no typed-slots transformer loaded
+        ts = MagicMock()
+        ts.transform.return_value = None
+        svc.typed_slots_plugins = ts
         svc.status = MagicMock()
         svc.intent_manifest = IntentManifest(bus)
         # mirror IntentService.__init__: the dispatcher notifies the orchestrator on

--- a/test/unittests/test_intent_context.py
+++ b/test/unittests/test_intent_context.py
@@ -70,6 +70,13 @@ def _make_service(config=None) -> IntentService:
     it = MagicMock()
     it.transform.side_effect = lambda intent: intent
     svc.intent_plugins = it
+
+    # OVOS-TRANSFORM-1 §3.7: no typed-slots transformer loaded
+    ts = MagicMock()
+    ts.transform.return_value = None
+    svc.typed_slots_plugins = ts
+
+    svc.intent_manifest = IntentManifest(bus)
     svc.status = MagicMock()
     return svc
 

--- a/test/unittests/test_intent_service_extended.py
+++ b/test/unittests/test_intent_service_extended.py
@@ -57,6 +57,11 @@ def _make_service(config=None) -> IntentService:
     it.transform.side_effect = lambda intent: intent
     svc.intent_plugins = it
 
+    # OVOS-TRANSFORM-1 §3.7: no typed-slots transformer loaded
+    ts = MagicMock()
+    ts.transform.return_value = None
+    svc.typed_slots_plugins = ts
+
     # INTENT-4 §10 manifest — indexes registration broadcasts
     svc.intent_manifest = IntentManifest(bus)
 

--- a/test/unittests/test_malformed_session_carrier.py
+++ b/test/unittests/test_malformed_session_carrier.py
@@ -41,6 +41,11 @@ def _make_service(bus) -> IntentService:
         plugins.transform.side_effect = transform
         setattr(svc, attr, plugins)
 
+    # OVOS-TRANSFORM-1 §3.7: no typed-slots transformer loaded
+    typed_slots = MagicMock()
+    typed_slots.transform.return_value = None
+    svc.typed_slots_plugins = typed_slots
+
     svc.disambiguate_lang = lambda m: "en-US"
     svc.intent_manifest = IntentManifest(bus)
     svc.intent_dispatcher = IntentDispatcher(

--- a/test/unittests/test_session2_completion_sync.py
+++ b/test/unittests/test_session2_completion_sync.py
@@ -52,6 +52,11 @@ def _make_service(bus, match) -> IntentService:
         plugins.transform.side_effect = transform
         setattr(svc, attr, plugins)
 
+    # OVOS-TRANSFORM-1 §3.7: no typed-slots transformer loaded
+    typed_slots = MagicMock()
+    typed_slots.transform.return_value = None
+    svc.typed_slots_plugins = typed_slots
+
     svc.disambiguate_lang = lambda m: "en-US"
     svc.intent_manifest = IntentManifest(bus)
     svc.intent_dispatcher = IntentDispatcher(

--- a/test/unittests/test_session2_intake.py
+++ b/test/unittests/test_session2_intake.py
@@ -44,6 +44,11 @@ def _make_service(bus, match=None) -> IntentService:
         plugins.transform.side_effect = transform
         setattr(svc, attr, plugins)
 
+    # OVOS-TRANSFORM-1 §3.7: no typed-slots transformer loaded
+    typed_slots = MagicMock()
+    typed_slots.transform.return_value = None
+    svc.typed_slots_plugins = typed_slots
+
     svc.disambiguate_lang = lambda m: "en-US"
     svc.intent_manifest = IntentManifest(bus)
     svc.intent_dispatcher = IntentDispatcher(

--- a/test/unittests/test_typed_slots_stage.py
+++ b/test/unittests/test_typed_slots_stage.py
@@ -1,0 +1,436 @@
+# Copyright 2024 OpenVoiceOS
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""OVOS-TRANSFORM-1 §3.7 typed-slots stage."""
+
+import unittest
+from collections import defaultdict
+from unittest.mock import MagicMock, patch
+
+from ovos_bus_client.message import Message
+from ovos_bus_client.session import Session, SessionManager
+from ovos_plugin_manager.templates.pipeline import IntentHandlerMatch
+from ovos_utils.fakebus import FakeBus
+
+from ovos_core.intent_services.dispatcher import IntentDispatcher
+from ovos_core.intent_services.manifest import IntentManifest
+from ovos_core.intent_services import service as service_module
+from ovos_core.intent_services.service import IntentService
+from ovos_core import transformers as transformers_module
+from ovos_core.transformers import TypedSlotsTransformersService
+
+
+def _make_plugin(name, priority=50, result=None, supported_types=frozenset(),
+                 raises=False):
+    """A stub typed-slots transformer recording the arguments it was given."""
+    plugin = MagicMock()
+    plugin.name = name
+    plugin.priority = priority
+    plugin.supported_types = supported_types
+    if raises:
+        plugin.transform.side_effect = RuntimeError("boom")
+    else:
+        plugin.transform.return_value = {} if result is None else result
+    return plugin
+
+
+def _make_typed_slots_service(plugins=None, config=None) -> TypedSlotsTransformersService:
+    """Create TypedSlotsTransformersService without loading real plugins."""
+    cfg = config or {}
+    with patch("ovos_core.transformers.find_typed_slots_transformer_plugins",
+               return_value={}), \
+         patch("ovos_core.transformers.Configuration", return_value=cfg):
+        svc = TypedSlotsTransformersService(FakeBus(), config=cfg)
+    if plugins is not None:
+        svc.loaded_plugins = {p.name: p for p in plugins}
+        svc._sorted_plugins = None
+    return svc
+
+
+def _make_service(typed_slots=None) -> IntentService:
+    """Construct IntentService without loading real pipelines or plugins."""
+    bus = FakeBus()
+    svc = IntentService.__new__(IntentService)
+    svc.bus = bus
+    svc.config = {}
+    svc.pipeline_plugins = {}
+    svc._deactivations = defaultdict(list)
+    svc.intent_dispatcher = IntentDispatcher(bus, timeout=0)
+
+    ut = MagicMock()
+    ut.transform.side_effect = lambda utt, ctx: (utt, ctx)
+    svc.utterance_plugins = ut
+
+    mt = MagicMock()
+    mt.transform.side_effect = lambda ctx: ctx
+    svc.metadata_plugins = mt
+
+    it = MagicMock()
+    it.transform.side_effect = lambda intent: intent
+    svc.intent_plugins = it
+
+    svc.typed_slots_plugins = typed_slots or _make_typed_slots_service(plugins=[])
+    svc.intent_manifest = IntentManifest(bus)
+    svc.status = MagicMock()
+    return svc
+
+
+def _number_entry(surface="two", value=2, start=0):
+    return {"span": [start, start + len(surface)], "surface": surface, "value": value}
+
+
+# ---------------------------------------------------------------------------
+# §3.7 / §4 — exactly one transformer runs, and which one
+# ---------------------------------------------------------------------------
+
+class TestSelection(unittest.TestCase):
+
+    def test_lowest_priority_number_is_selected(self):
+        first = _make_plugin("first", priority=10)
+        second = _make_plugin("second", priority=20)
+        svc = _make_typed_slots_service(plugins=[second, first])
+        self.assertIs(svc.selected, first)
+
+    def test_explicit_order_list_wins_over_priority(self):
+        first = _make_plugin("first", priority=10)
+        second = _make_plugin("second", priority=20)
+        svc = _make_typed_slots_service(plugins=[first, second],
+                                        config={"order": ["second", "first"]})
+        self.assertIs(svc.selected, second)
+
+    def test_only_the_selected_transformer_runs(self):
+        first = _make_plugin("first", priority=10, result={"number": []})
+        second = _make_plugin("second", priority=20)
+        svc = _make_typed_slots_service(plugins=[first, second])
+        svc.transform(["two"], frozenset({"number"}), Session("s"))
+        first.transform.assert_called_once()
+        second.transform.assert_not_called()
+
+    def test_tied_priority_without_an_order_list_is_logged(self):
+        first = _make_plugin("first", priority=10)
+        second = _make_plugin("second", priority=10)
+        svc = _make_typed_slots_service(plugins=[first, second])
+        with patch.object(transformers_module.LOG, "warning") as warn:
+            self.assertIsNotNone(svc.selected)
+        self.assertIn("share priority", warn.call_args[0][0])
+
+    def test_tied_priority_is_reported_once_not_once_per_utterance(self):
+        svc = _make_typed_slots_service(
+            plugins=[_make_plugin("first", priority=10, result={}),
+                     _make_plugin("second", priority=10)])
+        with patch.object(transformers_module.LOG, "warning") as warn:
+            for _ in range(5):
+                svc.transform(["two"], frozenset(), Session("s"))
+        self.assertEqual(warn.call_count, 1)
+
+    def test_no_plugin_loaded_computes_no_map(self):
+        svc = _make_typed_slots_service(plugins=[])
+        self.assertIsNone(svc.transform(["two"], frozenset(), Session("s")))
+
+
+# ---------------------------------------------------------------------------
+# §3.7 — the transformer's input
+# ---------------------------------------------------------------------------
+
+class TestTransformerInput(unittest.TestCase):
+
+    def test_transformer_receives_utterances_types_and_session(self):
+        plugin = _make_plugin("p", result={"number": []})
+        svc = _make_typed_slots_service(plugins=[plugin])
+        sess = Session("s")
+        svc.transform(["two apples"], frozenset({"number"}), sess)
+        plugin.transform.assert_called_once_with(
+            ["two apples"], frozenset({"number"}), sess)
+
+    def test_empty_declared_set_still_calls_the_transformer(self):
+        """§3.7 hands the transformer the declared set whatever it holds; what
+        to compute from it is the transformer's decision, not the
+        orchestrator's."""
+        plugin = _make_plugin("p", supported_types=frozenset({"number"}),
+                              result={"number": []})
+        svc = _make_typed_slots_service(plugins=[plugin])
+        svc.transform(["hello"], frozenset(), Session("s"))
+        plugin.transform.assert_called_once_with(["hello"], frozenset(), Session("s"))
+
+    def test_a_transformer_computing_every_registered_type_is_not_second_guessed(self):
+        """§3.7: a transformer MAY "compute every registered type where the
+        deployment asks for that". The orchestrator must not withhold the call
+        because the declared set names none of the types the plugin computes —
+        that would turn "computed, found nothing" into "not computed", which
+        OVOS-INTENT-1 §5.6 reads as a different answer."""
+        computed = {"number": [_number_entry()]}
+        plugin = _make_plugin("p", supported_types=frozenset({"number"}),
+                              result=computed)
+        svc = _make_typed_slots_service(plugins=[plugin])
+        self.assertEqual(
+            svc.transform(["two"], frozenset({"color"}), Session("s")), computed)
+
+
+# ---------------------------------------------------------------------------
+# §7 — a misbehaving transformer never aborts the round
+# ---------------------------------------------------------------------------
+
+class TestTransformerErrors(unittest.TestCase):
+
+    def test_raising_transformer_yields_no_map(self):
+        plugin = _make_plugin("p", raises=True)
+        svc = _make_typed_slots_service(plugins=[plugin])
+        self.assertIsNone(svc.transform(["two"], frozenset(), Session("s")))
+
+    def test_wrong_shape_return_yields_no_map(self):
+        plugin = _make_plugin("p", result=["not", "a", "map"])
+        svc = _make_typed_slots_service(plugins=[plugin])
+        self.assertIsNone(svc.transform(["two"], frozenset(), Session("s")))
+
+    def test_a_raising_transformer_lets_the_round_continue(self):
+        svc = _make_service(_make_typed_slots_service(
+            plugins=[_make_plugin("p", raises=True)]))
+        msg = Message("recognizer_loop:utterance", data={"utterances": ["two"]})
+        svc._run_typed_slots_stage(msg, Session("s"))
+        self.assertNotIn("typed_slots", msg.data)
+
+
+# ---------------------------------------------------------------------------
+# INTENT-4 §6.1 — the declared type set the manifest exposes
+# ---------------------------------------------------------------------------
+
+class TestDeclaredSlotTypes(unittest.TestCase):
+
+    def setUp(self):
+        self.bus = FakeBus()
+        self.manifest = IntentManifest(self.bus)
+
+    def _register(self, intent_name, **payload):
+        self.bus.emit(Message("ovos.intent.register.template",
+                              {"skill_id": "test.skill",
+                               "intent_name": intent_name,
+                               "lang": "en-US", **payload},
+                              {"session": Session("default").serialize()}))
+
+    def test_no_registrations_declare_nothing(self):
+        self.assertEqual(self.manifest.declared_slot_types("default"), frozenset())
+
+    def test_slot_types_field_is_read(self):
+        self._register("timer", samples=["set a timer"],
+                       slot_types={"length": "duration"})
+        self.assertEqual(self.manifest.declared_slot_types("default"),
+                         frozenset({"duration"}))
+
+    def test_sample_prefixes_are_read(self):
+        self._register("timer", samples=["set a timer for {duration:length}"])
+        self.assertEqual(self.manifest.declared_slot_types("default"),
+                         frozenset({"duration"}))
+
+    def test_types_from_several_intents_are_unioned(self):
+        self._register("timer", samples=["wait {duration:length}"])
+        self._register("paint", samples=["paint it {color:shade}"],
+                       slot_types={"count": "number"})
+        self.assertEqual(self.manifest.declared_slot_types("default"),
+                         frozenset({"duration", "color", "number"}))
+
+    def test_unregistered_type_names_are_not_declarations(self):
+        self._register("book", samples=["book a {hotel:place}"],
+                       slot_types={"place": "hotel"})
+        self.assertEqual(self.manifest.declared_slot_types("default"), frozenset())
+
+
+# ---------------------------------------------------------------------------
+# §3.2 / §3.7 — what happens to a map already on the entry Message
+# ---------------------------------------------------------------------------
+
+class TestProducerMap(unittest.TestCase):
+
+    def _transformed(self, svc, msg):
+        with patch("ovos_core.intent_services.service.get_message_lang",
+                   return_value="en-US"):
+            return svc._handle_transformers(msg)
+
+    def test_producer_map_dropped_when_the_utterance_chain_rewrote_the_text(self):
+        svc = _make_service()
+        svc.utterance_plugins.transform.side_effect = lambda utt, ctx: (["rewritten"], ctx)
+        msg = Message("recognizer_loop:utterance",
+                      data={"utterances": ["two apples"],
+                            "typed_slots": {"number": [_number_entry()]}})
+        self._transformed(svc, msg)
+        self.assertNotIn("typed_slots", msg.data)
+
+    def test_producer_map_dropped_when_a_plugin_rewrote_the_text_in_place(self):
+        """§3.2 makes in-place mutation of the utterance list conformant, and
+        an in-place plugin returns the very list it was handed, so the discard
+        must compare against a snapshot of the entry text."""
+        svc = _make_service()
+
+        def _rewrite_in_place(utterances, context):
+            utterances[:] = ["rewritten"]
+            return utterances, context
+
+        svc.utterance_plugins.transform.side_effect = _rewrite_in_place
+        msg = Message("recognizer_loop:utterance",
+                      data={"utterances": ["two apples"],
+                            "typed_slots": {"number": [_number_entry()]}})
+        self._transformed(svc, msg)
+        self.assertEqual(msg.data["utterances"], ["rewritten"])
+        self.assertNotIn("typed_slots", msg.data)
+
+    def test_producer_map_kept_when_the_utterance_chain_left_the_text_alone(self):
+        svc = _make_service()
+        msg = Message("recognizer_loop:utterance",
+                      data={"utterances": ["two apples"],
+                            "typed_slots": {"number": [_number_entry()]}})
+        self._transformed(svc, msg)
+        self.assertIn("typed_slots", msg.data)
+
+    def test_the_stage_replaces_a_producer_map(self):
+        computed = {"duration": [{"span": [0, 3], "surface": "1 h", "value": 3600}]}
+        svc = _make_service(_make_typed_slots_service(
+            plugins=[_make_plugin("p", result=computed)]))
+        msg = Message("recognizer_loop:utterance",
+                      data={"utterances": ["1 h"],
+                            "typed_slots": {"number": [_number_entry()]}})
+        svc._run_typed_slots_stage(msg, Session("s"))
+        self.assertEqual(msg.data["typed_slots"], computed)
+
+    def test_producer_map_is_filtered_and_carried_with_no_plugin_loaded(self):
+        svc = _make_service()
+        msg = Message("recognizer_loop:utterance",
+                      data={"utterances": ["two"],
+                            "typed_slots": {"number": [_number_entry()],
+                                            "hotel": [_number_entry()]}})
+        svc._run_typed_slots_stage(msg, Session("s"))
+        self.assertEqual(list(msg.data["typed_slots"]), ["number"])
+
+
+# ---------------------------------------------------------------------------
+# §3.7 — the declared set is computed for a transformer, not for its own sake
+# ---------------------------------------------------------------------------
+
+class TestDeclaredTypesAreComputedLazily(unittest.TestCase):
+    """Reading the declared set walks every registered intent, so it must not
+    run on an utterance no transformer will act on — the default deployment
+    loads none."""
+
+    def _stage(self, svc):
+        with patch.object(svc.intent_manifest, "declared_slot_types",
+                          return_value=frozenset({"number"})) as declared:
+            svc._run_typed_slots_stage(
+                Message("recognizer_loop:utterance", data={"utterances": ["two"]}),
+                Session("s"))
+        return declared.call_count
+
+    def test_the_manifest_is_not_scanned_when_no_transformer_is_selected(self):
+        self.assertEqual(self._stage(_make_service()), 0)
+
+    def test_the_manifest_is_scanned_once_when_a_transformer_is_selected(self):
+        svc = _make_service(_make_typed_slots_service(
+            plugins=[_make_plugin("p", result={})]))
+        self.assertEqual(self._stage(svc), 1)
+
+
+# ---------------------------------------------------------------------------
+# INTENT-1 §5.6 — the closed type set, and the shape of what survives
+# ---------------------------------------------------------------------------
+
+class TestClosedTypeSet(unittest.TestCase):
+
+    def test_unregistered_key_is_dropped_and_logged(self):
+        svc = _make_service(_make_typed_slots_service(plugins=[_make_plugin(
+            "p", result={"number": [_number_entry()],
+                         "hotel": [_number_entry()]})]))
+        msg = Message("recognizer_loop:utterance", data={"utterances": ["two"]})
+        with patch.object(service_module.LOG, "warning") as warn:
+            svc._run_typed_slots_stage(msg, Session("s"))
+        self.assertEqual(list(msg.data["typed_slots"]), ["number"])
+        self.assertIn("'hotel'", warn.call_args[0][0])
+
+    def test_a_malformed_map_is_dropped_rather_than_propagated(self):
+        svc = _make_service(_make_typed_slots_service(plugins=[_make_plugin(
+            "p", result={"number": [{"span": [0, 3], "surface": "two"}]})]))
+        msg = Message("recognizer_loop:utterance", data={"utterances": ["two"]})
+        svc._run_typed_slots_stage(msg, Session("s"))
+        self.assertNotIn("typed_slots", msg.data)
+
+    def test_a_non_map_producer_value_is_dropped(self):
+        svc = _make_service()
+        msg = Message("recognizer_loop:utterance",
+                      data={"utterances": ["two"], "typed_slots": ["nope"]})
+        svc._run_typed_slots_stage(msg, Session("s"))
+        self.assertNotIn("typed_slots", msg.data)
+
+
+# ---------------------------------------------------------------------------
+# PIPELINE-1 §7.1 — the map reaches dispatch
+# ---------------------------------------------------------------------------
+
+class TestCarryToDispatch(unittest.TestCase):
+
+    def setUp(self):
+        SessionManager.sessions = {"default": Session("default")}
+        SessionManager.bus = None
+
+    tearDown = setUp
+
+    def _round(self, svc, data):
+        bus = FakeBus()
+        SessionManager.connect_to_bus(bus)
+        svc.bus = bus
+        svc.intent_dispatcher = IntentDispatcher(bus, timeout=0)
+        seen = []
+        bus.on("test.skill:test_intent", seen.append)
+        matched = []
+        bus.on("ovos.intent.matched", matched.append)
+
+        def _match(utts, lang, message):
+            return IntentHandlerMatch(match_type="test.skill:test_intent",
+                                      match_data={"skill_id": "test.skill"},
+                                      skill_id="test.skill",
+                                      utterance=utts[0])
+
+        svc.get_pipeline = lambda session: [("fake", _match)]
+        svc.handle_utterance(Message("recognizer_loop:utterance", data=data))
+        self.assertEqual(len(seen), 1)
+        return seen[0], matched[0]
+
+    def test_computed_map_rides_the_dispatch_message(self):
+        computed = {"number": [_number_entry()]}
+        svc = _make_service(_make_typed_slots_service(
+            plugins=[_make_plugin("p", result=computed)]))
+        dispatch, _ = self._round(svc, {"utterances": ["two apples"]})
+        self.assertEqual(dispatch.data["typed_slots"], computed)
+
+    def test_producer_map_rides_the_dispatch_message_with_no_plugin_loaded(self):
+        svc = _make_service()
+        dispatch, _ = self._round(
+            svc, {"utterances": ["two apples"],
+                  "typed_slots": {"number": [_number_entry()],
+                                  "hotel": [_number_entry()]}})
+        self.assertEqual(dispatch.data["typed_slots"], {"number": [_number_entry()]})
+
+    def test_no_map_means_no_key_on_the_dispatch_message(self):
+        svc = _make_service()
+        dispatch, _ = self._round(svc, {"utterances": ["two apples"]})
+        self.assertNotIn("typed_slots", dispatch.data)
+
+    def test_intent_matched_carries_only_the_fields_9_2_names(self):
+        """PIPELINE-1 §9.2 fixes the notification payload and does not list
+        ``typed_slots``; the map's home is the dispatch Message (§7.1)."""
+        svc = _make_service(_make_typed_slots_service(
+            plugins=[_make_plugin("p", result={"number": [_number_entry()]})]))
+        _, matched = self._round(svc, {"utterances": ["two apples"]})
+        self.assertEqual(set(matched.data),
+                         {"skill_id", "intent_name", "lang", "utterance",
+                          "slots", "pipeline_id"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5.1 (claude-fable-5-1) via Claude Code — NOT human-reviewed. Verify before acting.

ovos-core implements every transformer chain OVOS-TRANSFORM-1 defines except the typed-slots stage, so a deployment that installs a typed-slots transformer has nowhere for it to run and no handler ever sees `data.typed_slots`. This adds the stage.

§3.7 governs it: "**Injection point.** After the utterance and metadata chains (§3.2, §3.3), before the first matcher sees the utterance. ... **Input.** Three things: the candidate utterance list as the preceding chains left it; the session (OVOS-MSG-1 §4) ... and the **set of types declared by registered intents**. ... **Exactly one transformer runs.** Where a deployment loads more than one typed-slots transformer, the orchestrator runs the one §4's ordering places first — the first entry of an explicit `transformer_id` list where the deployment configures one, otherwise the loaded transformer with the lowest `priority` number — and no other. ... **The type set is closed.** The valid keys are exactly the types registered in the OVOS-INTENT-1 §5.6 table. A transformer **MUST NOT** emit a key outside it, and an orchestrator **MUST** drop every such key from **any** `data.typed_slots` map it carries onward ... **One map, replaced not merged.**"

`TypedSlotsTransformersService` loads `opm.transformer.typed_slots` plugins from the `typed_slots_transformers` config block that every other transformer kind already has, and picks one: the first entry of an explicit order list, else the lowest priority number. The selection is resolved once and kept, so a tie that no list resolves is reported when the selection is made rather than on every utterance, and a reload re-selects. The orchestrator then always calls that plugin with the declared set and does not second-guess what it computes from it: §3.7 lets a transformer "compute every registered type where the deployment asks for that", and skipping the call would turn `{}` ("computed, found nothing") into an absent map ("not computed"), which OVOS-INTENT-1 §5.6 reads as a different answer.

The manifest exposes the declared set. It reads both places an INTENT-4 §6.1 registration can carry a declaration — the optional `slot_types` map and the `{type:name}` prefixes of the `samples` it was derived from, using spec-tools' own parser — since a producer may send either alone. Unregistered type names are not declarations and are left out. That scan walks every registered intent, so it only runs when a transformer is loaded to receive the result; the default deployment with no plugin does no work.

The map is written in exactly one place, `IntentService._run_typed_slots_stage`, called from `handle_utterance` once the working session is bound and before pipeline iteration starts. It is read in two: the utterance chain in `_handle_transformers` discards a producer's map when the chain rewrote the text its spans index (§3.2), and `_dispatch_match` copies `message.data` onto the dispatch Message, which is how the surviving map reaches the handler per PIPELINE-1 §7.1. That discard needed a second fix: §3.2 makes in-place mutation of the utterance list conformant, and `_handle_transformers` aliased the entry list rather than copying it, so a plugin that rewrites in place and returns the same object defeated the comparison and a stale map survived. The entry text is now snapshotted.

The closed-set drop runs over whatever map is present, the stage's own output and a producer's alike, so a deployment running no transformer still filters what it carries; a map that fails `validate_typed_slots` is dropped with a warning rather than propagated, and a plugin that raises leaves no map and does not stop the round (§7). `ovos.intent.matched` is deliberately unchanged: PIPELINE-1 §9.2 fixes that payload and does not list `typed_slots`, and a test pins the field set.

Thirty-one unit tests cover selection and its caching, the declared set, the lazy declared-types guard, the rewrite discard for both a returned list and an in-place mutation, replacement, the closed-set drop, the malformed-map and raising-plugin paths, and the carry to dispatch. Reverting `service.py` alone turns 9 of them red, reverting `manifest.py` alone turns the 5 declared-type tests red, and each of the three behavioural fixes above is individually red-before when reverted on its own. `test/unittests` is 581 passed with nothing failing, and `test/end2end` is 42 passed. The floors move to `ovos-plugin-manager>=2.12.0a1` and `ovos-spec-tools>=1.11.0a1`, which is where the plugin template and the validators live.

The six existing test helpers that build an `IntentService` through `__new__` gained a stub for the new attribute.