### PR TITLE
feat: load newly installed plugin skills as soon as the installer reports completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Most classic Mycroft skills also work on OVOS.
 
 When an install or uninstall requested over the bus fails, the `.failed` reply carries the installer's own output in `detail`, so a remote caller can see why without reading the service log. See [docs/skill-installer.md](docs/skill-installer.md).
 
+A completed runtime install through the bus (`ovos.skills.install`) triggers a discovery pass, so an eligible skill loads on that report rather than waiting for the periodic scan; the pass keeps the readiness and connectivity gating the scan applies. `skillmanager.rescan` asks the skill manager for that pass on demand and replies with what it loaded. See [docs/skill-manager.md](docs/skill-manager.md).
+
 ---
 
 ## Persona Support

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -33,6 +33,7 @@ ovos-messagebus  (WebSocket pub/sub)
    c. Query PHAL for network/internet status → load network/internet skills
    d. Emit `mycroft.skills.initialized`
    e. Loop every 30 s: scan for newly installed skills, call watchdog
+      (an installer completion report or `skillmanager.rescan` runs the same scan immediately)
 4. On exit: unload all skills gracefully, shutdown subsystems
 
 ## Subsystem Enable Flags

--- a/docs/bus-events.md
+++ b/docs/bus-events.md
@@ -47,6 +47,8 @@ All events use the OVOS `Message` format: `{type, data, context}`.
 | `skillmanager.activate` | * → core | Activate (load) a skill by ID |
 | `skillmanager.deactivate` | * → core | Deactivate (unload) a skill by ID |
 | `skillmanager.keep` | * → core | Deactivate all skills except one |
+| `skillmanager.rescan` | * → core | Scan for newly installed skills now instead of waiting for the periodic scan |
+| `skillmanager.rescan.response` | core → * | Response to `skillmanager.rescan`: `{loaded: [skill_id, ...]}`, the ids that pass loaded; empty when it loaded nothing |
 | `ovos.skills.settings_changed` | core → * | A skill's `settings.json` file changed |
 
 ## Converse
@@ -70,15 +72,15 @@ All events use the OVOS `Message` format: `{type, data, context}`.
 | Event | Direction | Description |
 |---|---|---|
 | `ovos.skills.install` | * → core | Install skill packages via pip |
-| `ovos.skills.install.complete` | core → * | Install succeeded |
+| `ovos.skills.install.complete` | core → * | Install succeeded; `SkillManager` runs a discovery pass on this report |
 | `ovos.skills.install.failed` | core → * | Install failed: `{error, detail}`, `detail` being the tail of the installer's output |
 | `ovos.skills.uninstall` | * → core | Uninstall skill packages |
 | `ovos.skills.uninstall.complete` | core → * | Uninstall succeeded |
 | `ovos.skills.uninstall.failed` | core → * | Uninstall failed: `{error, detail}` |
 | `ovos.pip.install` | * → core | Install arbitrary pip packages |
-| `ovos.pip.uninstall` | * → core | Uninstall arbitrary pip packages |
-| `ovos.pip.install.complete` | core → * | Install succeeded |
+| `ovos.pip.install.complete` | core → * | Install succeeded; `SkillManager` runs a discovery pass on this report |
 | `ovos.pip.install.failed` | core → * | Install failed: `{error, detail}` |
+| `ovos.pip.uninstall` | * → core | Uninstall arbitrary pip packages |
 | `ovos.pip.uninstall.complete` | core → * | Uninstall succeeded |
 | `ovos.pip.uninstall.failed` | core → * | Uninstall failed: `{error, detail}` |
 

--- a/docs/prerelease-quirks.md
+++ b/docs/prerelease-quirks.md
@@ -22,6 +22,19 @@ ran; `error` is unchanged, so existing consumers keep working. Before this a
 remote caller saw only the `InstallError` string and could not tell "this
 version is not published yet" from "this dependency conflicts".
 
