### PR TITLE
feat: ship the reference typed-slots transformer with the plugins extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ plugins = [
     "ovos-bidirectional-translation-plugin>=0.1.3a4, <1.0.0",
     "ovos-translate-server-plugin>=0.0.8a1, <1.0.0",
     "ovos-utterance-normalizer>=0.2.5a1, <1.0.0",
+    "ovos-typed-slots-transformer>=0.0.1a2, <1.0.0",
     "ovos-number-parser>=0.19.8a1,<1.0.0",
     "ovos-date-parser>=0.29.0,<1.0.0",
     "ovos-m2v-pipeline>=0.5.4a1,<1.0.0",


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5.1 (claude-fable-5-1) via Claude Code — NOT human-reviewed. Verify before acting.

Per relayed owner direction, ovos-core ships the reference typed-slots transformer with its default plugin set, adding `ovos-typed-slots-transformer>=0.0.1a2` as a floor pin to the `plugins` extra in pyproject.toml alongside the other utterance transformers; enabling it stays a config decision through the `typed_slots_transformers` block and remains off by default pending a benchmark.