### PR TITLE
ci: check the alpha channel strictly and drop the unresolvable rows

### DIFF
--- a/.github/workflows/channel_compat.yml
+++ b/.github/workflows/channel_compat.yml
@@ -1,28 +1,28 @@
 name: Channel Compat
 
 # Run the unit tests against the package versions an OVOS distro release
-# channel pins, instead of against current dev siblings.
-#
-# The distro publishes one constraints file per channel, fetched live by the
-# reusable workflow and uploaded as an artifact. As of writing, `stable` pins
-# ovos-workshop 3.4.x / ovos-bus-client 1.3.x / ovos-padatious 1.4.x and
-# `testing` pins ovos-workshop 7.0.x — both far below dev. A change can be green
-# on dev and still break every device on the fleet; this job is the gate for
-# that.
+# channel pins, instead of against current dev siblings. A change can be green
+# on dev and still break the fleet; this job is the gate for that.
 #
 # This is the third layer of the compat program:
 #
 #   boundary pins  where did the behavior change? (test/backcompat in
 #                  ovos-core and ovos-test-harness)
-#   channels       what does the fleet run today? (this file)
+#   channels       what does the fleet run? (this file)
 #   dev edge       where is the stack going? (build_tests.yml, ovoscope.yml)
 #
-# soft_fail is TRUE for now. A channel is behind dev by construction, so
-# the first runs are expected to fail a pile of tests — that is the finding, not
-# a broken job. TURN soft_fail OFF once the baseline is established, the same
-# way ovos-test-harness did it: check in a per-channel known-gap file, strict-
-# xfail exactly those node ids, and let anything else be red.
-# See https://github.com/OpenVoiceOS/ovos-test-harness (test/channel_gaps/).
+# Only the alpha channel is checked here, and it is strict. A single virtual
+# environment holding this repository plus a channel's pins can only resolve
+# when the channel's pins agree with this repository's own floors, and a
+# released channel caps the very siblings dev already requires. Alpha sits at
+# or ahead of dev, so it resolves, it runs, and it is also the channel the spec
+# lands in.
+#
+# The released channels are covered instead by ovos-test-harness, which
+# installs each channel's stack rather than this repository against a
+# constraints file, and records the known gaps per channel under
+# test/channel_gaps/. That is where a "does stable still work" question is
+# answered. See https://github.com/OpenVoiceOS/ovos-test-harness.
 
 on:
   pull_request:
@@ -40,19 +40,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - channel: stable
-            url: https://raw.githubusercontent.com/OpenVoiceOS/OpenVoiceOS/main/constraints-stable.txt
-          - channel: testing
-            url: https://raw.githubusercontent.com/OpenVoiceOS/OpenVoiceOS/main/constraints-testing.txt
+          - channel: alpha
+            url: https://raw.githubusercontent.com/OpenVoiceOS/OpenVoiceOS/main/constraints-alpha.txt
     name: ${{ matrix.channel }}
     uses: OpenVoiceOS/gh-automations/.github/workflows/channel-compat.yml@dev
     secrets: inherit
     with:
       channel_url: ${{ matrix.url }}
       channel_name: ${{ matrix.channel }}
-      # GitHub rejects `continue-on-error` on a job that calls a reusable
-      # workflow, so the advisory mode is an input instead.
-      soft_fail: true
+      soft_fail: false
       test_path: 'test/unittests'
       system_deps: 'swig libssl-dev portaudio19-dev libpulse-dev libfann-dev'
       install_extras: 'mycroft,plugins,skills-essential,lgpl,test'


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 5 (claude-opus-5) via Claude Code — NOT human-reviewed. Verify before acting.

Channel Compat checks the alpha channel, strictly, and nothing else. CI-only change.

## What the removed rows were for, and where that coverage lives

The `stable` and `testing` rows asked "does a change that is green on dev still work on the
versions the fleet actually runs". That question is real and it still needs answering. It is
answered in **ovos-test-harness**, which installs each channel's own stack rather than this
repository against a constraints file, and records the known gaps per channel in
`test/channel_gaps/` (269 node ids on stable, 184 on testing) so anything outside the
recorded set turns the job red.

**Do not reinstate these rows as "missing compat checks".** They cannot work in this shape,
for a structural reason given below.

## Why they cannot work here

A channel job installs this repository into one virtual environment alongside the channel's
pins. A released channel caps the very siblings dev already requires, so the resolve is
impossible:

```
Because ovos-core==3.5.2a1 depends on ovos-workshop>=9.6.9a1,<10.0.0
and ovos-workshop>=3.4.0,<3.5.0, we can conclude that ovos-core==3.5.2a1
cannot be used.
```

Both rows died there on every run and reported **green**, because `soft_fail` converted the
failure into a pass. They were not weak coverage; they were a green check for a comparison
that never ran, and no known-gap file could help because nothing was ever collected.

The harness avoids this by installing the channel's stack instead of this repository, which
is why the coverage belongs there and not here.

## Why alpha is strict

Alpha sits at or ahead of dev, so it resolves and runs, and it is the channel the spec lands
in. A spec-adoption change that only works against current dev siblings has to fail
somewhere, and this is that place. The alpha constraints pin `ovos-spec-tools>=1.12.0a1`,
the first release whose migration map carries the OVOS-FALLBACK-1 renames, which is exactly
the kind of floor this row exists to hold.

## Verification

The strict alpha row ran green in this repository's own CI. Locally, against
`constraints-alpha.txt` fetched from the same URL with the same extras: 618 passed, 39
subtests, resolving ovos-bus-client 2.11.15a1 and ovos-spec-tools 1.12.0a1.

The matching change for ovos-workshop is in OpenVoiceOS/ovos-workshop#625.
