### PR TITLE
fix: report the enable/disable target substitution

### DIFF
--- a/ovos_core/intent_services/manifest.py
+++ b/ovos_core/intent_services/manifest.py
@@ -38,13 +38,29 @@ def _target_skill_id(message: Message) -> Optional[str]:
     provisioning tool or a conflict-resolving skill acts on another skill's
     behalf, so a difference is never grounds for rejection and an absent
     context ``skill_id`` never makes the message malformed.
+
+    Substituting the source for an absent target contradicts §3.2 and is kept
+    only for the migration window. ``ovos-spec-tools`` bridges the legacy
+    ``mycroft.skill.{enable,disable}_intent`` onto the spec topics, and the
+    legacy payload has no ``skill_id`` field to carry, so a bridged toggle
+    arrives with the emitter named in its context and nothing else. Resolving
+    payload-only makes every such toggle a silent no-op. The substitution is
+    logged so that a spec-native producer omitting the target is visible rather
+    than silently retargeted, and it goes away with the mirror.
     """
     payload_skill_id = message.data.get("skill_id")
     source_skill_id = message.context.get("skill_id")
-    if payload_skill_id and source_skill_id and payload_skill_id != source_skill_id:
-        LOG.debug(f"{message.msg_type}: source {source_skill_id!r} acting on "
-                  f"target {payload_skill_id!r}")
-    return payload_skill_id or source_skill_id
+    if payload_skill_id:
+        if source_skill_id and payload_skill_id != source_skill_id:
+            LOG.debug(f"{message.msg_type}: source {source_skill_id!r} acting on "
+                      f"target {payload_skill_id!r}")
+        return payload_skill_id
+    if source_skill_id:
+        LOG.warning(f"{message.msg_type}: no target skill_id in the payload; "
+                    f"acting on the source {source_skill_id!r} instead. "
+                    "OVOS-INTENT-4 §3.2 names the target in `data`; this "
+                    "substitution serves the pre-spec bridge only.")
+    return source_skill_id
 
 
 class IntentManifest:
@@ -247,7 +263,7 @@ class IntentManifest:
 
     def _on_enable_disable(self, message: Message):
         enabled = message.msg_type == "ovos.intent.enable"
-        skill_id = message.data.get("skill_id") or message.context.get("skill_id")
+        skill_id = _target_skill_id(message)
         intent_name = message.data.get("intent_name")
         lang = message.data.get("lang")
         session_id = self._session_id_of(message)

--- a/test/unittests/test_intent_manifest.py
+++ b/test/unittests/test_intent_manifest.py
@@ -204,6 +204,34 @@ class TestManifestEnableDisable(unittest.TestCase):
         entry = list(self.m._index.values())[0]
         self.assertTrue(entry["enabled"])
 
+    def test_bridged_legacy_toggle_resolves_from_context(self):
+        # ovos-spec-tools bridges mycroft.skill.disable_intent onto the spec
+        # topic, and _toggle_legacy_to_spec has no skill_id field to carry, so
+        # the emitter is named only in the context. Resolving payload-only
+        # would make every bridged toggle a silent no-op.
+        msg = Message("ovos.intent.disable",
+                      data={"intent_name": "hello", "lang": "en-US"},
+                      context={"skill_id": "skill.test"})
+        with patch("ovos_core.intent_services.manifest.LOG.warning") as warn:
+            self.m._on_enable_disable(msg)
+        entry = list(self.m._index.values())[0]
+        self.assertFalse(entry["enabled"])
+        warned = " ".join(str(c.args[0]) for c in warn.call_args_list)
+        self.assertIn("§3.2", warned)
+        self.assertIn("skill.test", warned)
+
+    def test_payload_target_wins_over_a_differing_source(self):
+        # §3.2: the payload names the target, the context is provenance. A
+        # provisioning tool acting on another skill must not retarget itself.
+        self.m._on_register(_reg("skill.other", "hello", lang="en-US"))
+        msg = Message("ovos.intent.disable",
+                      data={"skill_id": "skill.other", "intent_name": "hello",
+                            "lang": "en-US"},
+                      context={"skill_id": "provisioner"})
+        self.m._on_enable_disable(msg)
+        by_skill = {k[1]: v["enabled"] for k, v in self.m._index.items()}
+        self.assertEqual(by_skill, {"skill.test": True, "skill.other": False})
+
 
 class TestDeregisterSessionScope(unittest.TestCase):
     """§11.1/§11.3 — deregistration MUST key off context.session.session_id,


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 5 (claude-opus-5) via Claude Code — NOT human-reviewed. Verify before acting.

`IntentManifest._on_enable_disable` was the one INTENT-4 §§5-8 handler resolving the target skill inline instead of through `_target_skill_id`. It now uses the helper, and the helper warns when it substitutes the context for an absent payload target.

## What did not change, and why

The substitution itself stays. It looks like an adoption residual and it is not: `ovos-spec-tools` bridges the legacy `mycroft.skill.{enable,disable}_intent` onto the spec topics, and `_toggle_legacy_to_spec` copies `intent_name` and nothing else — the legacy payload has no `skill_id` field to carry, which the map documents as a known lossy case and `test_toggle_legacy_to_spec_cannot_recover_skill_id` pins.

A bridged toggle therefore reaches the manifest with `{intent_name}` and its emitter named only in the context. Resolving payload-only would make every legacy toggle a silent no-op for as long as the mirror window lasts.

The inline expression and `_target_skill_id` already returned the same value for every input, so this is a consistency and observability change, not a behaviour change on either wire form.

## Why the m2v split does not port here

`ovos-m2v-pipeline#150` split its resolver into a spec path that refuses to substitute and a legacy path that keeps the fallback. That works because the two wire forms arrive on two topics with two handlers.

The manifest has one handler and both forms land on it. The mirror sets no provenance marker — receive-side dedup matches payload and context within a window rather than a flag — so nothing in the delivered message distinguishes a bridged legacy toggle from a spec-native toggle whose payload identity is absent. The WARN is what makes the second case visible instead of silently retargeting.

Removing the fallback is a migration-window retirement decision, not an adoption follow-up.

## Verification

- `test_bridged_legacy_toggle_resolves_from_context` fails before this change (no warning emitted) and passes after. It asserts the substituted identity and the clause reference appear in the warning, not merely that a log line exists.
- `test_payload_target_wins_over_a_differing_source` is a **pin, not a regression test** — it passes before and after, and holds the §3.2 rule that a provisioning tool acting on another skill is never retargeted to itself.
- Full unit suite in a clean venv: 618 passed, 39 subtests, no new warning under `-W default`.
