### PR TITLE
test: name the retired ovos.session.sync push by its literal topic

### DIFF
--- a/test/unittests/test_session2_intake.py
+++ b/test/unittests/test_session2_intake.py
@@ -22,6 +22,10 @@ from ovos_core.intent_services.service import IntentService
 
 INTENT_CONTEXT_FIELD = "intent_context"
 
+# the retired pre-spec push; OVOS-SESSION-2 §2.7 defines no topic on
+# which any participant pushes a session at another
+LEGACY_SESSION_SYNC = "ovos.session.sync"
+
 
 def _make_service(bus, match=None) -> IntentService:
     """A real IntentService wired to ``bus``, with the plugin machinery stubbed
@@ -184,7 +188,7 @@ class TestSessionSyncIsRetired(SessionIntakeTestCase):
         ovos-bus-client's own retained shim, by identity -- never one added
         by ``IntentService``."""
         SessionManager.connect_to_bus(self.bus)
-        before = list(self.bus.ee.listeners(SpecMessage.SESSION_SYNC))
+        before = list(self.bus.ee.listeners(LEGACY_SESSION_SYNC))
         self.assertEqual(
             before, [SessionManager.handle_session_sync],
             "sanity check failed: expected only ovos-bus-client's own "
@@ -193,7 +197,7 @@ class TestSessionSyncIsRetired(SessionIntakeTestCase):
 
         IntentService(self.bus, preload_pipelines=False)
 
-        after = list(self.bus.ee.listeners(SpecMessage.SESSION_SYNC))
+        after = list(self.bus.ee.listeners(LEGACY_SESSION_SYNC))
         self.assertEqual(
             after, before,
             "IntentService.__init__ added its own ovos.session.sync "
@@ -237,7 +241,7 @@ class TestSessionSyncIsRetired(SessionIntakeTestCase):
         # a would-be pusher tries to sync a context entry into the open round
         synced = Session("client-1")
         synced.intent_context = {"lights.skill:room": {"value": "kitchen"}}
-        self.bus.emit(Message(SpecMessage.SESSION_SYNC,
+        self.bus.emit(Message(LEGACY_SESSION_SYNC,
                               {"session": synced.serialize()},
                               dict(received[0].context)))
 

--- a/test/unittests/test_skill_manager.py
+++ b/test/unittests/test_skill_manager.py
@@ -25,10 +25,13 @@ from ovos_bus_client.message import Message
 from ovos_config import Configuration
 from ovos_config import LocalConf, DEFAULT_CONFIG
 from ovos_bus_client.session import SessionManager
-from ovos_spec_tools import SpecMessage
 from ovos_core.skill_manager import (SkillManager, PLUGIN_SKILL_RETRY_BASE_SECONDS,
                                       PLUGIN_SKILL_RETRY_MAX_SECONDS)
 from ovos_workshop.skill_launcher import SkillLoader
+
+# the retired pre-spec push; OVOS-SESSION-2 §2.7 defines no topic on
+# which any participant pushes a session at another
+LEGACY_SESSION_SYNC = "ovos.session.sync"
 
 
 class MessageBusMock:
@@ -136,7 +139,7 @@ class TestSkillManager(TestCase):
                     'recognizer_loop:record_end',
                     'recognizer_loop:audio_output_start',
                     'recognizer_loop:audio_output_end',
-                    SpecMessage.SESSION_SYNC,
+                    LEGACY_SESSION_SYNC,
                 ]
 
                 self.assertListEqual(expected_result, bus_mock.event_handlers)
@@ -658,7 +661,7 @@ class TestDeferredLoadingConfigFlag(TestCase):
                 'recognizer_loop:record_end',
                 'recognizer_loop:audio_output_start',
                 'recognizer_loop:audio_output_end',
-                SpecMessage.SESSION_SYNC,
+                LEGACY_SESSION_SYNC,
             ]
 
             self.assertListEqual(expected_handlers, self.message_bus_mock.event_handlers)
@@ -695,7 +698,7 @@ class TestDeferredLoadingConfigFlag(TestCase):
             'recognizer_loop:record_end',
             'recognizer_loop:audio_output_start',
             'recognizer_loop:audio_output_end',
-            SpecMessage.SESSION_SYNC,
+            LEGACY_SESSION_SYNC,
         ]
 
         self.assertListEqual(expected_handlers, self.message_bus_mock.event_handlers)
@@ -852,9 +855,11 @@ class TestSkillManagerSessionManagerBus(TestCase):
         SessionManager-owned handler per topic is registered, regardless of
         which subsystem connects first.
 
-        Counted by handler owner, not by topic: ``ovos.session.sync`` also
-        carries IntentService's own OVOS-SESSION-2 §2.7 subscriber, which is
-        a different handler doing a different job on the same topic.
+        Counted by handler owner, not by topic: OVOS-SESSION-2 §2.7 defines
+        no topic on which any participant pushes a session at another, so
+        IntentService itself owns no ``ovos.session.sync`` subscriber -- the
+        only listener on that topic is ovos-bus-client's own retired
+        pre-spec shim.
         """
         bus = MessageBusMock()
         SkillManager(bus, enable_intent_service=True, enable_file_watcher=False)
@@ -865,7 +870,7 @@ class TestSkillManagerSessionManagerBus(TestCase):
             "recognizer_loop:record_end",
             "recognizer_loop:audio_output_start",
             "recognizer_loop:audio_output_end",
-            SpecMessage.SESSION_SYNC,
+            LEGACY_SESSION_SYNC,
         ):
             owned = [h for t, h in bus.handlers
                      if t == topic


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5.1 (claude-fable-5-1) via Claude Code — NOT human-reviewed. Verify before acting.

ovos-spec-tools 1.11.0a2 removed `SpecMessage.SESSION_SYNC` because OVOS-SESSION-2 §2.7 defines no topic on which any participant pushes a session at another; `ovos.session.sync` retires with a one-cycle shim in ovos-bus-client. `test_session2_intake.py` and `test_skill_manager.py` still referenced the removed constant, which raised `AttributeError` on collection and left dev red with 6 failures. Both files now spell the topic as a local `LEGACY_SESSION_SYNC = "ovos.session.sync"` literal, commented as the retired pre-spec push, and never import it from bus-client. The `TestConnectToBusExactlyOnce` docstring's claim that IntentService owns its own subscriber on that topic was also stale post-#935 and is corrected to the end state that `TestSessionSyncIsRetired` already proves: IntentService subscribes to nothing on `ovos.session.sync`.

Reverting only the two test files reproduces the original `AttributeError` failures (6 failed, 544 passed); restoring the fix returns the full unittest suite to 550 passed, 0 failed, matching the clean-dev baseline of 544 passed plus these 6 now green. The `Ovoscope End-to-End Tests` job that was red on dev at 164455c is the known intermittent `test_intent_pipeline.py::TestIntentPipelineRouting::test_high_priority_stage_handles_before_low` message-count flake (got 10, expected 9); it is unrelated to this change and has been rerun via `gh run rerun --failed`.