+## #977 (alpha of 2026-09-09)
+
+`SkillManager` subscribes to `ovos.skills.install.complete` and
+`ovos.pip.install.complete` and runs its discovery pass on them, so a skill
+installed through the bus loads when the installer reports completion
+instead of waiting for the next 30 s scan. A new `skillmanager.rescan`
+request runs the same pass on demand and replies with
+`skillmanager.rescan.response` carrying `loaded`, the ids that pass loaded
+(empty when it loaded nothing, whether because discovery turned up nothing
+new or because gating held it back). Both paths keep the scan's connectivity
+gating and do nothing until the manager is ready; the startup load owns
+everything installed before then, and the 30 s scan stays as the backstop.
+
 ## #935 (alpha of 2026-09-06)
 
 The floor on `ovos-bus-client` moves to 2.11.13a1. Core no longer subscribes

--- a/docs/skill-installer.md
+++ b/docs/skill-installer.md
@@ -88,7 +88,7 @@ Every `.failed` reply carries two fields. `error` is the `InstallError` value na
 
 pip's stdout and stderr are always captured as one stream, whichever backend runs; with `print_logs` (the default) each line is also echoed through the service log as it arrives, prefixed `(pip)`. A non-zero exit raises `RuntimeError` carrying the full captured output.
 
-After a successful skill install, `ovos-plugin-manager`'s entry point cache is reloaded so the new skill is discovered on the next `SkillManager` scan cycle (every 30 s).
+After a successful install, `ovos-plugin-manager`'s entry point cache is reloaded before the `.complete` message is sent, and `SkillManager` runs a discovery pass on that message, loading the new skill once it passes the same readiness and connectivity gating the periodic scan applies. The periodic scan (every 30 s) remains the backstop.
 
 ## Error Types
 
@@ -107,7 +107,7 @@ After a successful skill install, `ovos-plugin-manager`'s entry point cache is r
 Default constraints are served from **`ovos-releases`** — the workspace repo that manages stable/testing/alpha constraint channels. See [`ovos-releases`](../../ovos-releases) for the constraints file format. Custom constraints can point to any HTTP URL or local path (`skills.installer.constraints` in `mycroft.conf`).
 
 ### Entry point cache reload
