### PR TITLE
fix: entry stamp replaces supplied utterance_id; re-impose all deployment-owned policy fields

### DIFF
--- a/ovos_core/intent_services/service.py
+++ b/ovos_core/intent_services/service.py
@@ -86,6 +86,19 @@ _PIPELINE_MIGRATION_MAP = {
 
 _PIPELINE_RE = re.compile(r'-(high|medium|low)$')
 
+# OVOS-PIPELINE-1 §5.5 / SESSION-1 §3: the deployment-owned per-component
+# override fields that a claiming plugin's ``updated_session`` MUST NOT be
+# able to relax or redirect for the stages that run after it: the pipeline
+# preference list, the six OVOS-TRANSFORM-1 §5 transformer-chain lists, the
+# three blacklist denylists, and ``site_id``.
+_DEPLOYMENT_OWNED_SESSION_FIELDS = (
+    "pipeline",
+    "audio_transformers", "utterance_transformers", "metadata_transformers",
+    "intent_transformers", "dialog_transformers", "tts_transformers",
+    "blacklisted_skills", "blacklisted_intents", "blacklisted_pipelines",
+    "site_id",
+)
+
 # OVOS-PIPELINE-1 §7.3 reserved intent_names, with the registry's "activation
 # push" column. §7.1: "Suppression MUST be keyed on the Match's ``intent_name``
 # and its registry row — never on the producing ``pipeline_id``". §7.3 states
@@ -728,6 +741,17 @@ class IntentService:
         sess = round_session(message)
         if match.updated_session is not None:
             updated = match.updated_session
+            # OVOS-PIPELINE-1 §5.5: every deployment-owned per-component
+            # override field (SESSION-1 §3) is re-imposed onto a plugin's
+            # updated_session from the value the orchestrator held before
+            # the plugin ran, so a claiming plugin cannot relax or redirect
+            # policy for the stages after it: `pipeline`, the six
+            # OVOS-TRANSFORM-1 §5 transformer-chain lists, the three
+            # blacklist denylists, and `site_id`.
+            pre_plugin_overrides = {
+                field: getattr(sess, field)
+                for field in _DEPLOYMENT_OWNED_SESSION_FIELDS
+            }
             if updated.resolved_session_id() != sess.resolved_session_id():
                 # §5.1/§4.2: updated_session is defined as the ROUND's session,
                 # updated — never a different session. A pipeline plugin
@@ -743,6 +767,8 @@ class IntentService:
             else:
                 # ``update`` returns the store for the default session, so the
                 # round carries on the one object every co-located view holds.
+                for field, value in pre_plugin_overrides.items():
+                    setattr(updated, field, value)
                 sess = SessionManager.update(updated)
                 open_round(message, sess)
                 SessionManager.bind(message, sess)
@@ -910,16 +936,20 @@ class IntentService:
         else. Every derived Message carries it for free, because
         ``Message.reply``/``Message.forward`` deep-copy ``context``.
 
-        A value already present is kept: a component that opened the lifecycle
-        out-of-band already sat at entry and stamped under this same rule.
+        The orchestrator's stamp replaces any value already present: the
+        no-overwrite rule binds components *after* entry (e.g. the transformer
+        chain re-asserting a value it finds dropped), not the entry stamp
+        itself.
 
         Returns:
             str: the lifecycle identifier now on the Message.
         """
-        uid = message.context.get("utterance_id")
-        if not uid:
-            uid = str(uuid4())
-            message.context["utterance_id"] = uid
+        prior = message.context.get("utterance_id")
+        uid = str(uuid4())
+        if prior:
+            LOG.debug(f"replacing supplied utterance_id '{prior}' with '{uid}' "
+                      f"at lifecycle entry (OVOS-PIPELINE-1 §9.1.1)")
+        message.context["utterance_id"] = uid
         return uid
 
     def handle_utterance(self, message: Message):
@@ -933,11 +963,11 @@ class IntentService:
         is emitted instead.
         """
         # OVOS-PIPELINE-1 §9.1.1: stamp the lifecycle identifier exactly once,
-        # at lifecycle entry, before anything derives from this Message. A value
-        # already present is never overwritten — regenerating it downstream would
-        # detach every already-derived Message from its lifecycle. Stamped
-        # before the §2.5 carrier check below so the dropped Message's own
-        # end-marker also carries one.
+        # at lifecycle entry, before anything derives from this Message. The
+        # entry stamp replaces any value already present, regardless of who
+        # supplied it — this Message is a new lifecycle. Stamped before the
+        # §2.5 carrier check below so the dropped Message's own end-marker
+        # also carries one.
         uid = self._stamp_utterance_id(message)
 
         # OVOS-SESSION-1 §2.5: reject a present-but-non-object session carrier

--- a/test/unittests/test_intent_service_extended.py
+++ b/test/unittests/test_intent_service_extended.py
@@ -1179,6 +1179,63 @@ class TestEmitMatchMessage(unittest.TestCase):
             svc._dispatch_match(match, msg, "en-US")
         svc.intent_plugins.transform.assert_called_once()
 
+    def test_updated_session_cannot_relax_deployment_owned_policy(self):
+        """OVOS-PIPELINE-1 §5.5: every deployment-owned per-component override
+        field (SESSION-1 §3 - `pipeline`, the six transformer-chain lists,
+        the three blacklist denylists, `site_id`) is re-imposed onto a
+        plugin's `updated_session` from the value the orchestrator held
+        before the plugin ran, so a claiming plugin cannot relax or redirect
+        policy for the stages after it."""
+        sess = Session("s")
+        sess.pipeline = ["ovos-adapt-pipeline-plugin-high"]
+        sess.blacklisted_skills = ["evil.skill"]
+        sess.blacklisted_intents = ["evil.skill:intent"]
+        sess.blacklisted_pipelines = ["ovos-ocp-pipeline-plugin"]
+        sess.site_id = "locked-site"
+        sess.audio_transformers = ["locked-audio-transformer"]
+        sess.utterance_transformers = ["locked-utterance-transformer"]
+        sess.metadata_transformers = ["locked-metadata-transformer"]
+        sess.intent_transformers = ["locked-intent-transformer"]
+        sess.dialog_transformers = ["locked-dialog-transformer"]
+        sess.tts_transformers = ["locked-tts-transformer"]
+
+        tampered = Session.deserialize(sess.serialize())
+        tampered.pipeline = []
+        tampered.blacklisted_skills = []
+        tampered.blacklisted_intents = []
+        tampered.blacklisted_pipelines = []
+        tampered.site_id = "attacker-site"
+        tampered.audio_transformers = []
+        tampered.utterance_transformers = []
+        tampered.metadata_transformers = []
+        tampered.intent_transformers = []
+        tampered.dialog_transformers = []
+        tampered.tts_transformers = []
+
+        svc = _make_service()
+        svc.bus.emit = MagicMock()
+        match = _make_match(session=tampered)
+        msg = Message("recognizer_loop:utterance",
+                      data={"utterances": ["hello"]},
+                      context={"session": sess.serialize()})
+        with patch("ovos_core.intent_services.service.SessionManager.get",
+                   return_value=sess):
+            svc._dispatch_match(match, msg, "en-US")
+
+        synced = Session.deserialize(
+            svc.bus.emit.call_args_list[-1][0][0].context["session"])
+        self.assertEqual(synced.pipeline, ["ovos-adapt-pipeline-plugin-high"])
+        self.assertEqual(synced.blacklisted_skills, ["evil.skill"])
+        self.assertEqual(synced.blacklisted_intents, ["evil.skill:intent"])
+        self.assertEqual(synced.blacklisted_pipelines, ["ovos-ocp-pipeline-plugin"])
+        self.assertEqual(synced.site_id, "locked-site")
+        self.assertEqual(synced.audio_transformers, ["locked-audio-transformer"])
+        self.assertEqual(synced.utterance_transformers, ["locked-utterance-transformer"])
+        self.assertEqual(synced.metadata_transformers, ["locked-metadata-transformer"])
+        self.assertEqual(synced.intent_transformers, ["locked-intent-transformer"])
+        self.assertEqual(synced.dialog_transformers, ["locked-dialog-transformer"])
+        self.assertEqual(synced.tts_transformers, ["locked-tts-transformer"])
+
 
 # ---------------------------------------------------------------------------
 # handle_utterance (basic wiring)
@@ -1704,12 +1761,23 @@ class TestUtteranceIdStamp(unittest.TestCase):
         b = IntentService._stamp_utterance_id(Message("test"))
         self.assertNotEqual(a, b)
 
-    def test_existing_identifier_is_never_overwritten(self):
-        """A component that opened the lifecycle out of band already stamped."""
-        msg = Message("test", {}, {"utterance_id": "opened-elsewhere"})
+    def test_entry_stamp_replaces_any_supplied_identifier(self):
+        """OVOS-PIPELINE-1 §9.1.1: the orchestrator's entry stamp replaces
+        any value already present on the entry Message; the no-overwrite
+        rule binds components after entry, not the entry stamp itself."""
+        msg = Message("test", {}, {"utterance_id": "supplied-by-caller"})
         uid = IntentService._stamp_utterance_id(msg)
-        self.assertEqual(uid, "opened-elsewhere")
-        self.assertEqual(msg.context["utterance_id"], "opened-elsewhere")
+        self.assertNotEqual(uid, "supplied-by-caller")
+        self.assertEqual(msg.context["utterance_id"], uid)
+
+    def test_stale_pong_carrying_the_replaced_id_is_discarded(self):
+        """A poll pong correlated on the pre-entry id no longer matches the
+        round's (freshly stamped) utterance_id, so it is dropped rather
+        than accepted into the round it does not belong to."""
+        msg = Message("test", {}, {"utterance_id": "pre-entry-id"})
+        uid = IntentService._stamp_utterance_id(msg)
+        pong = Message("some.ping.pong", {}, {"utterance_id": "pre-entry-id"})
+        self.assertNotEqual(pong.context["utterance_id"], uid)
 
     def test_derived_messages_carry_the_identifier(self):
         """`reply` and `forward` deep-copy context, so propagation is free."""


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5.1 (claude-fable-5-1) via Claude Code — NOT human-reviewed. Verify before acting.

Governing clauses (OVOS-PIPELINE-1, `architecture` repo @ `5da386ab0b219bc834baafe68a99210eb67297ff`):

> §9.1.1: the orchestrator MUST stamp `context.utterance_id` with its own value at entry regardless of any value already present on the entry Message; the no-overwrite rule binds components after entry.

> §5.5: after a plugin's `updated_session` is accepted, every session field SESSION-1 §3 marks as a deployment-owned per-component override — the `pipeline`, the six transformer lists, the three denylists, and `site_id` — is re-imposed from the inbound session.

Two gaps in the same intake path, both flagged in the architecture design-review audit (`code-gaps.md` items 8 and 9).

`_stamp_utterance_id` kept a caller-supplied `utterance_id` instead of replacing it, so an entry Message could dictate its own lifecycle id and a stale poll pong keyed on that id would still match the round. It now always assigns a fresh id at entry and logs at debug when a supplied one was replaced. The no-overwrite behaviour that binds components downstream of entry (the transformer-chain re-assertion already in `handle_utterance`) is untouched.

`_dispatch_match` accepted a plugin's `updated_session` wholesale, subject only to a `resolved_session_id()` equality guard, and never re-applied any deployment-owned override field from the session the orchestrator held before the plugin ran — only `blacklisted_pipelines`/`_skills`/`_intents` were even discussed in the audit as missing, but the same gap applies to every field SESSION-1 §3 registers in this role. The fix snapshots `pipeline`, the six OVOS-TRANSFORM-1 §5 transformer-chain lists, the three blacklist denylists, and `site_id` before the plugin runs, and re-imposes them onto the accepted `updated_session` afterward, so a claiming plugin cannot relax or redirect policy for the stages that run after it.

Three new tests in `test/unittests/test_intent_service_extended.py` cover both clauses: a pre-stamped entry Message gets a new id and a stale pong carrying the old id no longer matches it; a plugin returning a session with a cleared denylist, an emptied pipeline order, a tampered `site_id`, and all six transformer lists wiped sees every one of them restored. Reverting only the source change (keeping the tests) makes all three fail on the exact assertion the fix now satisfies; restoring the source makes them pass. The full suite (596 unittests + 42 end2end) passes with the change.

Another agent is working on `ovos_core/intent_services/manifest.py` on a separate branch; this PR does not touch that file.