### PR TITLE
fix: manifest refuses registrations on reserved intent names

### DIFF
--- a/ovos_core/intent_services/manifest.py
+++ b/ovos_core/intent_services/manifest.py
@@ -23,6 +23,12 @@ from ovos_utils.log import LOG
 
 from ovos_core.intent_services.working_session import raw_session_id
 
+# OVOS-PIPELINE-1 §7.3 reserved intent_name registry: skills and pipelines
+# MUST NOT register under these names (OVOS-INTENT-4 §5.3/§6.3).
+RESERVED_INTENT_NAMES = frozenset({
+    "converse", "response", "stop", "fallback", "common_query",
+})
+
 
 class IntentManifest:
     """INTENT-4 §10 orchestrator-owned manifest.
@@ -181,15 +187,14 @@ class IntentManifest:
         if not (intent_name and lang):
             LOG.warning(f"malformed intent registration from {skill_id!r}: missing required fields")
             return
-        if intent_name == "stop":
-            # OVOS-STOP-1 §2: "Skills and other pipelines MUST NOT register
-            # `stop`". Such a registration is malformed under OVOS-INTENT-4
-            # §5.3/§6.3 and PIPELINE-1 §7.3 — "log at WARN, do not index".
+        if intent_name in RESERVED_INTENT_NAMES:
+            # OVOS-PIPELINE-1 §7.3 / OVOS-INTENT-4 §5.3/§6.3: a registration
+            # naming a reserved intent_name is malformed — log at WARN, do
+            # not index.
             LOG.warning(
-                f"skill '{skill_id}' registered an intent literally named 'stop' — "
-                f"'stop' is reserved by OVOS-STOP-1 for the '{skill_id}:stop' "
-                "targeted-dispatch topic, so this registration is malformed "
-                "and is not indexed.")
+                f"{message.msg_type}: skill '{skill_id}' registered reserved "
+                f"intent_name '{intent_name}' — malformed per OVOS-PIPELINE-1 "
+                "§7.3, not indexed.")
             return
         session_id = raw_session_id(message)
         if session_id is None:
@@ -222,6 +227,13 @@ class IntentManifest:
         lang = message.data.get("lang")
         session_id = self._session_id_of(message)
         if not intent_name:
+            return
+        if intent_name in RESERVED_INTENT_NAMES:
+            # A reserved name was never indexed (§7.3), so deregistering it
+            # is a no-op — logged rather than silently ignored.
+            LOG.warning(
+                f"{message.msg_type}: skill '{skill_id}' deregistered reserved "
+                f"intent_name '{intent_name}' — ignored per OVOS-PIPELINE-1 §7.3.")
             return
         for method in ("keyword", "template"):
             if lang:

--- a/test/unittests/test_intent_manifest.py
+++ b/test/unittests/test_intent_manifest.py
@@ -18,7 +18,7 @@ from unittest.mock import patch
 from ovos_bus_client.message import Message
 from ovos_utils.fakebus import FakeBus
 
-from ovos_core.intent_services.manifest import IntentManifest
+from ovos_core.intent_services.manifest import IntentManifest, RESERVED_INTENT_NAMES
 
 
 def _manifest() -> IntentManifest:
@@ -70,14 +70,18 @@ class TestManifestRegister(unittest.TestCase):
         key = list(self.m._index.keys())[0]
         self.assertEqual(key[0], "sat-1")
 
-    def test_reserved_stop_intent_name_warns(self):
-        """STOP-1 §2/§9 and PIPELINE-1 §7.3: a registration naming the
-        reserved `stop` is malformed — "log at WARN, do not index"."""
-        with patch("ovos_core.intent_services.manifest.LOG") as mock_log:
-            self.m._on_register(_reg("skill.test", "stop"))
-        mock_log.warning.assert_called_once()
-        self.assertIn("reserved", str(mock_log.warning.call_args))
-        self.assertEqual(self.m._index, {})
+    def test_reserved_intent_names_warn_and_are_not_indexed(self):
+        """OVOS-PIPELINE-1 §7.3 / OVOS-INTENT-4 §5.3/§6.3: a registration
+        naming a reserved intent_name is malformed — "log at WARN, do not
+        index"."""
+        for reserved in RESERVED_INTENT_NAMES:
+            with self.subTest(reserved=reserved):
+                m = _manifest()
+                with patch("ovos_core.intent_services.manifest.LOG") as mock_log:
+                    m._on_register(_reg("skill.test", reserved))
+                mock_log.warning.assert_called_once()
+                self.assertIn("reserved", str(mock_log.warning.call_args))
+                self.assertEqual(m._index, {})
 
     def test_non_reserved_intent_name_does_not_warn(self):
         with patch("ovos_core.intent_services.manifest.LOG") as mock_log:
@@ -160,6 +164,18 @@ class TestManifestDeregister(unittest.TestCase):
                       data={"skill_id": "skill.other", "intent_name": "hello"},
                       context={"skill_id": "skill.test"})
         self.m._on_deregister(msg)
+        self.assertEqual(len(self.m._index), 2)
+
+    def test_deregister_reserved_intent_name_warns_and_is_a_noop(self):
+        # a reserved name was never indexed (§7.3); deregistering it must
+        # not touch the index and must log the ignored mutation.
+        msg = Message("ovos.intent.deregister",
+                      data={"skill_id": "skill.test", "intent_name": "stop"},
+                      context={"skill_id": "skill.test"})
+        with patch("ovos_core.intent_services.manifest.LOG") as mock_log:
+            self.m._on_deregister(msg)
+        mock_log.warning.assert_called_once()
+        self.assertIn("reserved", str(mock_log.warning.call_args))
         self.assertEqual(len(self.m._index), 2)
 
 


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5.1 (claude-fable-5-1) via Claude Code — NOT human-reviewed. Verify before acting.

OVOS-PIPELINE-1 §7.3 reserves five intent_names (`converse`, `response`, `stop`, `fallback`, `common_query`) that skills and pipelines must not register under; OVOS-INTENT-4 §5.3/§6.3 requires such a registration be treated as malformed — logged at WARN, never indexed. The manifest's `_on_register` only special-cased the literal string `stop`, leaving the other four reserved names free to shadow their reserving spec's targeted-dispatch topic if a skill or pipeline accidentally (or maliciously) registered under one of them.

This generalises the check into a single module-level `RESERVED_INTENT_NAMES` frozenset carrying the §7.3 citation as its only comment, applies it to both `ovos.intent.register.keyword` and `ovos.intent.register.template`, and extends the same refusal to `ovos.intent.deregister` (a reserved name was never indexed, so deregistering it is now an explicit logged no-op rather than a silent one). Pipeline plugins are untouched — per §7.3 they may still emit a reserved name as a `Match.intent_name`; only registration is refused.

Reverting just the source change makes `test_intent_manifest.py` fail to collect (`ImportError: cannot import name 'RESERVED_INTENT_NAMES'`, since the test module imports the new constant); restoring it makes the file's 62 tests (5 as subtests, one per reserved name) pass. The full unit suite is 605 passed. I looked for the ovoscope end2end path the standing rule asks for (a real skill declaring `stop` through ovos-workshop's registration path) and found that ovos-workshop does not currently emit `ovos.intent.register.keyword`/`.template` for adapt/padatious skills at all — see the `TODO: drop once the adapt/padatious pipeline consumes ovos.intent.register.* (INTENT-4 §5/§6) directly` markers in its `intents.py`. A workshop skill's intents don't reach this bus surface yet, so there's no live end2end path to add a test onto; the manifest's unit coverage is the only exercised backstop until that TODO lands upstream.