### PR TITLE
fix: registration consumers take skill_id from the message context

### DIFF
--- a/ovos_core/intent_services/manifest.py
+++ b/ovos_core/intent_services/manifest.py
@@ -167,10 +167,18 @@ class IntentManifest:
 
     def _on_register(self, message: Message):
         method = "keyword" if message.msg_type == "ovos.intent.register.keyword" else "template"
-        skill_id = message.data.get("skill_id") or message.context.get("skill_id")
+        skill_id = message.context.get("skill_id")
+        if not skill_id:
+            LOG.warning(f"dropping {message.msg_type}: no context['skill_id']")
+            return
+        payload_skill_id = message.data.get("skill_id")
+        if payload_skill_id and payload_skill_id != skill_id:
+            LOG.warning(f"dropping {message.msg_type}: payload skill_id "
+                        f"{payload_skill_id!r} differs from context skill_id {skill_id!r}")
+            return
         intent_name = message.data.get("intent_name")
         lang = message.data.get("lang")
-        if not (skill_id and intent_name and lang):
+        if not (intent_name and lang):
             LOG.warning(f"malformed intent registration from {skill_id!r}: missing required fields")
             return
         if intent_name == "stop":
@@ -201,11 +209,19 @@ class IntentManifest:
         }
 
     def _on_deregister(self, message: Message):
-        skill_id = message.data.get("skill_id") or message.context.get("skill_id")
+        skill_id = message.context.get("skill_id")
+        if not skill_id:
+            LOG.warning(f"dropping {message.msg_type}: no context['skill_id']")
+            return
+        payload_skill_id = message.data.get("skill_id")
+        if payload_skill_id and payload_skill_id != skill_id:
+            LOG.warning(f"dropping {message.msg_type}: payload skill_id "
+                        f"{payload_skill_id!r} differs from context skill_id {skill_id!r}")
+            return
         intent_name = message.data.get("intent_name")
         lang = message.data.get("lang")
         session_id = self._session_id_of(message)
-        if not (skill_id and intent_name):
+        if not intent_name:
             return
         for method in ("keyword", "template"):
             if lang:
@@ -230,10 +246,16 @@ class IntentManifest:
             entry["enabled"] = enabled
 
     def _on_skill_deregister(self, message: Message):
-        skill_id = message.data.get("skill_id") or message.context.get("skill_id")
-        session_id = self._session_id_of(message)
+        skill_id = message.context.get("skill_id")
         if not skill_id:
+            LOG.warning(f"dropping {message.msg_type}: no context['skill_id']")
             return
+        payload_skill_id = message.data.get("skill_id")
+        if payload_skill_id and payload_skill_id != skill_id:
+            LOG.warning(f"dropping {message.msg_type}: payload skill_id "
+                        f"{payload_skill_id!r} differs from context skill_id {skill_id!r}")
+            return
+        session_id = self._session_id_of(message)
         for key in [k for k in self._index if k[0] == session_id and k[1] == skill_id]:
             del self._index[key]
 

--- a/test/unittests/test_intent_context.py
+++ b/test/unittests/test_intent_context.py
@@ -472,7 +472,8 @@ class TestOrchestratorGate(unittest.TestCase):
             svc.intent_manifest._on_register(Message(
                 "ovos.intent.register.keyword",
                 {"skill_id": "lights.skill", "intent_name": "on",
-                 "lang": "en-US", "requires_context": list(requires)}, {}))
+                 "lang": "en-US", "requires_context": list(requires)},
+                {"skill_id": "lights.skill"}))
         return svc
 
     def _session(self, intent_context=None):
@@ -533,7 +534,8 @@ class TestOrchestratorSlotFill(unittest.TestCase):
         svc.intent_manifest._on_register(Message(
             "ovos.intent.register.keyword",
             {"skill_id": "lights.skill", "intent_name": "on", "lang": "en-US",
-             "requires_context": list(requires), "required": list(slot_names)}, {}))
+             "requires_context": list(requires), "required": list(slot_names)},
+            {"skill_id": "lights.skill"}))
         return svc
 
     def _session(self, intent_context):
