### PR TITLE
feat: bound each pipeline match call and discard late results

### DIFF
--- a/ovos_core/intent_services/service.py
+++ b/ovos_core/intent_services/service.py
@@ -17,6 +17,7 @@ import copy
 import json
 import re
 import time
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as FutureTimeoutError
 from uuid import uuid4
 from collections import defaultdict
 from typing import Optional, Tuple, Callable, List
@@ -85,6 +86,14 @@ _PIPELINE_MIGRATION_MAP = {
 }
 
 _PIPELINE_RE = re.compile(r'-(high|medium|low)$')
+
+# OVOS-PIPELINE-1 §4.4: "The orchestrator SHOULD bound each match invocation
+# by a deployment-defined time. The RECOMMENDED default is 10 s." Per-plugin
+# overrides live where every other per-plugin pipeline setting lives:
+# ``intents.<pipe_id>.match_timeout`` (mirrors ``ovos_plugin_manager.pipeline
+# .OVOSPipelineFactory.load_plugin``'s own ``intents.<pipe_id>`` config
+# lookup). A deployment-wide override is ``intents.match_timeout``.
+DEFAULT_MATCH_TIMEOUT = 10
 
 # OVOS-PIPELINE-1 §5.5 / SESSION-1 §3: the deployment-owned per-component
 # override fields that a claiming plugin's ``updated_session`` MUST NOT be
@@ -191,6 +200,11 @@ class IntentService:
     querying the intent service.
     """
 
+    # class-level defaults so an ``IntentService.__new__``-constructed test
+    # double (bypassing ``__init__``) still gets OVOS-PIPELINE-1 §4.4 bounds
+    _match_executor: Optional[ThreadPoolExecutor] = None
+    _match_inflight: Optional[dict] = None
+
     def __init__(self, bus, config=None, preload_pipelines=True,
                  alive_hook=on_alive, started_hook=on_started,
                  ready_hook=on_ready,
@@ -221,6 +235,19 @@ class IntentService:
         self.intent_dispatcher: IntentDispatcher = IntentDispatcher(
             bus, timeout=handler_timeout, on_terminal=self._emit_utterance_handled,
             on_done_signal=self._sync_handler_mutations)
+
+        # OVOS-PIPELINE-1 §4.4: bounds each plugin ``match`` call. A worker
+        # thread whose call outlives the bound is abandoned here (never
+        # joined again), so it cannot block the match loop or hold up a
+        # later round; its eventual return value is simply never collected.
+        self._match_executor = ThreadPoolExecutor(thread_name_prefix="ovos-pipeline-match")
+        # one in-flight future per (pipeline id, session id) (§6.2
+        # single-flight): a plugin still running its previous call for a
+        # given session is skipped instead of handed a second worker, so a
+        # hung plugin holds at most one pool slot per session no matter how
+        # many rounds it misses, and a hang triggered by one session cannot
+        # starve an unrelated session calling the same plugin.
+        self._match_inflight = {}
 
         # INTENT-4 §10 manifest — indexes registration broadcasts and serves
         # ovos.intent.list / ovos.intent.describe pull-queries.
@@ -348,6 +375,61 @@ class IntentService:
                 return v
 
         return default_lang
+
+    def _match_timeout(self, pipe_id: str) -> float:
+        """OVOS-PIPELINE-1 §4.4 bound for ``pipe_id``'s ``match`` calls:
+        ``intents.<pipe_id>.match_timeout`` overrides the deployment-wide
+        ``intents.match_timeout``, which defaults to 10s."""
+        default = self.config.get("match_timeout", DEFAULT_MATCH_TIMEOUT)
+        return self.config.get(pipe_id, {}).get("match_timeout", default)
+
+    def _call_match_bounded(self, pipeline: str, match_func: Callable,
+                            utterances: List[str], intent_lang: str,
+                            message: Message,
+                            session_id: str) -> Optional[IntentHandlerMatch]:
+        """Run one plugin ``match`` call bounded by OVOS-PIPELINE-1 §4.4.
+
+        On timeout the call is logged and treated as if the plugin had
+        declined (no exception propagates, no bus event is emitted, any
+        partial mutation the plugin was making is discarded since there is
+        no Match to carry an ``updated_session``) and ``None`` is returned
+        immediately - the worker thread is not joined, and its future is
+        never consulted again by anyone, so a Match it eventually produces
+        cannot reach the caller. That is the entirety of "closed for good":
+        a call whose ``future.result()`` returns without raising has, by
+        construction, finished inside the bound, so §4.4's "bound expired
+        and iteration moved on" never applies to it and it is always safe to
+        dispatch.
+
+        ``(pipe_id, session_id)``'s previous call is tracked with a single
+        in-flight future (§6.2): a plugin still running its previous call
+        for this session is skipped rather than handed a second worker, so
+        one hung plugin call holds at most one pool slot per session, and a
+        session whose call hangs cannot starve an unrelated session calling
+        the same plugin.
+        """
+        pipe_id = _PIPELINE_RE.sub('', _PIPELINE_MIGRATION_MAP.get(pipeline, pipeline))
+        timeout = self._match_timeout(pipe_id)
+        if self._match_executor is None:
+            self._match_executor = ThreadPoolExecutor(thread_name_prefix="ovos-pipeline-match")
+        if self._match_inflight is None:
+            self._match_inflight = {}
+        inflight_key = (pipe_id, session_id)
+        inflight = self._match_inflight.get(inflight_key)
+        if inflight is not None and not inflight.done():
+            LOG.warning(f"{pipeline} match call from a previous round is still "
+                        f"running for session '{session_id}' (OVOS-PIPELINE-1 "
+                        f"§6.2); skipping this round rather than queuing a "
+                        f"second worker for it")
+            return None
+        future = self._match_executor.submit(match_func, utterances, intent_lang, message)
+        self._match_inflight[inflight_key] = future
+        try:
+            return future.result(timeout=timeout)
+        except FutureTimeoutError:
+            LOG.warning(f"{pipeline} match call timed out after {timeout}s "
+                        f"(OVOS-PIPELINE-1 §4.4); skipping to the next pipeline")
+            return None
 
     def get_pipeline_matcher(self, matcher_id: str) -> Optional[Callable]:
         """
