### PR TITLE
fix: read each transformer stage's own config section

### DIFF
--- a/ovos_core/transformers.py
+++ b/ovos_core/transformers.py
@@ -14,13 +14,31 @@ from ovos_plugin_manager.typed_slots_transformers import find_typed_slots_transf
 from ovos_utils.log import LOG
 
 
+def _stage_config(config: Optional[dict], section: str) -> dict:
+    """The configuration for one transformer stage.
+
+    The plugin manager accepts either a whole core configuration or the
+    stage's own section, and when a whole configuration does not carry the
+    section it cannot tell the two apart: every top-level key then reads as
+    an enabled plugin, and the loader warns once per key that the plugin is
+    not installed. Reading the section here keeps a stage that configures
+    itself from the deployment off that path.
+
+    An explicit ``config`` is returned untouched, because a caller that
+    supplies one has already named the mapping it wants used.
+    """
+    if config is not None:
+        return config
+    return Configuration().get(section) or {}
+
+
 class UtteranceTransformersService(_UtteranceTransformersService):
     """Runs utterance transformers in OVOS-TRANSFORM §4 ascending priority
     order: a plugin of priority 1 runs first."""
 
     def __init__(self, bus, config: Optional[dict] = None):
-        config = config or Configuration()
-        super().__init__(bus=bus, config=config)
+        super().__init__(bus=bus,
+                         config=_stage_config(config, self.config_section))
 
     @classmethod
     def find_plugins(cls):
@@ -32,8 +50,8 @@ class MetadataTransformersService(_MetadataTransformersService):
     order: a plugin of priority 1 runs first."""
 
     def __init__(self, bus, config: Optional[dict] = None):
-        config = config or Configuration()
-        super().__init__(bus=bus, config=config)
+        super().__init__(bus=bus,
+                         config=_stage_config(config, self.config_section))
 
     @classmethod
     def find_plugins(cls):
@@ -45,8 +63,8 @@ class IntentTransformersService(_IntentTransformersService):
     order: a plugin of priority 1 runs first."""
 
     def __init__(self, bus, config: Optional[dict] = None):
-        config = config or Configuration()
-        super().__init__(bus=bus, config=config)
+        super().__init__(bus=bus,
+                         config=_stage_config(config, self.config_section))
 
     @classmethod
     def find_plugins(cls):
@@ -67,8 +85,8 @@ class TypedSlotsTransformersService(_TransformersService):
 
     def __init__(self, bus, config: Optional[dict] = None):
         self._selected = None
-        config = config or Configuration()
-        super().__init__(bus=bus, config=config)
+        super().__init__(bus=bus,
+                         config=_stage_config(config, self.config_section))
 
     @classmethod
     def find_plugins(cls):

--- a/test/unittests/test_transformers.py
+++ b/test/unittests/test_transformers.py
@@ -22,6 +22,7 @@ from ovos_core.transformers import (
     UtteranceTransformersService,
     MetadataTransformersService,
     IntentTransformersService,
+    TypedSlotsTransformersService,
 )
 
 