-After a successful install, `ovos_plugin_manager` is reloaded via `importlib.reload(ovos_plugin_manager)` to pick up new entry points. The `SkillManager` scan loop (every 30 s) then discovers and loads the new skill. See [`ovos-plugin-manager/docs/index.md`](../../ovos-plugin-manager/docs/index.md).
+After a successful install, `ovos_plugin_manager` is reloaded via `importlib.reload(ovos_plugin_manager)` to pick up new entry points. `SkillManager` runs a discovery pass on `ovos.skills.install.complete` / `ovos.pip.install.complete` (or on request via `skillmanager.rescan`), and its scan loop (every 30 s) is the backstop. See [`skill-manager.md`](skill-manager.md). See [`ovos-plugin-manager/docs/index.md`](../../ovos-plugin-manager/docs/index.md).
 
 ### `uv` acceleration
 `uv` is a fast pip-compatible installer. It is the default in **raspOVOS**. If `uv` is on `$PATH`, `SkillsStore.UV` is set and `uv pip install` is used instead of `pip`. See the [uv documentation](https://github.com/astral-sh/uv) for setup.

--- a/docs/skill-manager.md
+++ b/docs/skill-manager.md
@@ -52,6 +52,23 @@ mycroft.skills.train  →  (pipeline plugins train)  →  mycroft.skills.trained
 
 Training has a 60-second timeout. On failure, an error is logged but the manager continues.
 
+## Loading After an Install
+
+The periodic scan is not the only way a newly installed skill gets loaded. `SkillsStore` reloads `ovos-plugin-manager` before it reports a completed install, so the manager runs the same discovery pass as soon as it sees that report:
+
+```
+ovos.skills.install.complete  →  _load_new_skills()
+ovos.pip.install.complete     →  _load_new_skills()
+```
+
+A caller that wants to drive this explicitly sends `skillmanager.rescan`; the response names what that pass loaded, so a caller can tell a fresh load from a pass that loaded nothing:
+
+```
+skillmanager.rescan  →  skillmanager.rescan.response  {"loaded": ["skill-id", ...]}
+```
+
+Both paths apply the same connectivity gating as the scan, and both wait until the manager is ready: before the startup load has run, they do nothing and leave the new skill to that load. The 30 s scan remains the backstop.
+
 ## Settings File Watcher
 
 When enabled, a `FileWatcher` monitors `~/.config/ovos/skills/*/settings.json`. Any change emits:
@@ -68,6 +85,9 @@ ovos.skills.settings_changed  {skill_id: "..."}
 | `skillmanager.activate` | `activate_skill` |
 | `skillmanager.deactivate` | `deactivate_skill` |
 | `skillmanager.keep` | `deactivate_except` |
+| `skillmanager.rescan` | `handle_rescan_request` |
+| `ovos.skills.install.complete` | `handle_install_complete` |
+| `ovos.pip.install.complete` | `handle_install_complete` |
 | `mycroft.network.connected` | `handle_network_connected` |
 | `mycroft.internet.connected` | `handle_internet_connected` |
 | `mycroft.gui.available` | `handle_gui_connected` |

--- a/ovos_core/skill_manager.py
+++ b/ovos_core/skill_manager.py
@@ -230,6 +230,13 @@ class SkillManager(Thread):
         self.bus.on('skillmanager.deactivate', self.deactivate_skill)
         self.bus.on('skillmanager.keep', self.deactivate_except)
         self.bus.on('skillmanager.activate', self.activate_skill)
+        self.bus.on('skillmanager.rescan', self.handle_rescan_request)
+
+        # The installer reloads the plugin manager before it reports a
+        # completed install, so a scan issued on that report already sees the
+        # new entry points; without it the package waited for the periodic scan
+        self.bus.on('ovos.skills.install.complete', self.handle_install_complete)
+        self.bus.on('ovos.pip.install.complete', self.handle_install_complete)
 
         # Load skills waiting for connectivity (only if deferred loading is enabled)
         if self._use_deferred_loading:
@@ -397,7 +404,20 @@ class SkillManager(Thread):
         Returns:
             bool: True if new skills were loaded, False otherwise.
         """
-        loaded_new = False
+        return bool(self._load_untracked_plugin_skills(network=network, internet=internet))
+
+    def _load_untracked_plugin_skills(self, network: Optional[bool] = None,
+                                      internet: Optional[bool] = None) -> List[str]:
+        """Load every discoverable plugin skill that is not yet tracked.
+
+        Args:
+            network (bool): Network connection status.
+            internet (bool): Internet connection status.
+
+        Returns:
+            List[str]: Ids of the skills this call loaded, in discovery order.
+        """
+        loaded: List[str] = []
         if network is None:
             network = self._network_event.is_set()
         if internet is None:
@@ -425,8 +445,8 @@ class SkillManager(Thread):
             if not self._reserve_plugin_skill_load(skill_id):
                 continue
             if self._load_plugin_skill(skill_id, plug, reserved=True) is not None:
-                loaded_new = True
-        return loaded_new
+                loaded.append(skill_id)
+        return loaded
 
     def _get_internal_skill_bus(self) -> MessageBusClient:
         """Get a dedicated skill bus connection per skill.
@@ -606,13 +626,16 @@ class SkillManager(Thread):
 
     def _load_new_skills(self, network: Optional[bool] = None,
                           internet: Optional[bool] = None,
-                          gui: Optional[bool] = None) -> None:
+                          gui: Optional[bool] = None) -> List[str]:
         """Handle loading of skills installed since startup.
 
         Args:
             network (bool): Network connection status.
             internet (bool): Internet connection status.
             gui (bool): GUI connection status.
+
+        Returns:
+            List[str]: Ids of the skills this call loaded.
         """
         if self._use_deferred_loading:
             # When deferred loading is enabled, check event flags for gating
@@ -630,9 +653,9 @@ class SkillManager(Thread):
         if gui is None:
             gui = self._gui_event.is_set() or is_gui_connected(self.bus)
 
-        loaded_new = self.load_plugin_skills(network=network, internet=internet)
+        loaded = self._load_untracked_plugin_skills(network=network, internet=internet)
 
-        if loaded_new:
+        if loaded:
             # Pipeline engines consume intent registrations as they arrive;
             # engines with a deferred training step (e.g. padatious) train on
             # this request. It is fire-and-forget: no reply topic is part of