@@ -769,7 +771,8 @@ class TestRequiredSlotFilledFromContext(unittest.TestCase):
              "lang": "en-US",
              "required": ["location"],
              "required_slots": ["location"],
-             "requires_context": [{"key": "location", "scope": "shared"}]}, {}))
+             "requires_context": [{"key": "location", "scope": "shared"}]},
+            {"skill_id": "weather.skill"}))
         match = IntentHandlerMatch(match_type="weather.skill:forecast",
                                    match_data={"conf": 1.0},
                                    skill_id="weather.skill",

--- a/test/unittests/test_intent_manifest.py
+++ b/test/unittests/test_intent_manifest.py
@@ -84,6 +84,43 @@ class TestManifestRegister(unittest.TestCase):
             self.m._on_register(_reg("skill.test", "hello"))
         mock_log.warning.assert_not_called()
 
+    def test_register_without_context_skill_id_is_dropped(self):
+        # OVOS-INTENT-4 §3.2: context["skill_id"] is authoritative; a
+        # registration lacking it MUST be dropped, not fall back to data.
+        msg = Message("ovos.intent.register.keyword",
+                      data={"skill_id": "skill.test", "intent_name": "hello", "lang": "en-US"},
+                      context={})
+        with patch("ovos_core.intent_services.manifest.LOG") as mock_log:
+            self.m._on_register(msg)
+        self.assertEqual(self.m._index, {})
+        mock_log.warning.assert_called_once()
+
+    def test_register_mismatched_payload_skill_id_is_dropped(self):
+        # a payload skill_id differing from context.skill_id would let one
+        # skill register intents under another skill's identity.
+        msg = Message("ovos.intent.register.keyword",
+                      data={"skill_id": "skill.other", "intent_name": "hello", "lang": "en-US"},
+                      context={"skill_id": "skill.test"})
+        with patch("ovos_core.intent_services.manifest.LOG") as mock_log:
+            self.m._on_register(msg)
+        self.assertEqual(self.m._index, {})
+        mock_log.warning.assert_called_once()
+
+    def test_register_matching_payload_skill_id_still_registers(self):
+        msg = Message("ovos.intent.register.keyword",
+                      data={"skill_id": "skill.test", "intent_name": "hello", "lang": "en-US"},
+                      context={"skill_id": "skill.test"})
+        self.m._on_register(msg)
+        self.assertEqual(len(self.m._index), 1)
+
+    def test_register_without_payload_skill_id_uses_context(self):
+        msg = Message("ovos.intent.register.keyword",
+                      data={"intent_name": "hello", "lang": "en-US"},
+                      context={"skill_id": "skill.test"})
+        self.m._on_register(msg)
+        entry = list(self.m._index.values())[0]
+        self.assertEqual(entry["skill_id"], "skill.test")
+
 
 class TestManifestDeregister(unittest.TestCase):
     def setUp(self):
@@ -93,7 +130,8 @@ class TestManifestDeregister(unittest.TestCase):
 
     def test_deregister_specific_lang(self):
         msg = Message("ovos.intent.deregister",
-                      data={"skill_id": "skill.test", "intent_name": "hello", "lang": "en-US"})
+                      data={"skill_id": "skill.test", "intent_name": "hello", "lang": "en-US"},
+                      context={"skill_id": "skill.test"})
         self.m._on_deregister(msg)
         langs = [e["lang"] for e in self.m._index.values()]
         self.assertNotIn("en-US", langs)
@@ -101,9 +139,28 @@ class TestManifestDeregister(unittest.TestCase):
 
     def test_deregister_all_langs(self):
         msg = Message("ovos.intent.deregister",
-                      data={"skill_id": "skill.test", "intent_name": "hello"})
+                      data={"skill_id": "skill.test", "intent_name": "hello"},
+                      context={"skill_id": "skill.test"})
         self.m._on_deregister(msg)
         self.assertEqual(len(self.m._index), 0)
