### PR TITLE
feat(fallback): ovos.skills.fallback.list, so a client can see what has no phrases

### DIFF
--- a/ovos_core/intent_services/fallback_service.py
+++ b/ovos_core/intent_services/fallback_service.py
@@ -59,11 +59,39 @@ class FallbackService(ConfidenceMatcherPipeline):
         self._fallback_response_event = threading.Event()
         self.bus.on("ovos.skills.fallback.register", self.handle_register_fallback)
         self.bus.on("ovos.skills.fallback.deregister", self.handle_deregister_fallback)
+        self.bus.on("ovos.skills.fallback.list", self.handle_list_fallbacks)
 
     def _fallback_registry_snapshot(self) -> Dict[str, int]:
         """A stable copy of the registry, safe to iterate."""
         with self._registry_lock:
             return dict(self.registered_fallbacks)
+
+    def handle_list_fallbacks(self, message: Message) -> None:
+        """Answer which skills are registered as fallbacks, and at what priority.
+
+        The intent manifest (``ovos.intent.list`` / ``ovos.intent.describe``)
+        enumerates *registered intents*. A fallback skill registers no intent
+        and no phrasings at all -- it registers a handler that is offered every
+        utterance nothing else matched -- so it is invisible there by
+        construction, and nothing else on the bus could be asked about it.
+
+        That gap is not academic. A client asking the manifest "what can I be
+        asked in fr-FR" gets an empty list whether the answer is "nothing
+        matches French" or "French is answered by three fallback skills", and
+        those are opposite facts. One such client told its user their assistant
+        did not speak their language while it was answering them in it.
+
+        The reply carries no phrasings because a fallback has none to give;
+        knowing that a fallback exists is the whole of what can honestly be
+        published about it.
+        """
+        registry = self._fallback_registry_snapshot()
+        self.bus.emit(message.reply(
+            "ovos.skills.fallback.list.response",
+            {"ok": True,
+             "fallbacks": [{"skill_id": skill_id, "priority": priority}
+                           for skill_id, priority in
+                           sorted(registry.items(), key=lambda kv: (kv[1], kv[0]))]}))
 
     def _wire_lifecycle(self, skill_id: str) -> None:
         """Translate lifecycle done-signal for a fallback skill.
@@ -313,3 +341,4 @@ class FallbackService(ConfidenceMatcherPipeline):
             self._unwire_lifecycle(skill_id)
         self.bus.remove("ovos.skills.fallback.register", self.handle_register_fallback)
         self.bus.remove("ovos.skills.fallback.deregister", self.handle_deregister_fallback)
+        self.bus.remove("ovos.skills.fallback.list", self.handle_list_fallbacks)

--- a/ovos_core/intent_services/fallback_service.py
+++ b/ovos_core/intent_services/fallback_service.py
@@ -85,13 +85,21 @@ class FallbackService(ConfidenceMatcherPipeline):
         knowing that a fallback exists is the whole of what can honestly be
         published about it.
         """
+        # `handle_register_fallback` reads skill_id straight off the message and
+        # stores whatever it finds, so the registry can hold a None key. Sorting
+        # that against a str raises TypeError, and it would do so *before* the
+        # reply is emitted -- turning a malformed registration somewhere else
+        # into a query that never answers. An entry with no skill_id also names
+        # nothing a caller could act on, so it is left out rather than reported.
         registry = self._fallback_registry_snapshot()