@@ -500,3 +501,76 @@ class TestIntentTransformersServiceTransform(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestStageConfigResolution(unittest.TestCase):
+    """A stage reads its own config section.
+
+    The plugin manager accepts either a whole core configuration or a
+    stage's section, and cannot tell them apart when the whole
+    configuration does not carry the section: every top-level key then
+    reads as an enabled plugin and the loader warns once per key.
+    """
+
+    # a core configuration shaped like the shipped one, carrying none of
+    # the transformer sections
+    FULL_CONFIG = {
+        "lang": "en-US",
+        "listener": {"sample_rate": 16000},
+        "websocket": {"host": "127.0.0.1"},
+        "skills": {"blacklisted_skills": []},
+        "tts": {"module": "ovos-tts-plugin-server"},
+        "stt": {"module": "ovos-stt-plugin-server"},
+    }
+
+    SERVICES = (
+        ("ovos_core.transformers.find_utterance_transformer_plugins",
+         UtteranceTransformersService),
+        ("ovos_core.transformers.find_metadata_transformer_plugins",
+         MetadataTransformersService),
+        ("ovos_core.transformers.find_intent_transformer_plugins",
+         IntentTransformersService),
+        ("ovos_core.transformers.find_typed_slots_transformer_plugins",
+         TypedSlotsTransformersService),
+    )
+
+    def _warnings_at_boot(self, finder, cls):
+        with patch(finder, return_value={}), \
+             patch("ovos_core.transformers.Configuration",
+                   return_value=dict(self.FULL_CONFIG)), \
+             patch("ovos_plugin_manager.transformer_services.LOG.warning") as w:
+            cls(FakeBus())
+        return [c.args[0] for c in w.call_args_list]
+
+    def test_a_stage_whose_section_is_absent_warns_about_nothing(self):
+        for finder, cls in self.SERVICES:
+            with self.subTest(service=cls.__name__):
+                warnings = self._warnings_at_boot(finder, cls)
+                self.assertEqual(
+                    warnings, [],
+                    f"{cls.__name__} treated top-level config keys as "
+                    f"plugins: {warnings}")
+
+    def test_a_configured_but_missing_plugin_is_still_reported(self):
+        """The guard that silencing the spurious warnings kept the real one."""
+        cfg = dict(self.FULL_CONFIG)
+        cfg["utterance_transformers"] = {"ovos-utterance-plugin-cancel": {}}
+        with patch("ovos_core.transformers.find_utterance_transformer_plugins",
+                   return_value={}), \
+             patch("ovos_core.transformers.Configuration", return_value=cfg), \
+             patch("ovos_plugin_manager.transformer_services.LOG.warning") as w:
+            UtteranceTransformersService(FakeBus())
+        warnings = [c.args[0] for c in w.call_args_list]
+        self.assertEqual(len(warnings), 1, warnings)
+        self.assertIn("ovos-utterance-plugin-cancel", warnings[0])
+
+    def test_an_explicit_config_is_passed_through_untouched(self):
+        """A caller that supplies a mapping has named what it wants used."""
+        section = {"some-plugin": {"active": True}}
+        with patch("ovos_core.transformers.find_utterance_transformer_plugins",
+                   return_value={}), \
+             patch("ovos_plugin_manager.transformer_services.LOG.warning") as w:
+            svc = UtteranceTransformersService(FakeBus(), config=section)
+        self.assertEqual(svc.config, section)
+        self.assertEqual(len(w.call_args_list), 1)
+        self.assertIn("some-plugin", w.call_args_list[0].args[0])


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 5 (claude-opus-5) via Claude Code — NOT human-reviewed. Every number below was executed against `ovos-config 3.5.0a1`, and the vintages come from `git tag --contains` on the commit that added each section.

Each transformer stage reads its own configuration section instead of being handed the whole configuration.

## What this does not do

It does not reduce warning volume on a current deployment. All four sections ship in `ovos-config 3.5.0a1`, so `_resolve_section` finds each one and the ambiguous path is never taken. Measured on a stock config, head and `dev` produce the same warnings, and the ones they produce are genuine: a plugin named in the section that is not installed.

An earlier revision of this description claimed 34 spurious warnings per stage becoming zero. That figure was measured against a configuration with the section deleted, and the qualifier was carrying the whole claim.

## Where the storm is real

One stage, on one range of `ovos-config`. The sections entered the default configuration at different times:

| Section | Ships since |
| --- | --- |
| `utterance_transformers` | `0.1.0` |
| `metadata_transformers` | `0.1.0` |
| `intent_transformers` | `1.2.2` |
| `typed_slots_transformers` | `3.5.0a1` |

So three of the four have not been able to storm for years. `typed_slots_transformers` storms below `3.5.0a1`, where the section is absent and the whole `mycroft.conf` is read as the section:

```
'listener' is enabled in the 'typed_slots_transformers' config section but is not installed
'websocket' is enabled in the 'typed_slots_transformers' config section but is not installed
'skills'   is enabled in the 'typed_slots_transformers' config section but is not installed
```

34 lines on a stock configuration of that vintage, one per top-level key. That is the sighting the harness reported live, and it is real on that range.

## Why the change is still worth making

Not for the warning count. Because no stage should depend on the deployment shipping its section, and today all four do. `_resolve_section` accepts either a whole configuration or a section and cannot tell them apart when the section is missing:

```python
if cls.config_section and cls.config_section in config:
    return dict(config.get(cls.config_section) or {})
return dict(config)          # the whole mycroft.conf becomes "the section"
```

Any future section is in the same position `typed_slots_transformers` was in before `3.5.0a1`: correct only while the deployment happens to carry it. The new tests pin that property directly, constructing each stage against a configuration that lacks its section and asserting nothing is reported.

An explicit `config` argument is still passed through untouched, because a caller supplying one has named the mapping it wants used, and this repo's tests rely on that.

## What stays noisy, deliberately

A plugin genuinely configured and genuinely absent still warns, once. One of the new tests is the guard that silencing the ambiguous case did not silence the real one.

## Verification

| Run | Result |
| --- | --- |
| fail-before, `dev` source with the new tests | 4 failed, 42 passed |
| after | 42 passed, 4 subtests |
| full `test/unittests` | 608 passed |

Companion fixes for the same root cause, where the sections do **not** ship and the storm is on every boot: OpenVoiceOS/ovos-audio#201 and OpenVoiceOS/ovos-dinkum-listener#254. The root ambiguity is capped in OpenVoiceOS/ovos-plugin-manager#450, which merges after all three.
