### PR TITLE
test: the canonical fallback poll needs the spec-tools mapping floor

### DIFF
--- a/test/unittests/test_fallback_spelling_floor.py
+++ b/test/unittests/test_fallback_spelling_floor.py
@@ -1,0 +1,68 @@
+"""The fallback poll may only switch to its canonical spelling once the
+declared ovos-spec-tools floor can build the legacy wire twin.
+
+OVOS-FALLBACK-1 §6.1 names the poll pair `ovos.fallback.ping` and
+`ovos.fallback.pong`. Every shipped FallbackSkill subscribes to the legacy
+`ovos.skills.fallback.ping` alone, so once this service emits the canonical
+spelling the only thing that still reaches those skills is the legacy twin that
+ovos-bus-client puts on the wire. That twin is built from the migration map in
+*this* process's ovos-spec-tools, so a floor below the release carrying the
+FALLBACK-1 renames means no twin, no answer, and nothing in the logs.
+"""
+import ast
+import unittest
+from importlib.metadata import requires
+from pathlib import Path
+
+from packaging.requirements import Requirement
+from packaging.version import Version
+
+import ovos_core.intent_services.fallback_service as fallback_service
+
+# The first ovos-spec-tools release whose migration map carries the four
+# OVOS-FALLBACK-1 renames.
+MAP_FLOOR = Version("1.12.0a1")
+
+CANONICAL_POLL = {"ovos.fallback.ping", "ovos.fallback.pong"}
+
+
+def emitted_topics() -> set:
+    """Every string literal in the fallback service that names a bus topic."""
+    tree = ast.parse(Path(fallback_service.__file__).read_text())
+    return {node.value for node in ast.walk(tree)
+            if isinstance(node, ast.Constant) and isinstance(node.value, str)
+            and node.value.startswith("ovos.")}
+
+
+def declared_floor() -> Version:
+    for raw in requires("ovos-core") or []:
+        req = Requirement(raw)
+        if req.name != "ovos-spec-tools":
+            continue
+        floors = [Version(s.version) for s in req.specifier if s.operator == ">="]
+        if floors:
+            return max(floors)
+    raise AssertionError("ovos-core does not declare ovos-spec-tools")
+
+
+class TestFallbackSpellingFloor(unittest.TestCase):
+    def test_canonical_poll_requires_the_mapping_floor(self):
+        canonical = emitted_topics() & CANONICAL_POLL
+        if not canonical:
+            self.skipTest("the fallback poll still uses its legacy spelling")
+        self.assertGreaterEqual(
+            declared_floor(), MAP_FLOOR,
+            f"{sorted(canonical)} is emitted, so the legacy twin has to be "
+            f"built here, which needs ovos-spec-tools>={MAP_FLOOR}")
+
+    def test_the_floor_release_maps_the_poll_pair(self):
+        """MAP_FLOOR is a claim about a published release; hold it to it."""
+        from ovos_spec_tools import migration_counterpart
+        from ovos_spec_tools.version import VERSION_MAJOR, VERSION_MINOR, \
+            VERSION_BUILD, VERSION_ALPHA
+        installed = Version(f"{VERSION_MAJOR}.{VERSION_MINOR}.{VERSION_BUILD}"
+                            + (f"a{VERSION_ALPHA}" if VERSION_ALPHA else ""))
+        if installed < MAP_FLOOR:
+            self.skipTest(f"installed ovos-spec-tools {installed} predates the floor")
+        for topic in ("ovos.skills.fallback.ping", "ovos.skills.fallback.pong"):
+            self.assertIsNotNone(migration_counterpart(topic), topic)


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 5 (claude-opus-5) via Claude Code — NOT human-reviewed. Verify before acting.

A test that fires at whoever switches the fallback poll to its spec spelling
without bumping the floor that makes the switch safe. No production code changes.

## Why

OVOS-FALLBACK-1 §6.1 names the poll pair `ovos.fallback.ping` / `ovos.fallback.pong`.
`fallback_service.py:229` still emits the legacy `ovos.skills.fallback.ping`, and every
shipped FallbackSkill subscribes to that legacy spelling alone.

The day this service emits the canonical spelling, the only thing that still reaches
those skills is the legacy twin that ovos-bus-client puts on the wire. That twin is
built from the migration map in **this process's own** ovos-spec-tools — a consumer's
map has no say in it. The four FALLBACK-1 renames first appear in ovos-spec-tools
`1.12.0a1`; ovos-core declares `>=1.11.1a1`. Below the floor there is no twin, fallback
stops answering, and nothing appears in the logs.

Measured against the published wheels:

| ovos-spec-tools | `migration_counterpart("ovos.skills.fallback.ping")` |
| --- | --- |
| 1.11.2a1 | `None` |
| 1.12.0a1 | `ovos.fallback.ping` |

## What the test does

It parses the bus topics the fallback service emits. While the poll uses its legacy
spelling the first test skips. The moment a canonical poll topic appears in the source,
it asserts the declared `ovos-spec-tools` floor is at or above `1.12.0a1`. A second test
holds that constant to the installed release, so it cannot rot into a number nobody
checks.

## Verification

| Tree | Result |
| --- | --- |
| dev unmodified | 1 skipped, 1 passed |
| line 229 switched to `ovos.fallback.ping`, floor left at 1.11.1a1 | **1 failed**, 1 passed |
| both the switch and the floor bump applied | 2 passed |

The alarm fires only on the unsafe combination, and it is satisfiable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage to verify compatibility between fallback polling topics and the minimum supported specification-tools version.
  * Added validation that the declared compatibility floor supports the corresponding legacy polling topics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->