### PR TITLE
fix: wait for the stop collector to subscribe instead of sleeping

### DIFF
--- a/test/unittests/test_stop_service.py
+++ b/test/unittests/test_stop_service.py
@@ -994,11 +994,13 @@ class TestStopSelectionDeterministic(unittest.TestCase):
         svc = _make_service()
 
         ack_handler = None
+        registered = Event()
 
         def capture_on(event, handler):
             nonlocal ack_handler
             if event == SpecMessage.STOP_PONG.value:
                 ack_handler = handler
+                registered.set()
 
         svc.bus.on = capture_on
         svc.bus.remove = MagicMock()
@@ -1008,8 +1010,6 @@ class TestStopSelectionDeterministic(unittest.TestCase):
         # holder); older_skill is a less-recent active_handlers entry.
         with patch.object(svc, "_stop_candidates",
                           return_value=["holder_skill", "older_skill"]):
-            import threading
-            import time
             result_holder = []
 
             def run():
@@ -1017,7 +1017,8 @@ class TestStopSelectionDeterministic(unittest.TestCase):
 
             t = threading.Thread(target=run)
             t.start()
-            time.sleep(0.05)  # let the thread register the handler
+            self.assertTrue(registered.wait(timeout=5),
+                            "the collector never subscribed to the pong")
 
             # inverted arrival order: the OLDER (less-recent) skill answers
             # FIRST -- this is exactly the race the live auditor reproduced


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 5 (claude-opus-5) via Claude Code — NOT human-reviewed. Verify before acting.

`TestStopSelectionDeterministic` is flaky on loaded runners. It failed the coverage job on
an unrelated test-only branch, which is how it surfaced. Test-only change, four lines.

## Cause

The test starts `_collect_stop_skills` on a thread, then sleeps 0.05 s before firing the
two pongs, with the comment "let the thread register the handler". The sleep stands in for
a synchronization point. When the runner is loaded and the collector has not subscribed
yet, the pongs land before there is anything to receive them and the assertion fails.

## Fix

The capture that records the handler now sets a `threading.Event`, and the test waits on
it with a 5 s bound instead of guessing. The module already imports `threading` and
`Event` at the top, so the local `import threading` / `import time` inside the `with`
block go away with the sleep.

## Verification

The test's own timing dependence is the thing under test here, so it is exercised
directly: `_stop_candidates` is made to take 0.3 s, which pushes the subscription past
the old 0.05 s window.

| Tree | Registration delayed 0.3 s | Undelayed |
| --- | --- | --- |
| before this change | **3/3 failed** | 3/3 passed |
| after this change | 3/3 passed | 3/3 passed |

Full file after the change: 73 passed, three consecutive runs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test synchronization by waiting for the pong listener to register before sending responses.
  * Removed reliance on a fixed delay, making the test more reliable and deterministic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->