+
+    def test_deregister_without_context_skill_id_is_dropped(self):
+        # OVOS-INTENT-4 §3.2: context["skill_id"] is authoritative; a
+        # deregistration lacking it MUST be dropped, not fall back to data.
+        msg = Message("ovos.intent.deregister",
+                      data={"skill_id": "skill.test", "intent_name": "hello"},
+                      context={})
+        self.m._on_deregister(msg)
+        self.assertEqual(len(self.m._index), 2)
+
+    def test_deregister_mismatched_payload_skill_id_is_dropped(self):
+        # a payload skill_id differing from context.skill_id would let one
+        # skill deregister another skill's intents.
+        msg = Message("ovos.intent.deregister",
+                      data={"skill_id": "skill.other", "intent_name": "hello"},
+                      context={"skill_id": "skill.test"})
+        self.m._on_deregister(msg)
+        self.assertEqual(len(self.m._index), 2)
 
 
 class TestManifestEnableDisable(unittest.TestCase):
@@ -142,7 +199,7 @@ class TestDeregisterSessionScope(unittest.TestCase):
         # attacker runs under session B (context) but claims data.session_id=A
         msg = Message("ovos.intent.deregister",
                       data={"skill_id": "skill.test", "intent_name": "hello", "session_id": "A"},
-                      context={"session": {"session_id": "B"}})
+                      context={"session": {"session_id": "B"}, "skill_id": "skill.test"})
         self.m._on_deregister(msg)
         # session A's entry MUST survive; only B (which has no entry) was touched
         sessions = {e["session_id"] for e in self.m._index.values()}
@@ -152,7 +209,7 @@ class TestDeregisterSessionScope(unittest.TestCase):
         # the true owner of session A deregisters, context-scoped, no data.session_id
         msg = Message("ovos.intent.deregister",
                       data={"skill_id": "skill.test", "intent_name": "hello"},
-                      context={"session": {"session_id": "A"}})
+                      context={"session": {"session_id": "A"}, "skill_id": "skill.test"})
         self.m._on_deregister(msg)
         self.assertEqual(len(self.m._index), 0)
 
@@ -165,10 +222,27 @@ class TestSkillDeregister(unittest.TestCase):
         self.m._on_register(_reg("skill.b", "z"))
 
     def test_removes_only_target_skill(self):
-        msg = Message("ovos.skill.deregister", data={"skill_id": "skill.a"})
+        msg = Message("ovos.skill.deregister", data={"skill_id": "skill.a"},
+                      context={"skill_id": "skill.a"})
         self.m._on_skill_deregister(msg)
         skills = {e["skill_id"] for e in self.m._index.values()}
         self.assertNotIn("skill.a", skills)
+        self.assertIn("skill.b", skills)
+
+    def test_without_context_skill_id_is_dropped(self):
+        msg = Message("ovos.skill.deregister", data={"skill_id": "skill.a"}, context={})
+        self.m._on_skill_deregister(msg)
+        skills = {e["skill_id"] for e in self.m._index.values()}
+        self.assertIn("skill.a", skills)
+
+    def test_mismatched_payload_skill_id_is_dropped(self):
+        # a remote-uninstall attempt: another skill claims to deregister
+        # skill.a while its own context identifies it as skill.b.
+        msg = Message("ovos.skill.deregister", data={"skill_id": "skill.a"},
+                      context={"skill_id": "skill.b"})
+        self.m._on_skill_deregister(msg)
+        skills = {e["skill_id"] for e in self.m._index.values()}
+        self.assertIn("skill.a", skills)
         self.assertIn("skill.b", skills)
 
 