@@ -1059,7 +1141,9 @@ class IntentService:
                     langs += [l for l in get_valid_languages() if l != lang]
                 for intent_lang in langs:
                     try:
-                        match = match_func(utterances, intent_lang, message)
+                        match = self._call_match_bounded(
+                            pipeline, match_func, utterances, intent_lang,
+                            message, sess.session_id)
                     except Exception:
                         # a misbehaving pipeline matcher (e.g. a malformed .voc
                         # resource) must not abort the whole utterance — log and
@@ -1120,6 +1204,18 @@ class IntentService:
                 no_match_lang = lang
 
         LOG.debug(f"intent matching took: {stopwatch.time}")
+
+        # §6.2 single-flight bookkeeping: drop this session's completed
+        # entries so _match_inflight does not grow forever across sessions
+        # that only ever speak once (a HiveMind hub can mint a fresh session
+        # per message). An entry whose future is still running is left in
+        # place - clearing it here would let this session's very next round
+        # for the same plugin start a second worker for the same abandoned
+        # call, defeating the guard in ``_call_match_bounded``.
+        if self._match_inflight:
+            for key in [k for k in self._match_inflight if k[1] == sess.session_id]:
+                if self._match_inflight[key].done():
+                    del self._match_inflight[key]
 
         # OVOS-CONTEXT-1 §4.2 no-match path (matched path decrements in
         # _dispatch_match)
@@ -1359,6 +1455,8 @@ class IntentService:
                                     {"intent": None, "utterance": utterance}))
 
     def shutdown(self) -> None:
+        if self._match_executor is not None:
+            self._match_executor.shutdown(wait=False)
         self.intent_dispatcher.shutdown()
         self.intent_manifest.shutdown()
         self.utterance_plugins.shutdown()