+        listed = [(skill_id, priority) for skill_id, priority in registry.items()
+                  if isinstance(skill_id, str) and skill_id]
         self.bus.emit(message.reply(
             "ovos.skills.fallback.list.response",
             {"ok": True,
              "fallbacks": [{"skill_id": skill_id, "priority": priority}
                            for skill_id, priority in
-                           sorted(registry.items(), key=lambda kv: (kv[1], kv[0]))]}))
+                           sorted(listed, key=lambda kv: (kv[1], kv[0]))]}))
 
     def _wire_lifecycle(self, skill_id: str) -> None:
         """Translate lifecycle done-signal for a fallback skill.

--- a/test/unittests/test_fallback_service.py
+++ b/test/unittests/test_fallback_service.py
@@ -708,3 +708,37 @@ class TestFallbackListQuery(unittest.TestCase):
         self.bus.emit(Message("ovos.skills.fallback.list"))
         self.assertEqual(self.replies, [])
         self.service = FallbackService(self.bus)  # tearDown shuts this one down
+
+
+class TestFallbackListQueryMalformedRegistry(unittest.TestCase):
+    """A bad registration elsewhere must not make this query unanswerable.
+
+    `handle_register_fallback` reads skill_id off the message and stores
+    whatever it finds, so a malformed registration puts a None key in the
+    registry. Sorting that against a str raises TypeError *before* the reply is
+    emitted, so the caller waits out its timeout for a query that would
+    otherwise have succeeded.
+    """
+
+    def setUp(self):
+        self.bus = FakeBus()
+        self.service = FallbackService(self.bus)
+        self.replies = []
+        self.bus.on("ovos.skills.fallback.list.response",
+                    lambda message: self.replies.append(message))
+
+    def tearDown(self):
+        self.service.shutdown()
+
+    def test_a_registration_with_no_skill_id_does_not_break_the_query(self):
+        self.service.registered_fallbacks = {None: 101, "real-skill": 101}
+        self.bus.emit(Message("ovos.skills.fallback.list"))
+        self.assertEqual(len(self.replies), 1, "the query must still answer")
+        self.assertEqual(self.replies[0].data["fallbacks"],
+                         [{"skill_id": "real-skill", "priority": 101}])
+
+    def test_an_entry_with_no_name_is_left_out_rather_than_reported(self):
+        """It names nothing a caller could act on."""
+        self.service.registered_fallbacks = {None: 10, "": 20}
+        self.bus.emit(Message("ovos.skills.fallback.list"))
+        self.assertEqual(self.replies[0].data["fallbacks"], [])

--- a/test/unittests/test_fallback_service.py
+++ b/test/unittests/test_fallback_service.py
@@ -630,3 +630,81 @@ class TestFallbackHandlerLifecycle(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestFallbackListQuery(unittest.TestCase):
+    """`ovos.skills.fallback.list`: what the intent manifest cannot say.
+
+    The manifest enumerates registered intents. A fallback skill registers no
+    intent and no phrasings -- it registers a handler offered whatever nothing
+    else matched -- so it cannot appear there, and until now nothing else on
+    the bus could be asked about it either.
+
+    The consequence was a client that could not tell "no intents match this
+    language" from "this language is answered by fallbacks", which are opposite
+    facts about whether the assistant understands you.
+    """
+
+    def setUp(self):
+        self.bus = FakeBus()
+        self.service = FallbackService(self.bus)
+        self.replies = []
+        self.bus.on("ovos.skills.fallback.list.response",
+                    lambda message: self.replies.append(message))
+
+    def tearDown(self):
+        self.service.shutdown()
+
+    def _ask(self):
+        self.bus.emit(Message("ovos.skills.fallback.list"))
+        self.assertEqual(len(self.replies), 1)
+        return self.replies[-1].data
+
+    def test_an_empty_registry_answers_with_an_empty_list(self):
+        """Not an error, and not silence: nothing is registered, and saying so
+        is the answer a caller needs to distinguish it from a lost query."""
+        data = self._ask()
+        self.assertTrue(data["ok"])
+        self.assertEqual(data["fallbacks"], [])
+
+    def test_registered_fallbacks_are_reported_with_their_priority(self):
+        self.service.registered_fallbacks = {"skill-a": 50, "skill-b": 10}
+        data = self._ask()
+        self.assertTrue(data["ok"])
+        self.assertEqual(data["fallbacks"],
+                         [{"skill_id": "skill-b", "priority": 10},
+                          {"skill_id": "skill-a", "priority": 50}])
+
+    def test_the_order_is_the_order_they_will_be_tried_in(self):
+        """Priority ascending, because that is the order the pipeline uses.
+
+        A caller reading this to explain "what might answer me" is reading a
+        plan, and a plan in an arbitrary order is a worse plan.
+        """
+        self.service.registered_fallbacks = {"c": 30, "a": 10, "b": 20}
+        self.assertEqual([f["skill_id"] for f in self._ask()["fallbacks"]],
+                         ["a", "b", "c"])
+
+    def test_ties_are_broken_by_skill_id_so_the_answer_is_stable(self):
+        self.service.registered_fallbacks = {"z": 5, "a": 5}
+        self.assertEqual([f["skill_id"] for f in self._ask()["fallbacks"]],
+                         ["a", "z"])
+
+    def test_the_reply_is_a_snapshot_and_not_the_live_registry(self):
+        """The registry is mutated from bus handler threads while queries run.
+
+        Every other read in this service takes a snapshot under the lock for
+        that reason; a query that leaked the live dict would be the one place
+        a skill loading mid-read could raise.
+        """
+        self.service.registered_fallbacks = {"skill-a": 50}
+        data = self._ask()
+        self.service.registered_fallbacks["skill-b"] = 10
+        self.assertEqual([f["skill_id"] for f in data["fallbacks"]], ["skill-a"])
+
+    def test_the_handler_is_removed_on_shutdown(self):
+        self.service.shutdown()
+        self.replies.clear()
+        self.bus.emit(Message("ovos.skills.fallback.list"))
+        self.assertEqual(self.replies, [])
+        self.service = FallbackService(self.bus)  # tearDown shuts this one down


### PR DESCRIPTION
## The gap

The intent manifest (`ovos.intent.list` / `ovos.intent.describe`) enumerates **registered intents**. A fallback skill registers no intent and no phrasings at all — it registers a handler offered every utterance nothing else matched — so it cannot appear there by construction, and nothing else on the bus can be asked about it either.

A client that wants to answer "what can I be asked?" can enumerate every registered intent and still be unable to mention a `FallbackSkill` that answers a whole category of questions.

## Correcting how I found it

I first hit this on a bilingual hub whose manifest reported 69 registrations, all `en-US` and none for `fr-FR`, while the hub answered French correctly through fallback handlers. I originally wrote this PR up as *"the manifest cannot describe a language the hub demonstrably serves"*.

**That framing was wrong and I want to be straight about it.** The cause turned out to be my own misconfiguration — `secondary_langs` written one level too deep in the deployment's config, so the skills' French intent files were never registered. With the config corrected the manifest becomes accurate about French, and that particular symptom disappears.

## Why it is still worth having

The underlying gap survives the correction, because it is structural rather than configuration-dependent:

- A `FallbackSkill` registers a handler, not intents. On a *correctly* configured hub it is still invisible to the manifest — there is nothing to register and nothing to publish.
- On the hub above, a date/time skill registers `_fallback_answer` at priority 95 as a deliberate design choice, and a general-purpose fallback skill answers open questions. Neither can ever be listed.
- So a client cannot distinguish **"nothing handles this"** from **"a fallback will try"**, and an empty result reads as the former. That is a real ambiguity in the introspection API, independent of anyone's config.

## The change

One bus query, in `FallbackService`:

```
ovos.skills.fallback.list
  -> {"ok": true,
      "fallbacks": [{"skill_id": "...", "priority": 10}, ...]}
```

- **Ordered by priority, then skill_id.** A caller reading this to explain "what might answer me" is reading a plan; a plan in arbitrary order is a worse plan, and ties break deterministically so the answer is stable.
- **No phrasings**, because a fallback has none to give. That a fallback exists is the whole of what can honestly be published about it — and it is enough for a client to say *"nothing is registered for this, and something may still try"* rather than implying silence.
- Takes `_fallback_registry_snapshot()` like every other read in this service, since the registry is mutated from the bus handler threads serving register/deregister while queries run.
- Skips entries whose `skill_id` is not a non-empty string. `handle_register_fallback` stores whatever the message carried, so a `None` key sorted against a `str` raises `TypeError` *before* the reply is emitted — turning a malformed registration elsewhere into a query that never answers. Validating on the register side would be the deeper fix; it changes behaviour this PR does not otherwise touch, so it is left to maintainers.
- Removed on shutdown alongside its siblings.

## Tests

8 cases in `test_fallback_service.py`: the empty registry (an answer, not silence), priority ordering, stable tie-breaking, snapshot rather than live dict, shutdown symmetry, and the malformed-registry crash above.

`test_fallback_service.py`, `test_fallback_registry_concurrency.py` and `test_intent_manifest.py` — **108 passed**.

Follows #938, which made `ovos.intent.describe` answer for a whole skill.