--- a/test/unittests/test_intent_service_extended.py
+++ b/test/unittests/test_intent_service_extended.py
@@ -1386,7 +1386,7 @@ class TestRequiredSlotsBackstop(unittest.TestCase):
             {"skill_id": "test.skill", "intent_name": "intent",
              "lang": "en-US", "samples": ["do it"],
              "required_slots": required_slots},
-            {"session": {"session_id": "default"}}))
+            {"session": {"session_id": "default"}, "skill_id": "test.skill"}))
 
     def test_intent_not_in_manifest_is_noop(self):
         svc = _make_service()

--- a/test/unittests/test_typed_slots_stage.py
+++ b/test/unittests/test_typed_slots_stage.py
@@ -216,7 +216,8 @@ class TestDeclaredSlotTypes(unittest.TestCase):
                               {"skill_id": "test.skill",
                                "intent_name": intent_name,
                                "lang": "en-US", **payload},
-                              {"session": Session("default").serialize()}))
+                              {"session": Session("default").serialize(),
+                               "skill_id": "test.skill"}))
 
     def test_no_registrations_declare_nothing(self):
         self.assertEqual(self.manifest.declared_slot_types("default"), frozenset())


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5.1 (claude-fable-5-1) via Claude Code — NOT human-reviewed. Verify before acting.

> OVOS-INTENT-4 §3.2: "For registration and deregistration, the payload `skill_id` MUST equal `context.skill_id`. This holds for `ovos.intent.register.keyword`, `ovos.intent.register.template`, `ovos.entity.register`, `ovos.intent.deregister`, `ovos.entity.deregister`, and `ovos.skill.deregister`. A consumer — plugin or orchestrator — MUST NOT index or act on one of these messages whose payload `skill_id` differs from `context.skill_id`, and MUST log the mismatch at WARN with both values and the rejecting topic. Without this check a skill could register or deregister another skill's intents; `ovos.skill.deregister` (§8.4) in particular would be a remote uninstall."

`IntentManifest._on_register`, `_on_deregister`, and `_on_skill_deregister` read `skill_id = message.data.get("skill_id") or message.context.get("skill_id")`, preferring the untrusted payload over the authoritative context. Any skill that could publish these topics could name another skill's `skill_id` in the payload and have its registrations, deregistrations, or a full `ovos.skill.deregister` wipe applied to that other skill's manifest entries instead of its own.

The fix reads `skill_id` from `message.context` only in these three handlers. A message with no context `skill_id` is dropped with a WARN naming the topic. A message with a payload `skill_id` that differs from the context value is also dropped with a WARN naming both values and the topic, per the clause above. `_on_enable_disable` is intentionally left untouched — §3.2 explicitly exempts `ovos.intent.enable`/`disable` as control messages where the payload `skill_id` names the *target* being suppressed and the context `skill_id` names the requesting *source*, and the two are allowed to differ.

Fail-before: reverting only `manifest.py` (test files unchanged) made 5 of the new tests fail — one payload/context mismatch case and one missing-context case for each of `_on_register` and `_on_deregister`/`_on_skill_deregister` (skill_deregister mismatch and register-mismatch both asserted an empty/unaffected manifest and instead saw the attacker's mutation applied). Re-applying the fix made all 61 tests in `test_intent_manifest.py` pass.

A handful of existing tests elsewhere (`test_intent_context.py`, `test_intent_service_extended.py`, `test_typed_slots_stage.py`) called `_on_register` directly with an empty `context`, which relied on the old payload-fallback behavior; they now pass `skill_id` in `context` the way the orchestrator actually stamps dispatch messages (§3.1).

Full suite: 594 passed on the `dev` baseline; 602 passed on this branch (8 new tests, 0 regressions).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved intent registration and deregistration validation by requiring a skill identity in the message context.
  * Messages with missing or conflicting skill identities are now rejected, preventing unintended manifest changes.
  * Valid messages continue to support matching skill identifiers or omitted payload identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->