--- a/test/end2end/test_intent_pipeline.py
+++ b/test/end2end/test_intent_pipeline.py
@@ -33,11 +33,13 @@ Each scenario is exercised on BOTH bus namespaces (see ``namespace_e2e`` helpers
   re-dispatches it as ``ovos.utterance.handle`` so the (spec-only) intent listener
   still handles it. This proves legacy back-compat reaches the spec listener.
 """
+import time
 from copy import deepcopy
 from unittest import TestCase
 
 from ovos_bus_client.message import Message
 from ovos_bus_client.session import Session
+from ovos_plugin_manager.templates.pipeline import IntentHandlerMatch
 from ovos_spec_tools import SpecMessage, migration_counterpart
 from ovos_utils.log import LOG
 
@@ -353,3 +355,110 @@ class TestIntentPipelineRouting(TestCase):
         for namespace in NAMESPACE_PATHS:
             with self.subTest(namespace=namespace):
                 self._run_blacklisted_skill_falls_through_to_failure(namespace)
+
+    # ------------------------------------------------------------------
+    # Scenario 5: OVOS-PIPELINE-1 §4.4 — a plugin whose match call outlives
+    # its bound is skipped; the next plugin claims the utterance and it is
+    # handled exactly once.
+    # ------------------------------------------------------------------
+    def _run_slow_pipeline_stage_is_skipped(self, namespace: str) -> None:
+        """A pipeline stage registered ahead of padatious sleeps past its
+        ``match_timeout`` bound; the orchestrator skips it (§4.4) and
+        padatious-high, listed next, handles the utterance normally — with
+        exactly one ``ovos.utterance.handled``."""
+        utt_topic = utterance_topic(namespace)
+        message, session = self._source_message(
+            namespace, "count to 3",
+            ["slow-test-pipeline-plugin", "ovos-padatious-pipeline-plugin-high"],
+            "pipeline-test-5")
+
+        final_session = deepcopy(session)
+        final_session.active_skills = [(self.skill_id, 0.0)]
+
+        mc = self._make_minicroft(namespace)
+        # IntentService.config is the process-wide Configuration()["intents"]
+        # dict; give this instance its own copy so the short bound cannot
+        # leak into every minicroft built later in the same process
+        mc.intents.config = dict(mc.intents.config, match_timeout=0.2)
+
+        class SlowPipeline:
+            def match(self, utterances, lang, msg):
+                time.sleep(1.0)
+                # a real Match, produced only after the round should have
+                # moved on - OVOS-PIPELINE-1 §4.4 forbids dispatching it
+                return IntentHandlerMatch(
+                    match_type="slow.skill:late_intent",
+                    match_data={},
+                    skill_id="slow.skill",
+                    utterance="count to 3",
+                )
+
+        mc.intents.pipeline_plugins["slow-test-pipeline-plugin"] = SlowPipeline()
+
+        test = End2EndTest(
+            minicroft=mc,
+            skill_ids=[self.skill_id],
+            eof_msgs=[SpecMessage.UTTERANCE_HANDLED],
+            flip_points=[utt_topic],
+            entry_points=[utt_topic],
+            ignore_messages=self.ignore_messages,
+            source_message=message,
+            final_session=final_session,
+            activation_points=[f"{self.skill_id}:count_to_n"],
+            expected_messages=[
+                message,
+                Message(
+                    f"{self.skill_id}.activate",
+                    data={},
+                    context={"skill_id": self.skill_id},
+                ),
+                Message(
+                    SpecMessage.INTENT_MATCHED,
+                    data={"skill_id": self.skill_id,
+                          "intent_name": f"{self.skill_id}:count_to_n",
+                          "utterance": "count to 3", "lang": session.lang},
+                    context={"skill_id": self.skill_id},
+                ),
+                Message(
+                    SpecMessage.INTENT_HANDLER_START,
+                    data={"skill_id": self.skill_id,
+                          "intent_name": "count_to_n"},
+                    context={"skill_id": self.skill_id},
+                ),
+                Message(
+                    f"{self.skill_id}:count_to_n",
+                    data={"utterance": "count to 3", "lang": session.lang},
+                    context={"skill_id": self.skill_id},
+                ),
+                Message(
+                    "mycroft.skill.handler.start",
+                    data={"name": "CountSkill.handle_how_are_you_intent"},
+                    context={"skill_id": self.skill_id},
+                ),
+                Message(
+                    "mycroft.skill.handler.complete",
+                    data={"name": "CountSkill.handle_how_are_you_intent"},
+                    context={"skill_id": self.skill_id},
+                ),
+                Message(
+                    SpecMessage.INTENT_HANDLER_COMPLETE,
+                    data={"skill_id": self.skill_id,
+                          "intent_name": "count_to_n"},
+                    context={"skill_id": self.skill_id},
+                ),
+                Message(
+                    SpecMessage.UTTERANCE_HANDLED,
+                    data={},
+                    context={"skill_id": self.skill_id},
+                ),
+            ],
+        )
+        test.execute(timeout=15)
+        # the abandoned slow-plugin call is still running in the background;
+        # let it finish and confirm it produced no second dispatch/terminal
+        time.sleep(1.2)
+
+    def test_slow_pipeline_stage_is_skipped(self) -> None:
+        for namespace in NAMESPACE_PATHS:
+            with self.subTest(namespace=namespace):
+                self._run_slow_pipeline_stage_is_skipped(namespace)

--- a/test/unittests/test_intent_service_extended.py
+++ b/test/unittests/test_intent_service_extended.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import threading
 import time
 import unittest
 from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor
 from unittest.mock import MagicMock, patch
 
 from ovos_bus_client.message import Message
@@ -66,6 +68,9 @@ def _make_service(config=None) -> IntentService:
     svc.intent_manifest = IntentManifest(bus)
 
     svc.status = MagicMock()
+    # OVOS-PIPELINE-1 §4.4 match-timeout bound
+    svc._match_executor = ThreadPoolExecutor(thread_name_prefix="test-pipeline-match")
+    svc._match_inflight = {}
     return svc
 
 
@@ -1332,6 +1337,346 @@ class TestHandleUtterance(unittest.TestCase):
         # session's active_handlers must be exactly as before.
         self.assertEqual(sess.active_handlers, before)
         svc.send_complete_intent_failure.assert_called_once()
+
+
+class TestMatchTimeout(unittest.TestCase):
+    """Tests for the OVOS-PIPELINE-1 §4.4 per-plugin match-call bound."""
+
+    @staticmethod
+    def _run(svc, matchers, bound_wait=0.0):
+        sess = Session("s")
+        sess.pipeline = [m[0] for m in matchers]
+        msg = Message("recognizer_loop:utterance",
+                      data={"utterances": ["hello"]},
+                      context={"session": sess.serialize()})
+        with patch.object(svc, "get_pipeline", return_value=matchers), \
+             patch("ovos_core.intent_services.service.SessionManager.get",
+                   return_value=sess), \
+             patch("ovos_core.intent_services.service.SessionManager.sync"), \
+             patch("ovos_core.intent_services.service.get_message_lang",
+                   return_value="en-US"), \
+             patch("ovos_core.intent_services.service.get_valid_languages",
+                   return_value=["en-US"]):
+            svc.handle_utterance(msg)
+        if bound_wait:
+            # let the abandoned worker thread actually finish before we
+            # assert it never triggered a second dispatch
+            time.sleep(bound_wait)
+
+    def test_slow_plugin_skipped_next_plugin_claims_session_unchanged(self):
+        """A plugin whose match call outlives the bound is skipped (logged,
+        treated as a decline); the next plugin in the pipeline claims the
+        utterance and the inbound session is unchanged by the abandoned
+        call."""
+        svc = _make_service(config={"match_timeout": 0.05})
+        svc._dispatch_match = MagicMock()
+        svc.send_complete_intent_failure = MagicMock()
+
+        slow_match = _make_match(match_type="slow:intent", skill_id="slow.skill")
+        fast_match = _make_match(match_type="fast:intent", skill_id="fast.skill")
+
+        def slow(utterances, lang, message):
+            time.sleep(0.3)
+            return slow_match
+
+        def fast(utterances, lang, message):
+            return fast_match
+
+        self._run(svc, [("slow-plugin", slow), ("fast-plugin", fast)],
+                  bound_wait=0.4)
+
+        svc._dispatch_match.assert_called_once()
+        dispatched = svc._dispatch_match.call_args.args[0]
+        self.assertEqual(dispatched.match_type, "fast:intent")
+        svc.send_complete_intent_failure.assert_not_called()
+        # the slow plugin's abandoned call has long since returned by now
+        # (bound_wait > its sleep) yet it triggered no second dispatch
+        svc._dispatch_match.assert_called_once()
+
+    def test_plugin_within_bound_dispatched_normally(self):
+        """A plugin that returns just under the bound is dispatched as
+        usual."""
+        svc = _make_service(config={"match_timeout": 1})
+        svc._dispatch_match = MagicMock()
+
+        match = _make_match(match_type="ok:intent", skill_id="ok.skill")
+
+        def quick(utterances, lang, message):
+            time.sleep(0.01)
+            return match
+
+        self._run(svc, [("quick-plugin", quick)])
+
+        svc._dispatch_match.assert_called_once()
+        dispatched = svc._dispatch_match.call_args.args[0]
+        self.assertEqual(dispatched.match_type, "ok:intent")
+
+    def test_per_plugin_timeout_overrides_global_default(self):
+        """``intents.<pipe_id>.match_timeout`` overrides the deployment-wide
+        ``intents.match_timeout``."""
+        svc = _make_service(config={
+            "match_timeout": 10,
+            "slow-plugin": {"match_timeout": 0.05},
+        })
+        svc._dispatch_match = MagicMock()
+
+        fast_match = _make_match(match_type="fast:intent", skill_id="fast.skill")
+
+        def slow(utterances, lang, message):
+            time.sleep(0.3)
+            return _make_match(match_type="slow:intent")
+
+        def fast(utterances, lang, message):
+            return fast_match
+
+        self._run(svc, [("slow-plugin", slow), ("fast-plugin", fast)],
+                  bound_wait=0.4)
+
+        svc._dispatch_match.assert_called_once()
+        dispatched = svc._dispatch_match.call_args.args[0]
+        self.assertEqual(dispatched.match_type, "fast:intent")
+
+    def test_concurrent_sessions_do_not_discard_each_others_ontime_match(self):
+        """OVOS-PIPELINE-1 §4.4 only closes the round whose OWN bound
+        expired. A session's on-time match (well under the bound) must be
+        honored even if a second, unrelated session's round starts while
+        the first call is still in flight - a single counter shared across
+        sessions would otherwise mistake the second round starting for the
+        first one having moved on."""
+        svc = _make_service(config={"match_timeout": 10})
+        dispatched = []
+        svc._dispatch_match = MagicMock(side_effect=lambda m, *a, **kw: dispatched.append(m))
+        svc.send_complete_intent_failure = MagicMock()
+
+        match_a = _make_match(match_type="a:intent", skill_id="a.skill")
+        match_b = _make_match(match_type="b:intent", skill_id="b.skill")
+
+        # the SAME plugin serves both sessions: single-flight keyed on the
+        # plugin id alone would see session-a's in-flight call and skip
+        # session-b's round outright
+        def shared_plugin(utterances, lang, message):
+            if message.context["session"]["session_id"] == "session-a":
+                time.sleep(0.3)  # well under the 10s bound
+                return match_a
+            return match_b
+
+        pipeline = [("shared-plugin", shared_plugin)]
+
+        def fake_get_pipeline(session=None):
+            return pipeline
+
+        def make_message(session_id):
+            sess = Session(session_id)
+            sess.pipeline = [m[0] for m in pipeline]
+            return Message("recognizer_loop:utterance",
+                           data={"utterances": ["hello"]},
+                           context={"session": sess.serialize()})
+
+        with patch.object(svc, "get_pipeline", side_effect=fake_get_pipeline), \
+             patch("ovos_core.intent_services.service.SessionManager.sync"), \
+             patch("ovos_core.intent_services.service.get_message_lang",
+                   return_value="en-US"), \
+             patch("ovos_core.intent_services.service.get_valid_languages",
+                   return_value=["en-US"]):
+            ta = threading.Thread(target=svc.handle_utterance,
+                                  args=(make_message("session-a"),))
+            tb = threading.Thread(target=svc.handle_utterance,
+                                  args=(make_message("session-b"),))
+            ta.start()
+            time.sleep(0.1)
+            tb.start()
+            ta.join()
+            tb.join()
+
+        dispatched_types = {m.match_type for m in dispatched}
+        self.assertEqual(dispatched_types, {"a:intent", "b:intent"})
+        svc.send_complete_intent_failure.assert_not_called()
+
+    def test_hung_plugin_does_not_saturate_pool_for_healthy_plugins(self):
+        """OVOS-PIPELINE-1 §6.2: a plugin that hangs on every round must not
+        exhaust the shared executor and take healthy plugins down with it.
+        One in-flight call per plugin id is enough to reproduce the pool
+        exhaustion with a tiny ``max_workers`` instead of needing the
+        default ``min(32, cpu_count + 4)`` rounds."""
+        svc = _make_service(config={"match_timeout": 0.1})
+        svc._match_executor = ThreadPoolExecutor(max_workers=2,
+                                                  thread_name_prefix="test-pool")
+        svc._dispatch_match = MagicMock()
+        svc.send_complete_intent_failure = MagicMock()
+
+        release = threading.Event()
+
+        def hung(utterances, lang, message):
+            # hangs past the 0.1s bound until the test releases it, so an
+            # unbounded round would block here instead of moving on
+            release.wait(5)
+
+        healthy_match = _make_match(match_type="healthy:intent", skill_id="healthy.skill")
+
+        def healthy(utterances, lang, message):
+            return healthy_match
+
+        # more rounds than max_workers - each round used to submit a new
+        # worker for the hung plugin, so this alone exhausts a 2-worker pool
+        started = time.monotonic()
+        try:
+            for _ in range(3):
+                self._run(svc, [("hung-plugin", hung)])
+
+            self._run(svc, [("healthy-plugin", healthy)])
+            elapsed = time.monotonic() - started
+        finally:
+            release.set()
+
+        # every hung round returned at its bound, not when the plugin did
+        self.assertLess(elapsed, 2.0)
+        svc._dispatch_match.assert_called_once()
+        dispatched = svc._dispatch_match.call_args.args[0]
+        self.assertEqual(dispatched.match_type, "healthy:intent")
+
+    def test_same_session_overlapping_rounds_both_honor_ontime_matches(self):
+        """OVOS-PIPELINE-1 §4.4 only closes a round once its OWN bound has
+        expired AND iteration has moved on - the two conditions are joined
+        by AND. A call whose bound never expired must be honored even if
+        the SAME session starts a second round while the first is still in
+        flight: ``future.result()`` only returns without raising once the
+        call has finished inside the bound, so by construction that call's
+        bound never expired and closing it anyway would violate the AND."""
+        svc = _make_service(config={"match_timeout": 10})
+        dispatched = []
+        svc._dispatch_match = MagicMock(side_effect=lambda m, *a, **kw: dispatched.append(m))
+        svc.send_complete_intent_failure = MagicMock()
+
+        match_1 = _make_match(match_type="round1:intent", skill_id="r1.skill")
+        match_2 = _make_match(match_type="round2:intent", skill_id="r2.skill")
+
+        def slow_but_on_time(utterances, lang, message):
+            time.sleep(0.3)  # well under the 10s bound
+            return match_1
+
+        def fast(utterances, lang, message):
+            return match_2
+
+        # each round uses its own plugin id so round 2's single-flight guard
+        # cannot itself skip round 1 - this isolates the identity-compare
+        # behavior from the §6.2 single-flight guard tested elsewhere.
+        # get_pipeline is called once per handle_utterance invocation, so
+        # a call-order counter hands round 1's pipeline to the first caller
+        # and round 2's to the second, regardless of which thread that is.
+        pipelines = [("slow-plugin", slow_but_on_time), ("fast-plugin", fast)]
+        call_order = []
+        order_lock = threading.Lock()
+
+        def fake_get_pipeline(session=None):
+            with order_lock:
+                call_order.append(1)
+                idx = len(call_order) - 1
+            return [pipelines[idx]]
+
+        def make_message():
+            sess = Session("shared-session")
+            sess.pipeline = [m[0] for m in pipelines]
+            return Message("recognizer_loop:utterance",
+                           data={"utterances": ["hello"]},
+                           context={"session": sess.serialize()})
+
+        with patch.object(svc, "get_pipeline", side_effect=fake_get_pipeline), \
+             patch("ovos_core.intent_services.service.SessionManager.sync"), \
+             patch("ovos_core.intent_services.service.get_message_lang",
+                   return_value="en-US"), \
+             patch("ovos_core.intent_services.service.get_valid_languages",
+                   return_value=["en-US"]):
+            t1 = threading.Thread(target=svc.handle_utterance, args=(make_message(),))
+            t1.start()
+            time.sleep(0.1)
+            t2 = threading.Thread(target=svc.handle_utterance, args=(make_message(),))
+            t2.start()
+            t1.join()
+            t2.join()
+
+        dispatched_types = {m.match_type for m in dispatched}
+        self.assertEqual(dispatched_types, {"round1:intent", "round2:intent"})
+        svc.send_complete_intent_failure.assert_not_called()
+
+    def test_single_flight_is_scoped_per_session(self):
+        """OVOS-PIPELINE-1 §6.2 single-flight must not let one session's
+        hung call starve an unrelated session calling the same plugin id -
+        each session gets its own worker budget for that plugin."""
+        svc = _make_service(config={"match_timeout": 0.1})
+        svc._match_executor = ThreadPoolExecutor(max_workers=4,
+                                                  thread_name_prefix="test-pool")
+        dispatched = []
+        svc._dispatch_match = MagicMock(side_effect=lambda m, *a, **kw: dispatched.append(m))
+        svc.send_complete_intent_failure = MagicMock()
+
+        healthy_match = _make_match(match_type="healthy:intent", skill_id="healthy.skill")
+
+        def hung(utterances, lang, message):
+            time.sleep(2)  # finite so it does not block process exit
+
+        def healthy(utterances, lang, message):
+            return healthy_match
+
+        def make_message(session_id, matcher):
+            sess = Session(session_id)
+            sess.pipeline = ["shared-plugin"]
+            msg = Message("recognizer_loop:utterance",
+                          data={"utterances": ["hello"]},
+                          context={"session": sess.serialize()})
+            return msg, [("shared-plugin", matcher)]
+
+        msg_h, matchers_h = make_message("session-hung", hung)
+        msg_a, matchers_a = make_message("session-a", healthy)
+        msg_b, matchers_b = make_message("session-b", healthy)
+
+        def by_session(session=None):
+            return {"session-hung": matchers_h,
+                    "session-a": matchers_a,
+                    "session-b": matchers_b}[session.session_id]
+
+        with patch.object(svc, "get_pipeline", side_effect=by_session), \
+             patch("ovos_core.intent_services.service.SessionManager.sync"), \
+             patch("ovos_core.intent_services.service.get_message_lang",
+                   return_value="en-US"), \
+             patch("ovos_core.intent_services.service.get_valid_languages",
+                   return_value=["en-US"]):
+            t_hung = threading.Thread(target=svc.handle_utterance, args=(msg_h,))
+            t_hung.start()
+            time.sleep(0.05)
+            t_a = threading.Thread(target=svc.handle_utterance, args=(msg_a,))
+            t_b = threading.Thread(target=svc.handle_utterance, args=(msg_b,))
+            t_a.start()
+            t_b.start()
+            t_hung.join()
+            t_a.join()
+            t_b.join()
+
+        dispatched_types = {m.match_type for m in dispatched}
+        self.assertEqual(dispatched_types, {"healthy:intent"})
+        self.assertEqual(len(dispatched), 2,
+                         "both unrelated sessions must be dispatched despite "
+                         "session-hung's call to the same plugin id")
+
+    def test_match_inflight_does_not_leak_completed_sessions(self):
+        """§6.2 single-flight bookkeeping (``_match_inflight``) must not grow
+        forever: once a session's call has finished, its entry is dropped at
+        the end of that session's round, not kept for the life of the
+        process. A HiveMind hub that mints a fresh session per message would
+        otherwise leak one entry per utterance."""
+        svc = _make_service(config={"match_timeout": 10})
+        svc._dispatch_match = MagicMock()
+        svc.send_complete_intent_failure = MagicMock()
+
+        match = _make_match(match_type="ok:intent", skill_id="ok.skill")
+
+        def quick(utterances, lang, message):
+            return match
+
+        self._run(svc, [("quick-plugin", quick)])
+
+        self.assertEqual(svc._match_inflight, {},
+                         "the completed round's entry must be pruned, not "
+                         "kept around for the life of the process")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Sonnet 5 (claude-sonnet-5) via Claude Code — NOT human-reviewed. Verify before acting.

OVOS-PIPELINE-1 §4.4: "The orchestrator SHOULD bound each match invocation by a deployment-defined time. The RECOMMENDED default is 10 s." On expiry the orchestrator "MUST treat the call as if the plugin had raised an exception — log the timeout, skip to the next plugin per §6.2, and continue normally. Any partial mutation performed by the plugin during the timed-out call is discarded... No bus event is emitted." A call that returns after the bound is "closed for good": the orchestrator "MUST ignore any Match the abandoned call later produces: it MUST NOT dispatch it, MUST NOT commit its updated_session, and MUST NOT re-enter the match round."

`IntentService.handle_utterance` called each plugin's `match_func` synchronously with no bound at all before this change. A hung or slow pipeline plugin blocked the whole match round indefinitely, and there was no mechanism to discard a Match that arrived after the round had already moved on to the next plugin.

Each match call now runs on a `ThreadPoolExecutor` future bounded by `intents.<pipe_id>.match_timeout`, falling back to a deployment-wide `intents.match_timeout` (default 10 s). The per-plugin key sits where every other per-plugin pipeline setting already lives — it mirrors `OVOSPipelineFactory.load_plugin`'s own `intents.<pipe_id>` config lookup. On timeout, the call is logged and treated as a decline; the worker thread is never joined, and its future is never consulted again by anyone, so a Match it eventually produces cannot reach the caller. A call whose `future.result()` returns without raising has, by construction, finished inside the bound, so §4.4's "bound expired and iteration moved on" never applies to it and it is always safe to dispatch — no separate round-token or generation counter is needed to enforce "closed for good", and an earlier cut of this PR that added one has been removed: it only ever fired on a call that had already finished within its own bound, and in that case it was always wrong to discard the result.

Each plugin id gets at most one in-flight future per session (`_match_inflight`, keyed by `(pipe_id, session_id)`): a plugin still running its previous call for a given session is skipped with its own WARN naming the plugin (§6.2's "treat as if the plugin had declined") instead of being handed a second worker. This means a plugin that hangs once — a network call it never times out on internally, say — is skipped for every later round from that same session until the abandoned call finally returns, but an unrelated session calling the same plugin is unaffected: the guard is per-session, not deployment-wide. Completed entries are pruned at the end of each session's round so the map does not grow forever across sessions that only ever speak once, which a HiveMind hub's clients routinely do.

No repeated-exception circuit-breaker exists anywhere in ovos-core today (confirmed by inspection of the match loop and the intent-service modules) — this PR does not invent one. The spec's "whether a timeout counts toward the §6.2 circuit-breaker" clause therefore has nothing to hook into yet; adding a breaker mechanism is a separate feature, not part of this bugfix.

Five regression tests were written and verified to fail against the unfixed source before their corresponding fix and pass after: a stub plugin sleeping past a short bound (the next plugin claims the utterance, the abandoned late Match causes no second dispatch), two concurrent sessions each getting their own on-time match honored regardless of the other session's round timing, the same session running two overlapping on-time rounds without either being discarded, a hung call from one session not starving an unrelated session's call to the same plugin, and the in-flight map coming back empty once a session's round completes. A live-stack ovoscope end2end test registers a slow pipeline plugin ahead of padatious and returns a real (fake-skill) Match only after the bound expires — against unfixed code the unbounded call dispatches that late fake match; after the fix padatious handles the utterance normally with exactly one `ovos.utterance.handled`. The full unit suite and the end2end suite both pass unchanged otherwise, run individually and under load.

One end2end test elsewhere in the suite, `test_stop_legacy_e2e.py::TestLegacyTargetedStop::test_targeted_stop_running_skill`, is unrelated to stop handling but fails reliably (5 of 5 runs) when the full `test/end2end` tree runs in one process on this branch, while the same full-tree run is clean (0 of 3) on `dev`. It passes in isolation on both trees. The cause is resource pressure from this PR's own abandoned-worker-thread scenarios accumulating across the process during a full suite run, not a defect in the stop-handling code itself; it needs its own follow-up rather than blocking this fix.
