### PR TITLE
docs: state what the typed-slots drop actually logs

### DIFF
--- a/ovos_core/intent_services/service.py
+++ b/ovos_core/intent_services/service.py
@@ -684,8 +684,7 @@ class IntentService:
             message.data.pop("typed_slots")
             return
 
-        # drop_unregistered_typed_slots already logs each dropped key with
-        # its reason (unregistered, or a registered type with no entries)
+        # the library logs the dropped keys itself, in one warning naming them all
         kept = drop_unregistered_typed_slots(typed_slots)
         try:
             validate_typed_slots(kept)


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5.1 (claude-fable-5-1) via Claude Code — NOT human-reviewed. Verify before acting.

Update the comment in `_run_typed_slots_stage` to accurately describe that the library logs dropped typed-slot keys in one warning naming them all, not individually with per-key reasons.