### PR TITLE
fix: drop empty typed-slot types with unregistered ones (INTENT-1 §5.6)

### DIFF
--- a/ovos_core/intent_services/service.py
+++ b/ovos_core/intent_services/service.py
@@ -684,11 +684,9 @@ class IntentService:
             message.data.pop("typed_slots")
             return
 
+        # drop_unregistered_typed_slots already logs each dropped key with
+        # its reason (unregistered, or a registered type with no entries)
         kept = drop_unregistered_typed_slots(typed_slots)
-        for slot_type in typed_slots:
-            if slot_type not in kept:
-                LOG.warning(f"dropping typed_slots key {slot_type!r}: not a "
-                            f"type registered by OVOS-INTENT-1 §5.6")
         try:
             validate_typed_slots(kept)
         except MalformedTypedSlots as e:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "ovos-config>=2.1.4a5,<4.0.0",
     "ovos-workshop>=9.6.9a1,<10.0.0",
     "rapidfuzz>=3.6,<4.0",
-    "ovos-spec-tools[langcodes]>=1.11.0a1,<2.0.0",
+    "ovos-spec-tools[langcodes]>=1.11.1a1,<2.0.0",
 ]
 
 [project.urls]

--- a/test/unittests/test_typed_slots_stage.py
+++ b/test/unittests/test_typed_slots_stage.py
@@ -344,14 +344,64 @@ class TestDeclaredTypesAreComputedLazily(unittest.TestCase):
 class TestClosedTypeSet(unittest.TestCase):
 
     def test_unregistered_key_is_dropped_and_logged(self):
+        from ovos_spec_tools import intent as spec_tools_intent
         svc = _make_service(_make_typed_slots_service(plugins=[_make_plugin(
             "p", result={"number": [_number_entry()],
                          "hotel": [_number_entry()]})]))
         msg = Message("recognizer_loop:utterance", data={"utterances": ["two"]})
-        with patch.object(service_module.LOG, "warning") as warn:
+        with patch.object(spec_tools_intent._log, "warning") as warn:
             svc._run_typed_slots_stage(msg, Session("s"))
         self.assertEqual(list(msg.data["typed_slots"]), ["number"])
-        self.assertIn("'hotel'", warn.call_args[0][0])
+        self.assertIn("hotel", warn.call_args[0][1])
+
+    def test_dropping_an_empty_registered_type_is_not_misreported(self):
+        """A registered type with no entries is dropped by
+        ``drop_unregistered_typed_slots`` itself, which already logs the
+        reason; ovos-core must not additionally claim it "is not a type
+        registered" — that reason is simply false for this case."""
+        color_entry = {"span": [0, 3], "surface": "red",
+                       "value": {"hex": "#ff0000", "name": "red"}}
+        svc = _make_service(_make_typed_slots_service(plugins=[_make_plugin(
+            "p", result={"number": [], "color": [color_entry]})]))
+        msg = Message("recognizer_loop:utterance", data={"utterances": ["red"]})
+        with patch.object(service_module.LOG, "warning") as warn:
+            svc._run_typed_slots_stage(msg, Session("s"))
+        for call in warn.call_args_list:
+            self.assertNotIn("not a type registered", call[0][0])
+
+    def test_empty_typed_list_is_dropped(self):
+        """OVOS-INTENT-1 §5.6: a type computed with nothing of that kind
+        found must be omitted, not carried with an empty list."""
+        color_entry = {"span": [0, 3], "surface": "red",
+                       "value": {"hex": "#ff0000", "name": "red"}}
+        svc = _make_service(_make_typed_slots_service(plugins=[_make_plugin(
+            "p", result={"number": [], "color": [color_entry]})]))
+        msg = Message("recognizer_loop:utterance", data={"utterances": ["red"]})
+        svc._run_typed_slots_stage(msg, Session("s"))
+        self.assertEqual(list(msg.data["typed_slots"]), ["color"])
+
+    def test_a_non_conformant_plugins_empty_type_carries_no_entry(self):
+        """A plugin returning only an empty-list type violates §5.6's "omit
+        rather than list empty" rule, but the stage still filters it: the
+        map that reaches the message carries no ``date`` key."""
+        svc = _make_service(_make_typed_slots_service(
+            plugins=[_make_plugin("p", result={"date": []})]))
+        msg = Message("recognizer_loop:utterance", data={"utterances": ["today"]})
+        svc._run_typed_slots_stage(msg, Session("s"))
+        self.assertNotIn("date", msg.data.get("typed_slots", {}))
+
+    def test_drop_runs_before_validate(self):
+        """Reversing the order would let an empty-list type reach
+        ``validate_typed_slots`` and reject the whole map instead of just
+        that type being dropped."""
+        color_entry = {"span": [0, 3], "surface": "red",
+                       "value": {"hex": "#ff0000", "name": "red"}}
+        svc = _make_service(_make_typed_slots_service(plugins=[_make_plugin(
+            "p", result={"number": [], "color": [color_entry]})]))
+        msg = Message("recognizer_loop:utterance", data={"utterances": ["red"]})
+        svc._run_typed_slots_stage(msg, Session("s"))
+        self.assertIn("typed_slots", msg.data)
+        self.assertEqual(msg.data["typed_slots"], {"color": [color_entry]})
 
     def test_a_malformed_map_is_dropped_rather_than_propagated(self):
         svc = _make_service(_make_typed_slots_service(plugins=[_make_plugin(


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5.1 (claude-fable-5-1) via Claude Code — NOT human-reviewed. Verify before acting.

OVOS-INTENT-1 §5.6 requires an orchestrator to drop a `typed_slots` key whose list is empty at the same point it drops a key naming an unregistered type. `ovos-spec-tools` 1.11.1a1 moved that logic into `drop_unregistered_typed_slots` itself, and the function's own warning already names each dropped key together with the actual reason, unregistered or empty. `ovos-core`'s `_run_typed_slots_stage` predated that change and carried its own per-key warning loop that unconditionally claimed every drop was "not a type registered by OVOS-INTENT-1 §5.6" — false for a registered type dropped only because its list came back empty. This PR removes the now-redundant loop and bumps the `ovos-spec-tools` floor pin to `>=1.11.1a1`.

Regression coverage in `test/unittests/test_typed_slots_stage.py` checks that a producer map with an empty-list type drops that type while keeping a populated one, that a non-conformant plugin returning only an empty-list type leaves no entry for it, that the drop-before-validate ordering is pinned (reversing it would reject the whole map instead of just the empty type), and that the misleading "not a type registered" message is gone for a registered-but-empty type — the last one is red against the unfixed loop and green after removing it. Full `test/unittests` (585 tests) and `test/end2end` (42 tests) pass on this branch.