@@ -642,6 +665,47 @@ class SkillManager(Thread):
             # deferred-training engine.
             LOG.debug("Requesting pipeline intent training")
             self.bus.emit(Message("mycroft.skills.train"))
+        return loaded
+
+    def _rescan_plugin_skills(self) -> List[str]:
+        """Run one discovery pass now instead of waiting for the periodic scan.
+
+        Until the manager is ready, ``run()`` owns the first load: it waits
+        for the intent service so no registration is lost, and anything that
+        became discoverable before then is picked up by that load or by the
+        periodic scan that follows it.
+
+        Returns:
+            List[str]: Ids of the skills this pass loaded.
+        """
+        if not self.is_all_loaded():
+            LOG.debug("Skill manager is not ready yet, leaving the new skills to the startup load")
+            return []
+        try:
+            return self._load_new_skills()
+        except Exception:
+            LOG.exception("Failed to load newly installed skills")
+            return []
+
+    def handle_install_complete(self, message: Message) -> None:
+        """Load the plugin skills an installer run just made discoverable.
+
+        Args:
+            message: ``ovos.skills.install.complete`` or ``ovos.pip.install.complete``.
+        """
+        loaded = self._rescan_plugin_skills()
+        if loaded:
+            LOG.info(f"Loaded skills reported by the installer: {loaded}")
+
+    def handle_rescan_request(self, message: Message) -> None:
+        """Scan for newly installed plugin skills and report what was loaded.
+
+        Args:
+            message: ``skillmanager.rescan``; the response carries ``loaded``,
+                the ids this scan loaded, empty when it loaded nothing.
+        """
+        loaded = self._rescan_plugin_skills()
+        self.bus.emit(message.response({"loaded": loaded}))
 
     def _unload_plugin_skill(self, skill_id: str) -> None:
         """Unload a plugin skill.

--- a/test/unittests/test_skill_manager.py
+++ b/test/unittests/test_skill_manager.py
@@ -128,6 +128,9 @@ class TestSkillManager(TestCase):
                     'skillmanager.deactivate',
                     'skillmanager.keep',
                     'skillmanager.activate',
+                    'skillmanager.rescan',
+                    'ovos.skills.install.complete',
+                    'ovos.pip.install.complete',
                     #'mycroft.skills.initialized',
                     'mycroft.skills.is_alive',
                     'mycroft.skills.is_ready',
@@ -601,6 +604,94 @@ class TestSkillManager(TestCase):
                          "load attempts grew linearly with scan cycles - backoff is not applied")
         self.assertGreater(load_attempts, 0, "skill should still be retried eventually")
 
+    def _mark_ready(self):
+        """Put the manager where ``run()`` leaves it once the startup load is done."""
+        self.skill_manager.status.set_ready()
+        gui_patch = patch(self.mock_package + 'is_gui_connected', return_value=False)
+        self.addCleanup(gui_patch.stop)
+        gui_patch.start()
+        self.message_bus_mock.message_types = []
+        self.message_bus_mock.message_data = []
+
+    def _discoverable_plugin(self, skill_id, network_before_load=False):
+        """Register a plugin whose loader reports a clean load."""
+        mock_loader = Mock(spec=SkillLoader)
+        mock_loader.skill_id = skill_id
+        mock_loader.load.return_value = True
+        mock_loader.runtime_requirements.network_before_load = network_before_load
+        mock_loader.runtime_requirements.internet_before_load = False
+        self.skill_manager._get_plugin_skill_loader = Mock(return_value=mock_loader)
+        self.skill_manager.plugin_skills = {}
+        return Mock()
+
+    def test_install_complete_loads_the_new_skill_without_waiting_for_the_scan(self):
+        """A skill the installer just made discoverable is loaded on its
+        completion report, not on the next periodic scan."""
+        for topic in ('ovos.skills.install.complete', 'ovos.pip.install.complete'):
+            with self.subTest(topic=topic):
+                skill_id = 'test.installed.skill'
+                plugin = self._discoverable_plugin(skill_id)
+                self._mark_ready()
+
+                with patch(self.mock_package + 'find_skill_plugins',
+                           return_value={skill_id: plugin}):
+                    self.skill_manager.handle_install_complete(Message(topic))
+
+                self.assertIn(skill_id, self.skill_manager.plugin_skills)
+                self.assertIn('mycroft.skill.loaded', self.message_bus_mock.message_types)
+                self.assertIn('mycroft.skills.train', self.message_bus_mock.message_types)
+
+    def test_install_complete_before_ready_leaves_the_load_to_startup(self):
+        """Before the startup load ran, an install report must not load
+        anything: ``run()`` waits for the intent service first."""
+        self.skill_manager._load_new_skills = Mock()
+
+        self.skill_manager.handle_install_complete(Message('ovos.skills.install.complete'))
+
+        self.skill_manager._load_new_skills.assert_not_called()
+
+    def test_install_complete_keeps_the_connectivity_gating(self):
+        """An install report goes through the same network gate as the scan."""
+        skill_id = 'test.network.skill'
+        plugin = self._discoverable_plugin(skill_id, network_before_load=True)
+        self.skill_manager._use_deferred_loading = True
+        self.skill_manager._network_event.clear()
+        self._mark_ready()
+
+        with patch(self.mock_package + 'find_skill_plugins',
+                   return_value={skill_id: plugin}):
+            self.skill_manager.handle_install_complete(Message('ovos.skills.install.complete'))
+
+        self.assertNotIn(skill_id, self.skill_manager.plugin_skills)
+        self.assertNotIn('mycroft.skill.loaded', self.message_bus_mock.message_types)
+
+    def test_rescan_reports_only_the_skills_that_call_loaded(self):
+        """The rescan response names what this pass loaded, so a caller can
+        tell a fresh load from a scan that found nothing new."""
+        skill_id = 'test.rescanned.skill'
+        plugin = self._discoverable_plugin(skill_id)
+        self._mark_ready()
+
+        with patch(self.mock_package + 'find_skill_plugins',
+                   return_value={skill_id: plugin}):
+            self.skill_manager.handle_rescan_request(Message('skillmanager.rescan'))
+            self.skill_manager.handle_rescan_request(Message('skillmanager.rescan'))
+
+        responses = [data for msg_type, data
+                     in zip(self.message_bus_mock.message_types, self.message_bus_mock.message_data)
+                     if msg_type == 'skillmanager.rescan.response']
+        self.assertListEqual([{'loaded': [skill_id]}, {'loaded': []}], responses)
+
+    def test_rescan_before_ready_reports_nothing_loaded(self):
+        self.skill_manager._load_new_skills = Mock()
+
+        self.skill_manager.handle_rescan_request(Message('skillmanager.rescan'))
+
+        self.skill_manager._load_new_skills.assert_not_called()
+        self.assertIn('skillmanager.rescan.response', self.message_bus_mock.message_types)
+        self.assertDictEqual({'loaded': []}, self.message_bus_mock.message_data[-1])
+
+
 class TestDeferredLoadingConfigFlag(TestCase):
     """Test suite for the optional deferred loading config flag."""
 
@@ -654,6 +745,9 @@ class TestDeferredLoadingConfigFlag(TestCase):
                 'skillmanager.deactivate',
                 'skillmanager.keep',
                 'skillmanager.activate',
+                'skillmanager.rescan',
+                'ovos.skills.install.complete',
+                'ovos.pip.install.complete',
                 'mycroft.skills.is_alive',
                 'mycroft.skills.is_ready',
                 'mycroft.skills.all_loaded',
@@ -685,6 +779,9 @@ class TestDeferredLoadingConfigFlag(TestCase):
             'skillmanager.deactivate',
             'skillmanager.keep',
             'skillmanager.activate',
+            'skillmanager.rescan',
+            'ovos.skills.install.complete',
+            'ovos.pip.install.complete',
             'mycroft.network.connected',
             'mycroft.internet.connected',
             'mycroft.gui.available',

--- a/test/unittests/test_train_request_nonblocking.py
+++ b/test/unittests/test_train_request_nonblocking.py
@@ -29,7 +29,7 @@ class TestTrainRequestNonBlocking(TestCase):
         self.manager._use_deferred_loading = False
         self.manager._gui_event = Event()
         self.manager._gui_event.set()  # skip the is_gui_connected round-trip
-        self.manager.load_plugin_skills = Mock(return_value=True)
+        self.manager._load_untracked_plugin_skills = Mock(return_value=["skill-a"])
 
     def test_train_request_emitted_after_load(self):
         self.manager._load_new_skills(network=True, internet=True, gui=False)
@@ -49,6 +49,6 @@ class TestTrainRequestNonBlocking(TestCase):
         mock_log.exception.assert_not_called()
 
     def test_no_train_request_when_nothing_loaded(self):
-        self.manager.load_plugin_skills = Mock(return_value=False)
+        self.manager._load_untracked_plugin_skills = Mock(return_value=[])
         self.manager._load_new_skills(network=True, internet=True, gui=False)
         self.assertEqual(self.train_requests, [])


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5.1 (claude-fable-5-1) via Claude Code — NOT human-reviewed. Verify before acting.

A skill installed through the bus is only picked up by `SkillManager`'s periodic scan, so an install that completes in ten seconds can sit unloaded for up to thirty more, and an operator driving installs remotely has no way to ask for a load now or to learn whether anything new appeared. `SkillsStore` already reloads `ovos-plugin-manager` before it reports `ovos.skills.install.complete` / `ovos.pip.install.complete`, so the new entry points are visible at that moment.

`SkillManager` now subscribes to both completion topics and runs its discovery pass on them, and handles a new `skillmanager.rescan` request that runs the same pass on demand and replies with `skillmanager.rescan.response` carrying `loaded`, the ids that pass loaded (empty when it loaded nothing, whether because discovery turned up nothing new or because the gating held it back). Both go through `_load_new_skills`, so the existing network/internet gating and the post-load `mycroft.skills.train` request apply unchanged, and both do nothing until the manager is ready: `run()` waits for the intent service before its first load so no registration is lost, and anything installed before then belongs to that load. The 30 s scan stays as the backstop. To report the ids, the loop body of `load_plugin_skills` moved into `_load_untracked_plugin_skills`, which returns the list; `load_plugin_skills` keeps its boolean contract on top of it and `_load_new_skills` returns the list. `test_train_request_nonblocking.py` stubbed `load_plugin_skills` and now stubs the new seam, since that is what `_load_new_skills` reads.

Both handlers run on the bus client's `ExecutorEventEmitter` thread pool, so an install report or a rescan can arrive while the 30 s scan, a connectivity-triggered load, or another report is already inside `_load_new_skills`. That is the situation `_reserve_plugin_skill_load` already exists for: each pass claims a skill id under `_plugin_skills_lock` before loading it and any overlapping pass sees it as tracked and skips it, so a skill is loaded once no matter how many passes overlap, and the only cost of an overlap is a redundant `find_skill_plugins()` call. The ready gate keeps both handlers out of the window before `run()`'s first load.

Five tests in `test/unittests/test_skill_manager.py` cover the install report loading a skill on both topics, the report doing nothing before the manager is ready, the network gate still applying, the rescan response naming what the pass loaded and then coming back empty, and a rescan before ready replying with an empty list. With the tests kept and only the source reverted to `dev`, `test_skill_manager.py` is 9 failed, 27 passed (the five new tests plus the three tests that pin the exact bus-handler list); with the source restored it is 48 passed, 2 subtests. The full `test/unittests` suite is 623 passed, 41 subtests, 2 warnings, both pre-existing `ovos_utils.log` deprecations. mypy's error count on the repo is unchanged and flake8 reports nothing new on the touched files.

`README.md`, `docs/skill-manager.md`, `docs/bus-events.md`, `docs/skill-installer.md`, `docs/architecture.md` and a `docs/prerelease-quirks.md` entry are updated in the same change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Newly installed skills are discovered and loaded immediately after successful skill or package installation.
  - Added on-demand skill rescanning with a response listing skills loaded during the scan.
  - Rescans respect readiness and connectivity checks; periodic scanning remains available as a fallback.

- **Documentation**
  - Updated documentation covering immediate discovery, rescan behavior, related events, and startup handling.

- **Tests**
  - Added coverage for installation events, on-demand rescans, deferred loading, and training behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->