### PR TITLE
fix: unload plugin skills whose package was uninstalled

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Most classic Mycroft skills also work on OVOS.
 
 When an install or uninstall requested over the bus fails, the `.failed` reply carries the installer's own output in `detail`, so a remote caller can see why without reading the service log. See [docs/skill-installer.md](docs/skill-installer.md).
 
+A skill uninstalled at runtime through the bus (`ovos.skills.uninstall`) is unloaded as soon as the installer reports completion, so it stops answering without a restart. See [docs/skill-manager.md](docs/skill-manager.md).
+
 ---
 
 ## Persona Support

--- a/docs/bus-events.md
+++ b/docs/bus-events.md
@@ -73,13 +73,13 @@ All events use the OVOS `Message` format: `{type, data, context}`.
 | `ovos.skills.install.complete` | core → * | Install succeeded |
 | `ovos.skills.install.failed` | core → * | Install failed: `{error, detail}`, `detail` being the tail of the installer's output |
 | `ovos.skills.uninstall` | * → core | Uninstall skill packages |
-| `ovos.skills.uninstall.complete` | core → * | Uninstall succeeded |
+| `ovos.skills.uninstall.complete` | core → * | Uninstall succeeded; `SkillManager` unloads the skills that are no longer discoverable |
 | `ovos.skills.uninstall.failed` | core → * | Uninstall failed: `{error, detail}` |
 | `ovos.pip.install` | * → core | Install arbitrary pip packages |
 | `ovos.pip.uninstall` | * → core | Uninstall arbitrary pip packages |
 | `ovos.pip.install.complete` | core → * | Install succeeded |
 | `ovos.pip.install.failed` | core → * | Install failed: `{error, detail}` |
-| `ovos.pip.uninstall.complete` | core → * | Uninstall succeeded |
+| `ovos.pip.uninstall.complete` | core → * | Uninstall succeeded; `SkillManager` unloads the skills that are no longer discoverable |
 | `ovos.pip.uninstall.failed` | core → * | Uninstall failed: `{error, detail}` |
 
 ## Connectivity / Network

--- a/docs/prerelease-quirks.md
+++ b/docs/prerelease-quirks.md
@@ -22,6 +22,27 @@ ran; `error` is unchanged, so existing consumers keep working. Before this a
 remote caller saw only the `InstallError` string and could not tell "this
 version is not published yet" from "this dependency conflicts".
 
+## #978 (alpha of 2026-09-09)
+
+`SkillManager` subscribes to `ovos.skills.uninstall.complete` and
+`ovos.pip.uninstall.complete`. On either it compares the loaded plugin
+skills with what `find_skill_plugins()` still returns (the installer reloads
+the plugin manager before it reports) and shuts down every skill whose
+package is gone, dropping it from the load-retry bookkeeping so a later
+reinstall loads again. Before this the uninstalled skill stayed loaded, and
+answering, until the next restart; `skillmanager.deactivate` only silences a
+skill. A skill still inside `loader.load()` when the report lands is not tracked
+yet, so the pass records the verdict against its id and the load shuts the
+loader down instead of tracking it; without that, the finished load revived a
+package that was already gone and only the next uninstall removed it again.
+A discovery failure unloads nothing. An empty discovery result is decided by
+what the installed packages still declare in their entry point metadata, read
+without importing: entry points still declared means the packages are there
+and something else is wrong, so everything is kept and a warning is logged;
+none declared is a real removal. Counting loaded skills could not decide this,
+because one distribution may expose several skill entry points and removing it
+can legitimately empty discovery.
+
 ## #935 (alpha of 2026-09-06)
 
 The floor on `ovos-bus-client` moves to 2.11.13a1. Core no longer subscribes

--- a/docs/prerelease-quirks.md
+++ b/docs/prerelease-quirks.md
@@ -48,13 +48,13 @@ skill. A skill still inside `loader.load()` when the report lands is not tracked
 yet, so the pass records the verdict against its id and the load shuts the
 loader down instead of tracking it; without that, the finished load revived a
 package that was already gone and only the next uninstall removed it again.
-A discovery failure unloads nothing. An empty discovery result is decided by
-what the installed packages still declare in their entry point metadata, read
-without importing: entry points still declared means the packages are there
-and something else is wrong, so everything is kept and a warning is logged;
-none declared is a real removal. Counting loaded skills could not decide this,
-because one distribution may expose several skill entry points and removing it
-can legitimately empty discovery.
+A discovery failure unloads nothing. A skill is treated as removed only when
+it is neither importable nor declared in the installed entry point metadata,
+which is read on every pass without importing anything: an import that breaks
+leaves the skill declared, so it keeps its loader instead of being shut down.
+Metadata that cannot be read at all unloads nothing. Counting loaded skills
+could not decide this, because one distribution may expose several skill entry
+points and removing it can legitimately empty discovery.
 
 ## #935 (alpha of 2026-09-06)
 

--- a/docs/skill-installer.md
+++ b/docs/skill-installer.md
@@ -88,7 +88,7 @@ Every `.failed` reply carries two fields. `error` is the `InstallError` value na
 
 pip's stdout and stderr are always captured as one stream, whichever backend runs; with `print_logs` (the default) each line is also echoed through the service log as it arrives, prefixed `(pip)`. A non-zero exit raises `RuntimeError` carrying the full captured output.
 
-After a successful skill install, `ovos-plugin-manager`'s entry point cache is reloaded so the new skill is discovered on the next `SkillManager` scan cycle (every 30 s).
+After a successful skill install, `ovos-plugin-manager`'s entry point cache is reloaded so the new skill is discovered on the next `SkillManager` scan cycle (every 30 s). After a successful uninstall the same reload happens before the `.complete` message, and `SkillManager` unloads the skills that are no longer discoverable on that message.
 
 ## Error Types
 

--- a/docs/skill-installer.md
+++ b/docs/skill-installer.md
@@ -88,7 +88,7 @@ Every `.failed` reply carries two fields. `error` is the `InstallError` value na
 
 pip's stdout and stderr are always captured as one stream, whichever backend runs; with `print_logs` (the default) each line is also echoed through the service log as it arrives, prefixed `(pip)`. A non-zero exit raises `RuntimeError` carrying the full captured output.
 
-After a successful install, `ovos-plugin-manager`'s entry point cache is reloaded before the `.complete` message is sent, and `SkillManager` runs a discovery pass on that message, loading the new skill once it passes the same readiness and connectivity gating the periodic scan applies. The periodic scan (every 30 s) remains the backstop. After a successful uninstall the same reload happens before the `.complete` message, and `SkillManager` unloads the skills that are no longer discoverable on that message.
+After a successful install, `ovos-plugin-manager`'s entry point cache is reloaded before the `.complete` message is sent, and `SkillManager` runs a discovery pass on that message, loading the new skill once it passes the same readiness and connectivity gating the periodic scan applies. The periodic scan (every 30 s) remains the backstop. After a successful uninstall the same reload happens before the `.complete` message. On that message, `SkillManager` unloads the skills that are neither discoverable nor declared in installed entry-point metadata: an import failure leaves a still-installed package undiscoverable, and the metadata is what keeps that from unloading it.
 
 ## Error Types
 

--- a/docs/skill-manager.md
+++ b/docs/skill-manager.md
@@ -52,6 +52,25 @@ mycroft.skills.train  →  (pipeline plugins train)  →  mycroft.skills.trained
 
 Training has a 60-second timeout. On failure, an error is logged but the manager continues.
 
+## Unloading After an Uninstall
+
+`SkillsStore` reloads `ovos-plugin-manager` before it reports a completed uninstall, so `find_skill_plugins()` no longer returns the removed package. On that report the manager compares the loaded plugin skills with what is still discoverable and shuts down every one that is gone:
+
+```
+ovos.skills.uninstall.complete  →  _unload_undiscoverable_plugin_skills()
+ovos.pip.uninstall.complete     →  _unload_undiscoverable_plugin_skills()
+```
+
+The unloaded id is also dropped from the load-retry bookkeeping, so a later reinstall loads again on the next pass. Discovery is not trusted unconditionally: if it raises, nothing is unloaded and no bookkeeping is cleared.
+
+An empty result needs a second question. `find_skill_plugins()` reports what it could *import* and swallows the error when an import fails, so nothing coming back means either every skill package is gone or none of them would import this time. What the installed packages still *declare* separates the two, and it is read from entry point metadata without importing anything. Entry points still declared means the packages are there and something else is wrong, so every skill and its bookkeeping are kept and a warning is logged; none declared is a real removal and the skills are unloaded. Metadata that cannot be read at all is "cannot tell", and nothing is unloaded.
+
+Counting loaded skills cannot answer that question, because one distribution may expose several skill entry points: uninstalling a single package can legitimately empty discovery with several skills loaded.
+
+The removal list and the loader instances behind it are taken under the same lock, and each shutdown runs outside it, so a replacement loaded for one of those ids by an overlapping pass is never the one shut down.
+
+A skill still inside `loader.load()` when the report lands is not tracked yet, so the pass has no loader to detach for it. It records the verdict against that id instead, and the load honours it on the way out: the loader is shut down and never tracked, rather than the finished load reviving a package that is already gone. Such a load is never announced on `mycroft.skill.loaded` either, since it was never available. The verdict is spent on the one load it was recorded against, so a reinstall that reserves the id afresh loads normally. `skillmanager.deactivate` only silences a skill; this is what removes it.
+
 ## Settings File Watcher
 
 When enabled, a `FileWatcher` monitors `~/.config/ovos/skills/*/settings.json`. Any change emits:
@@ -68,6 +87,8 @@ ovos.skills.settings_changed  {skill_id: "..."}
 | `skillmanager.activate` | `activate_skill` |
 | `skillmanager.deactivate` | `deactivate_skill` |
 | `skillmanager.keep` | `deactivate_except` |
+| `ovos.skills.uninstall.complete` | `handle_uninstall_complete` |
+| `ovos.pip.uninstall.complete` | `handle_uninstall_complete` |
 | `mycroft.network.connected` | `handle_network_connected` |
 | `mycroft.internet.connected` | `handle_internet_connected` |
 | `mycroft.gui.available` | `handle_gui_connected` |

--- a/docs/skill-manager.md
+++ b/docs/skill-manager.md
@@ -80,9 +80,11 @@ ovos.pip.uninstall.complete     →  _unload_undiscoverable_plugin_skills()
 
 The unloaded id is also dropped from the load-retry bookkeeping, so a later reinstall loads again on the next pass. Discovery is not trusted unconditionally: if it raises, nothing is unloaded and no bookkeeping is cleared.
 
-An empty result needs a second question. `find_skill_plugins()` reports what it could *import* and swallows the error when an import fails, so nothing coming back means either every skill package is gone or none of them would import this time. What the installed packages still *declare* separates the two, and it is read from entry point metadata without importing anything. Entry points still declared means the packages are there and something else is wrong, so every skill and its bookkeeping are kept and a warning is logged; none declared is a real removal and the skills are unloaded. Metadata that cannot be read at all is "cannot tell", and nothing is unloaded.
+`find_skill_plugins()` reports what it could *import* and swallows the error when an import fails, so a skill whose package is present but whose import broke is missing from the result in exactly the same way as an uninstalled one. What the installed packages still *declare* separates those two, and it is read from entry point metadata without importing anything, so it is read on every pass and the two sets are used together: a skill is gone only when it is neither importable nor declared. Unloading on an import failure would shut a still-installed skill down and discard its loader, and the next pass would load it again.
 
-Counting loaded skills cannot answer that question, because one distribution may expose several skill entry points: uninstalling a single package can legitimately empty discovery with several skills loaded.
+Metadata that cannot be read at all is "cannot tell", and nothing is unloaded. When nothing imports but entry points are still declared, every skill is kept and a warning is logged.
+
+Counting loaded skills cannot answer this, because one distribution may expose several skill entry points: uninstalling a single package can legitimately empty discovery with several skills loaded.
 
 The removal list and the loader instances behind it are taken under the same lock, and each shutdown runs outside it, so a replacement loaded for one of those ids by an overlapping pass is never the one shut down.
 

--- a/ovos_core/skill_manager.py
+++ b/ovos_core/skill_manager.py
@@ -813,30 +813,26 @@ class SkillManager(Thread):
         except Exception:
             LOG.exception("Plugin skill discovery failed, keeping the loaded skills")
             return []
+        # `find_skill_plugins()` reports what it could import and swallows the error
+        # when an import fails, so a skill whose package is present but whose import
+        # broke is missing from `discoverable` exactly like an uninstalled one. Only
+        # the entry points the installed packages declare tell those apart, and that
+        # is read without importing anything, so it is read on every pass rather than
+        # only when nothing imported at all. Unloading on an import failure would shut
+        # a still-installed skill down and discard its loader.
+        declared = self._declared_skill_plugins()
+        if declared is None:
+            LOG.warning("The installed skill entry points could not be read, so a "
+                        "missing plugin skill cannot be told from one that would not "
+                        "import; keeping the loaded skills")
+            return []
+        installed = discoverable | declared
+        if not discoverable and declared:
+            LOG.warning(f"Plugin skill discovery returned nothing while {len(declared)} "
+                        f"skill entry points are still installed; keeping them")
         with self._plugin_skills_lock:
-            # an uninstall of one package cannot make every other package
-            # vanish, so an empty result with several skills loaded is a
-            # discovery hiccup (metadata race, a half-written dist-info during
-            # a concurrent install), not a mass removal; with a single skill
-            # loaded, empty is the legitimate "the last skill was removed"
-            if not discoverable:
-                # nothing imported: either every skill package is gone, or none of them
-                # would import this time (a metadata race, a half-written dist-info during
-                # a concurrent install, a dependency that broke). How many skills are
-                # loaded cannot tell those apart - one distribution can expose several
-                # skill entry points, so removing a single package can legitimately empty
-                # this - but what the installed packages still declare can.
-                declared = self._declared_skill_plugins()
-                if declared is None:
-                    LOG.warning("Plugin skill discovery returned nothing and the installed "
-                                "entry points could not be read; keeping the loaded skills")
-                    return []
-                if declared:
-                    LOG.warning(f"Plugin skill discovery returned nothing while {len(declared)} "
-                                f"skill entry points are still installed; keeping them")
-                    return []
             removed = [skill_id for skill_id in self.plugin_skills
-                       if skill_id not in discoverable]
+                       if skill_id not in installed]
             # detach under the lock that decided the removal, and keep the
             # loader instance rather than the id: once an id stops being
             # tracked an overlapping pass is free to load a replacement for
@@ -847,14 +843,14 @@ class SkillManager(Thread):
             # a failed load leaves a backoff record and no loader; without
             # this a reinstall of that package would wait out the backoff
             stale_failures = [skill_id for skill_id in self._plugin_skill_failures
-                              if skill_id not in discoverable]
+                              if skill_id not in installed]
             # a load in flight holds the reservation and is not in
             # `plugin_skills` yet, so there is nothing to detach for it here.
             # Record the verdict instead: `_load_plugin_skill` discards the
             # loader it is about to track rather than reviving a dead package.
             self._plugin_skill_unload_pending.update(
                 skill_id for skill_id in self._loading_plugin_skills
-                if skill_id not in discoverable)
+                if skill_id not in installed)
         for skill_id, skill_loader in detached:
             LOG.info('Unloading plugin skill: ' + skill_id)
             self._shutdown_skill_loader(skill_loader)

--- a/ovos_core/skill_manager.py
+++ b/ovos_core/skill_manager.py
@@ -16,8 +16,9 @@
 import os
 import threading
 import time
+from importlib.metadata import entry_points
 from threading import Thread, Event
-from typing import Callable, List, Optional
+from typing import Callable, List, Optional, Set
 
 from ovos_bus_client.client import MessageBusClient
 from ovos_bus_client.message import Message
@@ -36,6 +37,7 @@ from ovos_core.intent_services import IntentService
 from ovos_workshop.skills.api import SkillApi
 
 from ovos_plugin_manager.skills import find_skill_plugins
+from ovos_plugin_manager.utils import DEPRECATED_ENTRYPOINTS, PluginTypes
 
 # Backoff schedule for retrying a plugin skill whose load raised before a
 # `PluginSkillLoader` instance existed (eg. an error in the skill's own
@@ -135,6 +137,10 @@ class SkillManager(Thread):
         self.plugin_skills = {}
         self._plugin_skills_lock = threading.RLock()
         self._loading_plugin_skills = set()
+        # ids whose package went undiscoverable while their load held the
+        # reservation. The sweep that noticed had no loader to detach yet, so
+        # it leaves the verdict here for `_load_plugin_skill` to honour.
+        self._plugin_skill_unload_pending = set()
         # skill_id -> (attempt_count, last_attempt_time) for plugin skills whose
         # load raised before a loader object existed (see _load_plugin_skill).
         # These are retried with an exponential backoff instead of every scan.
@@ -231,6 +237,12 @@ class SkillManager(Thread):
         self.bus.on('skillmanager.keep', self.deactivate_except)
         self.bus.on('skillmanager.activate', self.activate_skill)
 
+        # The installer reloads the plugin manager before it reports a
+        # completed uninstall, so discovery no longer returns the removed
+        # package; drop the loaded skills that went with it
+        self.bus.on('ovos.skills.uninstall.complete', self.handle_uninstall_complete)
+        self.bus.on('ovos.pip.uninstall.complete', self.handle_uninstall_complete)
+
         # Load skills waiting for connectivity (only if deferred loading is enabled)
         if self._use_deferred_loading:
             self.bus.on("mycroft.network.connected", self.handle_network_connected)
@@ -261,6 +273,10 @@ class SkillManager(Thread):
             if skill_id in self.plugin_skills or skill_id in self._loading_plugin_skills:
                 return False
             self._loading_plugin_skills.add(skill_id)
+            # a verdict can only speak for the reservation it was recorded
+            # against; clearing here keeps an older one from discarding this
+            # attempt, which starts from a package that is discoverable again
+            self._plugin_skill_unload_pending.discard(skill_id)
             return True
 
     def _release_plugin_skill_load(self, skill_id):
@@ -484,17 +500,34 @@ class SkillManager(Thread):
         try:
             skill_loader = self._get_plugin_skill_loader(skill_id, skill_class=skill_plugin)
             load_status = skill_loader.load(skill_plugin)
-            if load_status:
-                self.bus.emit(Message("mycroft.skill.loaded", {"skill_id": skill_id}))
         except Exception:
             LOG.exception(f'Load of skill {skill_id} failed!')
             load_status = False
         finally:
-            if skill_loader is not None:
-                with self._plugin_skills_lock:
+            with self._plugin_skills_lock:
+                # read the verdict and drop the reservation in one step, so a
+                # sweep either lands before this (and is honoured here) or
+                # after (and detaches the loader itself)
+                abandoned = skill_id in self._plugin_skill_unload_pending
+                self._plugin_skill_unload_pending.discard(skill_id)
+                if skill_loader is not None and not abandoned:
                     self.plugin_skills[skill_id] = skill_loader
+                self._loading_plugin_skills.discard(skill_id)
+            if abandoned:
+                # the package is gone, so this is not a failure to back off
+                # from: a reinstall should load on the next scan
+                self._clear_plugin_skill_failure(skill_id)
+                self._logged_skill_warnings.discard(skill_id)
+                LOG.info(f"Discarding {skill_id}: its package was uninstalled "
+                         f"while the skill was loading")
+                self._shutdown_skill_loader(skill_loader)
+            elif skill_loader is not None:
                 if load_status:
                     self._clear_plugin_skill_failure(skill_id)
+                    # announced once the loader is tracked, and never for a load the
+                    # uninstall abandoned: a consumer acting on this finds the skill
+                    # present, and is not told about one that was just shut down
+                    self.bus.emit(Message("mycroft.skill.loaded", {"skill_id": skill_id}))
             else:
                 # `_get_plugin_skill_loader`/`.load()` raised before a loader
                 # object existed - there is nothing to track in
@@ -502,8 +535,9 @@ class SkillManager(Thread):
                 # this skill would look "never attempted" and get retried
                 # (and its intents re-registered) on every 30s scan forever.
                 self._record_plugin_skill_failure(skill_id)
-            self._release_plugin_skill_load(skill_id)
 
+        if abandoned:
+            return None
         return skill_loader if load_status else None
 
     def wait_for_intent_service(self) -> None:
@@ -657,16 +691,123 @@ class SkillManager(Thread):
                 LOG.info('Unloading plugin skill: ' + skill_id)
                 skill_loader = self.plugin_skills.pop(skill_id)
 
-        # Call shutdown methods outside the lock to prevent deadlocks
-        if skill_loader is not None and skill_loader.instance is not None:
-            try:
-                skill_loader.instance.shutdown()
-            except Exception:
-                LOG.exception('Failed to run skill specific shutdown code: ' + skill_loader.skill_id)
-            try:
-                skill_loader.instance.default_shutdown()
-            except Exception:
-                LOG.exception('Failed to shutdown skill: ' + skill_loader.skill_id)
+        self._shutdown_skill_loader(skill_loader)
+
+    def _shutdown_skill_loader(self, skill_loader: Optional[PluginSkillLoader]) -> None:
+        """Run the shutdown hooks of a loader already detached from tracking.
+
+        The caller holds no lock here: skill shutdown code may re-enter
+        ``_plugin_skills_lock`` and running it under that lock deadlocks.
+
+        Args:
+            skill_loader: The detached loader, or None when nothing was detached.
+        """
+        if skill_loader is None or skill_loader.instance is None:
+            return
+        try:
+            skill_loader.instance.shutdown()
+        except Exception:
+            LOG.exception('Failed to run skill specific shutdown code: ' + skill_loader.skill_id)
+        try:
+            skill_loader.instance.default_shutdown()
+        except Exception:
+            LOG.exception('Failed to shutdown skill: ' + skill_loader.skill_id)
+
+    @staticmethod
+    def _declared_skill_plugins() -> Optional[Set[str]]:
+        """The skill entry points installed packages declare, without importing any of them.
+
+        `find_skill_plugins()` reports what it could import and swallows the error when an
+        import fails, so an empty result means either "every skill package is gone" or
+        "nothing would import this time". Only package metadata separates those two, and
+        they call for opposite answers.
+
+        Returns:
+            The declared entry point names, or None when the metadata could not be read -
+            which is "cannot tell", not "nothing is installed".
+        """
+        try:
+            groups = [PluginTypes.SKILL.value]
+            groups += [old for old, new in DEPRECATED_ENTRYPOINTS.items()
+                       if new == PluginTypes.SKILL.value]
+            declared = set()
+            for group in groups:
+                declared.update(point.name for point in entry_points(group=group))
+            return declared
+        except Exception:
+            LOG.exception("Could not read the declared skill entry points")
+            return None
+
+    def _unload_undiscoverable_plugin_skills(self) -> List[str]:
+        """Unload the tracked plugin skills whose package is no longer discoverable.
+
+        Returns:
+            List[str]: Ids of the skills this call unloaded.
+        """
+        try:
+            discoverable = set(find_skill_plugins())
+        except Exception:
+            LOG.exception("Plugin skill discovery failed, keeping the loaded skills")
+            return []
+        with self._plugin_skills_lock:
+            # an uninstall of one package cannot make every other package
+            # vanish, so an empty result with several skills loaded is a
+            # discovery hiccup (metadata race, a half-written dist-info during
+            # a concurrent install), not a mass removal; with a single skill
+            # loaded, empty is the legitimate "the last skill was removed"
+            if not discoverable:
+                # nothing imported: either every skill package is gone, or none of them
+                # would import this time (a metadata race, a half-written dist-info during
+                # a concurrent install, a dependency that broke). How many skills are
+                # loaded cannot tell those apart - one distribution can expose several
+                # skill entry points, so removing a single package can legitimately empty
+                # this - but what the installed packages still declare can.
+                declared = self._declared_skill_plugins()
+                if declared is None:
+                    LOG.warning("Plugin skill discovery returned nothing and the installed "
+                                "entry points could not be read; keeping the loaded skills")
+                    return []
+                if declared:
+                    LOG.warning(f"Plugin skill discovery returned nothing while {len(declared)} "
+                                f"skill entry points are still installed; keeping them")
+                    return []
+            removed = [skill_id for skill_id in self.plugin_skills
+                       if skill_id not in discoverable]
+            # detach under the lock that decided the removal, and keep the
+            # loader instance rather than the id: once an id stops being
+            # tracked an overlapping pass is free to load a replacement for
+            # it, and a detach that named only the id would pop and shut down
+            # that replacement instead of the loader this pass chose
+            detached = [(skill_id, self.plugin_skills.pop(skill_id))
+                        for skill_id in removed]
+            # a failed load leaves a backoff record and no loader; without
+            # this a reinstall of that package would wait out the backoff
+            stale_failures = [skill_id for skill_id in self._plugin_skill_failures
+                              if skill_id not in discoverable]
+            # a load in flight holds the reservation and is not in
+            # `plugin_skills` yet, so there is nothing to detach for it here.
+            # Record the verdict instead: `_load_plugin_skill` discards the
+            # loader it is about to track rather than reviving a dead package.
+            self._plugin_skill_unload_pending.update(
+                skill_id for skill_id in self._loading_plugin_skills
+                if skill_id not in discoverable)
+        for skill_id, skill_loader in detached:
+            LOG.info('Unloading plugin skill: ' + skill_id)
+            self._shutdown_skill_loader(skill_loader)
+        for skill_id in set(removed) | set(stale_failures):
+            self._clear_plugin_skill_failure(skill_id)
+            self._logged_skill_warnings.discard(skill_id)
+        return removed
+
+    def handle_uninstall_complete(self, message: Message) -> None:
+        """Unload the plugin skills an installer run just removed.
+
+        Args:
+            message: ``ovos.skills.uninstall.complete`` or ``ovos.pip.uninstall.complete``.
+        """
+        removed = self._unload_undiscoverable_plugin_skills()
+        if removed:
+            LOG.info(f"Unloaded skills removed by the installer: {removed}")
 
     def is_alive(self, message: Optional[Message] = None) -> bool:
         """Respond to is_alive status request."""

--- a/ovos_core/skill_manager.py
+++ b/ovos_core/skill_manager.py
@@ -18,7 +18,7 @@ import threading
 import time
 from importlib.metadata import entry_points
 from threading import Thread, Event
-from typing import Callable, List, Optional, Set
+from typing import Callable, Dict, List, Optional, Set
 
 from ovos_bus_client.client import MessageBusClient
 from ovos_bus_client.message import Message
@@ -137,6 +137,11 @@ class SkillManager(Thread):
         self.plugin_skills = {}
         self._plugin_skills_lock = threading.RLock()
         self._loading_plugin_skills = set()
+        # the serial of the attempt behind each tracked loader or reserved load,
+        # so that a pass judging a snapshot can tell the attempt it read from a
+        # later one under the same id
+        self._plugin_skill_serials: Dict[str, int] = {}
+        self._plugin_skill_last_serial = 0
         # ids whose package went undiscoverable while their load held the
         # reservation. The sweep that noticed had no loader to detach yet, so
         # it leaves the verdict here for `_load_plugin_skill` to honour.
@@ -280,6 +285,8 @@ class SkillManager(Thread):
             if skill_id in self.plugin_skills or skill_id in self._loading_plugin_skills:
                 return False
             self._loading_plugin_skills.add(skill_id)
+            self._plugin_skill_last_serial += 1
+            self._plugin_skill_serials[skill_id] = self._plugin_skill_last_serial
             # a verdict can only speak for the reservation it was recorded
             # against; clearing here keeps an older one from discarding this
             # attempt, which starts from a package that is discoverable again
@@ -290,6 +297,7 @@ class SkillManager(Thread):
         """Clear the in-progress marker for a skill load attempt."""
         with self._plugin_skills_lock:
             self._loading_plugin_skills.discard(skill_id)
+            self._plugin_skill_serials.pop(skill_id, None)
 
     def _should_retry_plugin_skill(self, skill_id: str) -> bool:
         """Check whether enough time has passed to retry a previously failed load."""
@@ -531,7 +539,10 @@ class SkillManager(Thread):
                 abandoned = skill_id in self._plugin_skill_unload_pending
                 self._plugin_skill_unload_pending.discard(skill_id)
                 if skill_loader is not None and not abandoned:
+                    # the loader keeps the attempt's serial while it is tracked
                     self.plugin_skills[skill_id] = skill_loader
+                else:
+                    self._plugin_skill_serials.pop(skill_id, None)
                 self._loading_plugin_skills.discard(skill_id)
             if abandoned:
                 # the package is gone, so this is not a failure to back off
@@ -754,6 +765,7 @@ class SkillManager(Thread):
             if skill_id in self.plugin_skills:
                 LOG.info('Unloading plugin skill: ' + skill_id)
                 skill_loader = self.plugin_skills.pop(skill_id)
+                self._plugin_skill_serials.pop(skill_id, None)
 
         self._shutdown_skill_loader(skill_loader)
 
@@ -808,6 +820,14 @@ class SkillManager(Thread):
         Returns:
             List[str]: Ids of the skills this call unloaded.
         """
+        # What this pass judges is read before the packages are. A loader
+        # tracked or a load reserved after this point started from a package
+        # installed after the reading below, so it is not this pass's to
+        # remove, however stale that reading is by the time the verdicts
+        # land; each attempt's serial tells it from the one read here.
+        with self._plugin_skills_lock:
+            judged = {skill_id: self._plugin_skill_serials.get(skill_id)
+                      for skill_id in set(self.plugin_skills) | self._loading_plugin_skills}
         try:
             discoverable = set(find_skill_plugins())
         except Exception:
@@ -831,8 +851,10 @@ class SkillManager(Thread):
             LOG.warning(f"Plugin skill discovery returned nothing while {len(declared)} "
                         f"skill entry points are still installed; keeping them")
         with self._plugin_skills_lock:
-            removed = [skill_id for skill_id in self.plugin_skills
-                       if skill_id not in installed]
+            gone = [skill_id for skill_id, serial in judged.items()
+                    if skill_id not in installed
+                    and self._plugin_skill_serials.get(skill_id) == serial]
+            removed = [skill_id for skill_id in gone if skill_id in self.plugin_skills]
             # detach under the lock that decided the removal, and keep the
             # loader instance rather than the id: once an id stops being
             # tracked an overlapping pass is free to load a replacement for
@@ -840,6 +862,8 @@ class SkillManager(Thread):
             # that replacement instead of the loader this pass chose
             detached = [(skill_id, self.plugin_skills.pop(skill_id))
                         for skill_id in removed]
+            for skill_id in removed:
+                self._plugin_skill_serials.pop(skill_id, None)
             # a failed load leaves a backoff record and no loader; without
             # this a reinstall of that package would wait out the backoff
             stale_failures = [skill_id for skill_id in self._plugin_skill_failures
@@ -848,9 +872,12 @@ class SkillManager(Thread):
             # `plugin_skills` yet, so there is nothing to detach for it here.
             # Record the verdict instead: `_load_plugin_skill` discards the
             # loader it is about to track rather than reviving a dead package.
+            # Only the reservation read above gets it: one made since belongs
+            # to a reinstall, and `_reserve_plugin_skill_load` already cleared
+            # whatever an older pass had left for that id.
             self._plugin_skill_unload_pending.update(
-                skill_id for skill_id in self._loading_plugin_skills
-                if skill_id not in installed)
+                skill_id for skill_id in gone
+                if skill_id in self._loading_plugin_skills)
         for skill_id, skill_loader in detached:
             LOG.info('Unloading plugin skill: ' + skill_id)
             self._shutdown_skill_loader(skill_loader)

--- a/test/unittests/test_skill_manager.py
+++ b/test/unittests/test_skill_manager.py
@@ -112,6 +112,15 @@ class TestSkillManager(TestCase):
             str(self.skill_dir): self.skill_loader_mock
         }
 
+    def _warnings_mentioning(self, text):
+        """The warnings logged that say `text`. Counted by content, not in
+        total: `SkillManager.__init__` warns when no skill package is
+        installed at all, so the total depends on the environment the tests
+        run in -- a bare venv logs one more than CI, which installs
+        skills-essential."""
+        return [call.args[0] for call in self.log_mock.warning.call_args_list
+                if text in call.args[0]]
+
     def test_instantiate(self):
         # With default config (deferred_loading: false), connectivity handlers are NOT registered
         # Ensure deferred_loading is explicitly False to isolate from other tests
@@ -782,8 +791,7 @@ class TestSkillManager(TestCase):
             loader.instance.default_shutdown.assert_not_called()
         self.assertDictEqual({}, self.skill_manager._plugin_skill_failures)
         self.assertSetEqual({'test.first.skill'}, self.skill_manager._logged_skill_warnings)
-        self.log_mock.warning.assert_called_once()
-        self.assertIn('keeping them', self.log_mock.warning.call_args[0][0])
+        self.assertEqual(1, len(self._warnings_mentioning('keeping them')))
 
     def test_uninstall_complete_unloads_the_last_skill_on_empty_discovery(self):
         """With exactly one skill loaded, an empty discovery is the legitimate
@@ -797,7 +805,7 @@ class TestSkillManager(TestCase):
         self.assertDictEqual({}, self.skill_manager.plugin_skills)
         loader.instance.shutdown.assert_called_once_with()
         loader.instance.default_shutdown.assert_called_once_with()
-        self.log_mock.warning.assert_not_called()
+        self.assertEqual([], self._warnings_mentioning('keeping'))
 
     def test_uninstall_complete_shuts_down_only_the_loader_it_detached(self):
         """A pass detaches the loader instances it decided to remove, so a
@@ -915,8 +923,7 @@ class TestSkillManager(TestCase):
 
         self.assertSetEqual(set(), self.skill_manager._plugin_skill_unload_pending)
         self.assertIn('test.kept.skill', self.skill_manager.plugin_skills)
-        self.log_mock.warning.assert_called_once()
-        self.assertIn('keeping them', self.log_mock.warning.call_args[0][0])
+        self.assertEqual(1, len(self._warnings_mentioning('keeping them')))
 
     def test_a_skill_that_would_not_import_is_not_treated_as_removed(self):
         """A partial discovery result must not unload a still-installed skill.

--- a/test/unittests/test_skill_manager.py
+++ b/test/unittests/test_skill_manager.py
@@ -761,8 +761,12 @@ class TestSkillManager(TestCase):
         mock_loader.load.assert_called_once()
 
     def test_uninstall_complete_keeps_everything_when_discovery_returns_nothing(self):
-        """An empty discovery result with several skills loaded is a hiccup,
-        not a mass removal: warn, keep every skill, clear no bookkeeping."""
+        """An empty discovery result is a hiccup when the entry points are still
+        declared: warn and keep every loaded skill.
+
+        The backoff record for `test.third.skill` is a separate matter. It is not
+        declared, so that package really is gone, and leaving its record behind
+        would make a reinstall wait out a backoff it no longer owes."""
         self.skill_manager.plugin_skills = {}
         loaders = [self._tracked_loader('test.first.skill'), self._tracked_loader('test.second.skill')]
         self.skill_manager._plugin_skill_failures = {'test.third.skill': (2, 0.0)}
@@ -776,7 +780,7 @@ class TestSkillManager(TestCase):
         for loader in loaders:
             loader.instance.shutdown.assert_not_called()
             loader.instance.default_shutdown.assert_not_called()
-        self.assertDictEqual({'test.third.skill': (2, 0.0)}, self.skill_manager._plugin_skill_failures)
+        self.assertDictEqual({}, self.skill_manager._plugin_skill_failures)
         self.assertSetEqual({'test.first.skill'}, self.skill_manager._logged_skill_warnings)
         self.log_mock.warning.assert_called_once()
         self.assertIn('keeping them', self.log_mock.warning.call_args[0][0])
@@ -913,6 +917,57 @@ class TestSkillManager(TestCase):
         self.assertIn('test.kept.skill', self.skill_manager.plugin_skills)
         self.log_mock.warning.assert_called_once()
         self.assertIn('keeping them', self.log_mock.warning.call_args[0][0])
+
+    def test_a_skill_that_would_not_import_is_not_treated_as_removed(self):
+        """A partial discovery result must not unload a still-installed skill.
+
+        `find_skill_plugins()` swallows the error when one entry point fails to
+        import, so that skill is missing from the result exactly like an uninstalled
+        one. Its entry point is still declared, and that is what separates the two:
+        it stays tracked, keeps its loader, keeps its retry record, and a load in
+        flight for it is not marked for discard.
+        """
+        self.skill_manager.plugin_skills = {}
+        good = self._tracked_loader('test.imports.skill')
+        broken = self._tracked_loader('test.broken.skill')
+        self.skill_manager._plugin_skill_failures = {'test.broken.skill': (1, 0.0)}
+        self.skill_manager._loading_plugin_skills = {'test.inflight.skill'}
+        self.skill_manager._plugin_skill_unload_pending = set()
+
+        # Only the healthy one imports; all three are still declared.
+        with patch(self.mock_package + 'find_skill_plugins',
+                   return_value={'test.imports.skill': object()}), \
+                self._declared('test.imports.skill', 'test.broken.skill',
+                               'test.inflight.skill'):
+            removed = self.skill_manager._unload_undiscoverable_plugin_skills()
+
+        self.assertEqual([], removed)
+        self.assertIn('test.broken.skill', self.skill_manager.plugin_skills)
+        broken.instance.shutdown.assert_not_called()
+        good.instance.shutdown.assert_not_called()
+        self.assertIn('test.broken.skill', self.skill_manager._plugin_skill_failures)
+        self.assertSetEqual(set(), self.skill_manager._plugin_skill_unload_pending)
+
+    def test_a_skill_that_is_neither_importable_nor_declared_is_removed(self):
+        """The counterpart: gone from both is a real uninstall, even alongside a
+        healthy skill, so a partial result still removes what actually went away."""
+        self.skill_manager.plugin_skills = {}
+        self._tracked_loader('test.imports.skill')
+        gone = self._tracked_loader('test.gone.skill')
+        self.skill_manager._plugin_skill_failures = {'test.gone.skill': (1, 0.0)}
+        self.skill_manager._loading_plugin_skills = {'test.gone.inflight'}
+        self.skill_manager._plugin_skill_unload_pending = set()
+
+        with patch(self.mock_package + 'find_skill_plugins',
+                   return_value={'test.imports.skill': object()}), \
+                self._declared('test.imports.skill'):
+            removed = self.skill_manager._unload_undiscoverable_plugin_skills()
+
+        self.assertEqual(['test.gone.skill'], removed)
+        gone.instance.shutdown.assert_called_once_with()
+        self.assertNotIn('test.gone.skill', self.skill_manager._plugin_skill_failures)
+        self.assertSetEqual({'test.gone.inflight'},
+                            self.skill_manager._plugin_skill_unload_pending)
 
     def test_one_package_can_own_every_loaded_skill(self):
         """A distribution may expose several skill entry points, so uninstalling one

--- a/test/unittests/test_skill_manager.py
+++ b/test/unittests/test_skill_manager.py
@@ -128,6 +128,8 @@ class TestSkillManager(TestCase):
                     'skillmanager.deactivate',
                     'skillmanager.keep',
                     'skillmanager.activate',
+                    'ovos.skills.uninstall.complete',
+                    'ovos.pip.uninstall.complete',
                     #'mycroft.skills.initialized',
                     'mycroft.skills.is_alive',
                     'mycroft.skills.is_ready',
@@ -601,6 +603,314 @@ class TestSkillManager(TestCase):
                          "load attempts grew linearly with scan cycles - backoff is not applied")
         self.assertGreater(load_attempts, 0, "skill should still be retried eventually")
 
+    def _declared(self, *names):
+        """Patch what installed packages declare, separately from what imports.
+
+        `find_skill_plugins()` answers "what imported"; the entry point metadata answers
+        "what is installed". Only together do they say whether an empty discovery result
+        is a removal or a hiccup, so a test that stubs one states the other too.
+        """
+        return patch.object(self.skill_manager, '_declared_skill_plugins',
+                            return_value=set(names))
+
+    def _tracked_loader(self, skill_id):
+        """A loaded plugin skill as `_load_plugin_skill` leaves it in `plugin_skills`."""
+        loader = Mock(spec=SkillLoader)
+        loader.skill_id = skill_id
+        loader.instance = Mock()
+        self.skill_manager.plugin_skills[skill_id] = loader
+        return loader
+
+    def test_uninstall_complete_unloads_the_skill_whose_package_is_gone(self):
+        """A loaded skill whose package the installer removed is shut down on
+        the completion report; the ones still discoverable are untouched."""
+        for topic in ('ovos.skills.uninstall.complete', 'ovos.pip.uninstall.complete'):
+            with self.subTest(topic=topic):
+                self.skill_manager.plugin_skills = {}
+                gone = self._tracked_loader('test.gone.skill')
+                kept = self._tracked_loader('test.kept.skill')
+                self.skill_manager._plugin_skill_failures = {'test.gone.skill': (2, 0.0)}
+
+                with patch(self.mock_package + 'find_skill_plugins',
+                           return_value={'test.kept.skill': Mock()}):
+                    self.skill_manager.handle_uninstall_complete(Message(topic))
+
+                self.assertNotIn('test.gone.skill', self.skill_manager.plugin_skills)
+                self.assertIn('test.kept.skill', self.skill_manager.plugin_skills)
+                gone.instance.shutdown.assert_called_once_with()
+                gone.instance.default_shutdown.assert_called_once_with()
+                kept.instance.shutdown.assert_not_called()
+                kept.instance.default_shutdown.assert_not_called()
+                self.assertNotIn('test.gone.skill', self.skill_manager._plugin_skill_failures)
+
+    def test_uninstall_complete_lets_a_reinstall_load_again(self):
+        """After the package is removed and reinstalled, the next pass loads it
+        again instead of treating it as tracked or waiting out a backoff."""
+        skill_id = 'test.reinstalled.skill'
+        self.skill_manager.plugin_skills = {}
+        self._tracked_loader(skill_id)
+        # the shape a load that raised before a loader existed leaves behind:
+        # no loader, a backoff record that would hold a fresh attempt for a while
+        self.skill_manager._plugin_skill_failures = {skill_id: (6, time_module.time())}
+
+        with patch(self.mock_package + 'find_skill_plugins', return_value={}), self._declared():
+            self.skill_manager.handle_uninstall_complete(Message('ovos.skills.uninstall.complete'))
+
+        self.assertDictEqual({}, self.skill_manager.plugin_skills)
+        self.assertDictEqual({}, self.skill_manager._plugin_skill_failures)
+
+        mock_loader = Mock(spec=SkillLoader)
+        mock_loader.skill_id = skill_id
+        mock_loader.load.return_value = True
+        mock_loader.runtime_requirements.network_before_load = False
+        mock_loader.runtime_requirements.internet_before_load = False
+        self.skill_manager._get_plugin_skill_loader = Mock(return_value=mock_loader)
+        with patch(self.mock_package + 'find_skill_plugins', return_value={skill_id: Mock()}):
+            self.skill_manager._load_new_skills(network=True, internet=True, gui=False)
+
+        self.assertIn(skill_id, self.skill_manager.plugin_skills)
+        mock_loader.load.assert_called_once()
+
+    def test_uninstall_complete_keeps_everything_when_discovery_returns_nothing(self):
+        """An empty discovery result with several skills loaded is a hiccup,
+        not a mass removal: warn, keep every skill, clear no bookkeeping."""
+        self.skill_manager.plugin_skills = {}
+        loaders = [self._tracked_loader('test.first.skill'), self._tracked_loader('test.second.skill')]
+        self.skill_manager._plugin_skill_failures = {'test.third.skill': (2, 0.0)}
+        self.skill_manager._logged_skill_warnings = {'test.first.skill'}
+
+        with patch(self.mock_package + 'find_skill_plugins', return_value={}), \
+                self._declared('test.first.skill', 'test.second.skill'):
+            self.skill_manager.handle_uninstall_complete(Message('ovos.skills.uninstall.complete'))
+
+        self.assertCountEqual(['test.first.skill', 'test.second.skill'], self.skill_manager.plugin_skills)
+        for loader in loaders:
+            loader.instance.shutdown.assert_not_called()
+            loader.instance.default_shutdown.assert_not_called()
+        self.assertDictEqual({'test.third.skill': (2, 0.0)}, self.skill_manager._plugin_skill_failures)
+        self.assertSetEqual({'test.first.skill'}, self.skill_manager._logged_skill_warnings)
+        self.log_mock.warning.assert_called_once()
+        self.assertIn('keeping them', self.log_mock.warning.call_args[0][0])
+
+    def test_uninstall_complete_unloads_the_last_skill_on_empty_discovery(self):
+        """With exactly one skill loaded, an empty discovery is the legitimate
+        removal of the last skill and it is unloaded."""
+        self.skill_manager.plugin_skills = {}
+        loader = self._tracked_loader('test.last.skill')
+
+        with patch(self.mock_package + 'find_skill_plugins', return_value={}), self._declared():
+            self.skill_manager.handle_uninstall_complete(Message('ovos.skills.uninstall.complete'))
+
+        self.assertDictEqual({}, self.skill_manager.plugin_skills)
+        loader.instance.shutdown.assert_called_once_with()
+        loader.instance.default_shutdown.assert_called_once_with()
+        self.log_mock.warning.assert_not_called()
+
+    def test_uninstall_complete_shuts_down_only_the_loader_it_detached(self):
+        """A pass detaches the loader instances it decided to remove, so a
+        replacement loaded for one of those ids in the meantime survives.
+
+        Two overlapping completion reports can both see the same untracked-yet
+        id in their removal list. The moment the first detaches it, a scan or
+        an install report is free to load a replacement under that id; the
+        second pass must not shut that replacement down."""
+        self.skill_manager.plugin_skills = {}
+        first = self._tracked_loader('test.first.skill')
+        self._tracked_loader('test.second.skill')
+        self._tracked_loader('test.kept.skill')
+
+        replacement = Mock(spec=SkillLoader)
+        replacement.skill_id = 'test.second.skill'
+        replacement.instance = Mock()
+
+        def reload_second():
+            # the interleaved load: legitimate, because the id is untracked
+            self.skill_manager.plugin_skills['test.second.skill'] = replacement
+
+        first.instance.shutdown.side_effect = reload_second
+
+        with patch(self.mock_package + 'find_skill_plugins',
+                   return_value={'test.kept.skill': Mock()}):
+            self.skill_manager._unload_undiscoverable_plugin_skills()
+
+        self.assertIs(replacement, self.skill_manager.plugin_skills.get('test.second.skill'))
+        replacement.instance.shutdown.assert_not_called()
+        replacement.instance.default_shutdown.assert_not_called()
+
+    def test_uninstall_during_load_discards_the_skill_that_was_loading(self):
+        """A load in flight when the uninstall lands must not revive the package.
+
+        The loading skill holds the reservation and is not in `plugin_skills`
+        yet, so the completion pass finds nothing to detach for it. Without a
+        verdict left behind, the load finishes and tracks a skill whose package
+        is gone - and since only an uninstall report unloads, nothing removes
+        it again."""
+        skill_id = 'test.loading.skill'
+        self.skill_manager.plugin_skills = {}
+        blocked = Event()
+        loading = Event()
+
+        mock_loader = Mock(spec=SkillLoader)
+        mock_loader.skill_id = skill_id
+        mock_loader.instance = Mock()
+
+        def block_until_released(_):
+            loading.set()
+            blocked.wait(timeout=10)
+            return True
+
+        mock_loader.load.side_effect = block_until_released
+        self.skill_manager._get_plugin_skill_loader = Mock(return_value=mock_loader)
+
+        loader_thread = Thread(
+            target=self.skill_manager._load_plugin_skill,
+            args=(skill_id, Mock()), daemon=True)
+        loader_thread.start()
+        self.assertTrue(loading.wait(timeout=10), "the load never started")
+        self.assertIn(skill_id, self.skill_manager._loading_plugin_skills)
+
+        # the package goes away while the load sits inside loader.load()
+        with patch(self.mock_package + 'find_skill_plugins', return_value={}), self._declared():
+            self.skill_manager.handle_uninstall_complete(
+                Message('ovos.skills.uninstall.complete'))
+
+        blocked.set()
+        loader_thread.join(timeout=10)
+        self.assertFalse(loader_thread.is_alive(), "the load never finished")
+
+        self.assertNotIn(skill_id, self.skill_manager.plugin_skills)
+        self.assertNotIn(skill_id, self.skill_manager._loading_plugin_skills)
+        mock_loader.instance.shutdown.assert_called_once_with()
+        mock_loader.instance.default_shutdown.assert_called_once_with()
+        # the package is gone, not broken: a reinstall must not wait out a backoff
+        self.assertNotIn(skill_id, self.skill_manager._plugin_skill_failures)
+
+    def test_uninstall_during_load_lets_a_later_reinstall_load(self):
+        """The verdict is spent on the load it was recorded against.
+
+        A reinstall reserves the id afresh, so the discarded attempt must not
+        leave anything behind that discards the new one too."""
+        skill_id = 'test.reloaded.skill'
+        self.skill_manager.plugin_skills = {}
+        self.skill_manager._loading_plugin_skills = set()
+        self.skill_manager._plugin_skill_unload_pending = {skill_id}
+
+        mock_loader = Mock(spec=SkillLoader)
+        mock_loader.skill_id = skill_id
+        mock_loader.load.return_value = True
+        mock_loader.runtime_requirements.network_before_load = False
+        mock_loader.runtime_requirements.internet_before_load = False
+        self.skill_manager._get_plugin_skill_loader = Mock(return_value=mock_loader)
+
+        with patch(self.mock_package + 'find_skill_plugins', return_value={skill_id: Mock()}):
+            self.skill_manager.load_plugin_skills(network=True, internet=True)
+
+        self.assertIn(skill_id, self.skill_manager.plugin_skills)
+        self.assertNotIn(skill_id, self.skill_manager._plugin_skill_unload_pending)
+
+    def test_uninstall_keeps_a_loading_skill_when_the_packages_are_installed(self):
+        """A skill still loading is kept by the same reasoning as a loaded one: the
+        entry points are still declared, so nothing importing is a hiccup."""
+        self.skill_manager.plugin_skills = {}
+        self._tracked_loader('test.kept.skill')
+        self.skill_manager._loading_plugin_skills = {'test.loading.skill'}
+
+        with patch(self.mock_package + 'find_skill_plugins', return_value={}), \
+                self._declared('test.kept.skill', 'test.loading.skill'):
+            self.skill_manager.handle_uninstall_complete(
+                Message('ovos.skills.uninstall.complete'))
+
+        self.assertSetEqual(set(), self.skill_manager._plugin_skill_unload_pending)
+        self.assertIn('test.kept.skill', self.skill_manager.plugin_skills)
+        self.log_mock.warning.assert_called_once()
+        self.assertIn('keeping them', self.log_mock.warning.call_args[0][0])
+
+    def test_one_package_can_own_every_loaded_skill(self):
+        """A distribution may expose several skill entry points, so uninstalling one
+        package can legitimately empty discovery with several skills loaded.
+
+        Counting loaded skills read that as a hiccup and kept every one of them
+        registered; what the installed packages declare says it was a real removal."""
+        self.skill_manager.plugin_skills = {}
+        loaders = [self._tracked_loader(f'bundle.skill.{n}') for n in ('one', 'two', 'three')]
+
+        with patch(self.mock_package + 'find_skill_plugins', return_value={}), self._declared():
+            removed = self.skill_manager._unload_undiscoverable_plugin_skills()
+
+        self.assertCountEqual(['bundle.skill.one', 'bundle.skill.two', 'bundle.skill.three'],
+                              removed)
+        self.assertDictEqual({}, self.skill_manager.plugin_skills)
+        for loader in loaders:
+            loader.instance.shutdown.assert_called_once_with()
+
+    def test_unreadable_entry_point_metadata_unloads_nothing(self):
+        """`_declared_skill_plugins` returning None is "cannot tell", and that must not
+        read as "nothing is installed" and shut every skill down."""
+        self.skill_manager.plugin_skills = {}
+        loader = self._tracked_loader('test.kept.skill')
+
+        with patch(self.mock_package + 'find_skill_plugins', return_value={}), \
+                patch.object(self.skill_manager, '_declared_skill_plugins', return_value=None):
+            removed = self.skill_manager._unload_undiscoverable_plugin_skills()
+
+        self.assertEqual([], removed)
+        self.assertIn('test.kept.skill', self.skill_manager.plugin_skills)
+        loader.instance.shutdown.assert_not_called()
+
+    def test_an_abandoned_load_is_never_announced_as_loaded(self):
+        """`mycroft.skill.loaded` says a skill is available. A load the uninstall
+        abandoned is shut down and never tracked, so it was never available."""
+        skill_id = 'test.announced.skill'
+        self.skill_manager.plugin_skills = {}
+        self.skill_manager._plugin_skill_unload_pending = {skill_id}
+        self.skill_manager._loading_plugin_skills = {skill_id}
+        self.skill_manager.bus.message_types = []
+
+        mock_loader = Mock(spec=SkillLoader)
+        mock_loader.skill_id = skill_id
+        mock_loader.instance = Mock()
+        mock_loader.load.return_value = True
+        self.skill_manager._get_plugin_skill_loader = Mock(return_value=mock_loader)
+
+        self.assertIsNone(self.skill_manager._load_plugin_skill(skill_id, Mock(), reserved=True))
+
+        self.assertNotIn('mycroft.skill.loaded', self.skill_manager.bus.message_types)
+        self.assertNotIn(skill_id, self.skill_manager.plugin_skills)
+        mock_loader.instance.shutdown.assert_called_once_with()
+
+    def test_a_completed_load_is_announced(self):
+        """The counterpart: a load nothing abandoned still announces itself."""
+        skill_id = 'test.normal.skill'
+        self.skill_manager.plugin_skills = {}
+        self.skill_manager._plugin_skill_unload_pending = set()
+        self.skill_manager._loading_plugin_skills = {skill_id}
+        self.skill_manager.bus.message_types = []
+
+        mock_loader = Mock(spec=SkillLoader)
+        mock_loader.skill_id = skill_id
+        mock_loader.instance = Mock()
+        mock_loader.load.return_value = True
+        self.skill_manager._get_plugin_skill_loader = Mock(return_value=mock_loader)
+
+        self.skill_manager._load_plugin_skill(skill_id, Mock(), reserved=True)
+
+        self.assertIn('mycroft.skill.loaded', self.skill_manager.bus.message_types)
+        self.assertIn(skill_id, self.skill_manager.plugin_skills)
+        mock_loader.instance.shutdown.assert_not_called()
+
+    def test_uninstall_complete_keeps_everything_when_discovery_fails(self):
+        """A discovery error must not read as "every package is gone"."""
+        self.skill_manager.plugin_skills = {}
+        loader = self._tracked_loader('test.kept.skill')
+
+        with patch(self.mock_package + 'find_skill_plugins', side_effect=RuntimeError("boom")):
+            self.skill_manager.handle_uninstall_complete(Message('ovos.skills.uninstall.complete'))
+
+        self.assertIn('test.kept.skill', self.skill_manager.plugin_skills)
+        loader.instance.shutdown.assert_not_called()
+        self.log_mock.exception.assert_called_once()
+
+
 class TestDeferredLoadingConfigFlag(TestCase):
     """Test suite for the optional deferred loading config flag."""
 
@@ -654,6 +964,8 @@ class TestDeferredLoadingConfigFlag(TestCase):
                 'skillmanager.deactivate',
                 'skillmanager.keep',
                 'skillmanager.activate',
+                'ovos.skills.uninstall.complete',
+                'ovos.pip.uninstall.complete',
                 'mycroft.skills.is_alive',
                 'mycroft.skills.is_ready',
                 'mycroft.skills.all_loaded',
@@ -685,6 +997,8 @@ class TestDeferredLoadingConfigFlag(TestCase):
             'skillmanager.deactivate',
             'skillmanager.keep',
             'skillmanager.activate',
+            'ovos.skills.uninstall.complete',
+            'ovos.pip.uninstall.complete',
             'mycroft.network.connected',
             'mycroft.internet.connected',
             'mycroft.gui.available',

--- a/test/unittests/test_skill_manager.py
+++ b/test/unittests/test_skill_manager.py
@@ -909,6 +909,93 @@ class TestSkillManager(TestCase):
         self.assertIn(skill_id, self.skill_manager.plugin_skills)
         self.assertNotIn(skill_id, self.skill_manager._plugin_skill_unload_pending)
 
+    def test_uninstall_sweep_leaves_a_reinstall_reserved_after_its_reading_alone(self):
+        """The verdict speaks only for the attempt the sweep read.
+
+        Between reading the packages and recording its verdicts the sweep
+        holds no lock, and a reinstall can reserve the same id in that gap.
+        That load started from a package the reading knows nothing about;
+        marking it would have `_load_plugin_skill` discard a good loader and
+        leave the skill out until the next scan."""
+        skill_id = 'test.reinstalled.skill'
+        self.skill_manager.plugin_skills = {}
+        self.skill_manager._loading_plugin_skills = set()
+        self.skill_manager._plugin_skill_unload_pending = set()
+        self.assertTrue(self.skill_manager._reserve_plugin_skill_load(skill_id))
+        read_serial = self.skill_manager._plugin_skill_serials[skill_id]
+
+        def reinstall_while_the_packages_are_read():
+            # the load the sweep read ends without a loader, and the
+            # reinstall's load takes the id before the verdicts land
+            self.skill_manager._release_plugin_skill_load(skill_id)
+            self.assertTrue(self.skill_manager._reserve_plugin_skill_load(skill_id))
+            return {}
+
+        with patch(self.mock_package + 'find_skill_plugins',
+                   side_effect=reinstall_while_the_packages_are_read), self._declared():
+            removed = self.skill_manager._unload_undiscoverable_plugin_skills()
+
+        self.assertEqual([], removed)
+        self.assertSetEqual(set(), self.skill_manager._plugin_skill_unload_pending)
+        self.assertIn(skill_id, self.skill_manager._loading_plugin_skills)
+        self.assertNotEqual(read_serial, self.skill_manager._plugin_skill_serials[skill_id])
+
+    def test_uninstall_sweep_detaches_the_load_it_read_even_when_it_finishes_first(self):
+        """The counterpart: the load the sweep read may finish and track its
+        loader before the verdicts land. Its package was gone when the packages
+        were read, so that loader is the sweep's to detach, reservation or not."""
+        skill_id = 'test.finished.skill'
+        self.skill_manager.plugin_skills = {}
+        self.skill_manager._loading_plugin_skills = set()
+        self.assertTrue(self.skill_manager._reserve_plugin_skill_load(skill_id))
+        mock_loader = Mock(spec=SkillLoader)
+        mock_loader.skill_id = skill_id
+        mock_loader.instance = Mock()
+
+        def finish_while_the_packages_are_read():
+            # what `_load_plugin_skill` does when its verdict is not in yet
+            with self.skill_manager._plugin_skills_lock:
+                self.skill_manager.plugin_skills[skill_id] = mock_loader
+                self.skill_manager._loading_plugin_skills.discard(skill_id)
+            return {}
+
+        with patch(self.mock_package + 'find_skill_plugins',
+                   side_effect=finish_while_the_packages_are_read), self._declared():
+            removed = self.skill_manager._unload_undiscoverable_plugin_skills()
+
+        self.assertEqual([skill_id], removed)
+        self.assertNotIn(skill_id, self.skill_manager.plugin_skills)
+        self.assertNotIn(skill_id, self.skill_manager._plugin_skill_serials)
+        mock_loader.instance.shutdown.assert_called_once_with()
+
+    def test_uninstall_sweep_keeps_a_loader_that_replaced_the_one_it_read(self):
+        """A loader tracked under an id after the reading came from a later
+        attempt, whatever the reading said about that id."""
+        skill_id = 'test.replaced.skill'
+        self.skill_manager.plugin_skills = {}
+        self.skill_manager._loading_plugin_skills = set()
+        old = self._tracked_loader(skill_id)
+        new = Mock(spec=SkillLoader)
+        new.skill_id = skill_id
+        new.instance = Mock()
+
+        def replace_while_the_packages_are_read():
+            self.skill_manager._unload_plugin_skill(skill_id)
+            self.assertTrue(self.skill_manager._reserve_plugin_skill_load(skill_id))
+            with self.skill_manager._plugin_skills_lock:
+                self.skill_manager.plugin_skills[skill_id] = new
+                self.skill_manager._loading_plugin_skills.discard(skill_id)
+            return {}
+
+        with patch(self.mock_package + 'find_skill_plugins',
+                   side_effect=replace_while_the_packages_are_read), self._declared():
+            removed = self.skill_manager._unload_undiscoverable_plugin_skills()
+
+        self.assertEqual([], removed)
+        self.assertIs(new, self.skill_manager.plugin_skills[skill_id])
+        new.instance.shutdown.assert_not_called()
+        old.instance.shutdown.assert_called_once_with()
+
     def test_uninstall_keeps_a_loading_skill_when_the_packages_are_installed(self):
         """A skill still loading is kept by the same reasoning as a loaded one: the
         entry points are still declared, so nothing importing is a hiccup."""


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5.1 (claude-fable-5-1) via Claude Code — NOT human-reviewed. Verify before acting.

A plugin skill uninstalled through the bus stays loaded, and keeps answering, until the next restart. `SkillsStore` removes the package and reloads `ovos-plugin-manager` before it reports `ovos.skills.uninstall.complete` / `ovos.pip.uninstall.complete`, but nothing in `SkillManager` consumes that report; `_unload_plugin_skill` exists and is only reached from `shutdown()`, and `skillmanager.deactivate` only silences a skill without shutting it down.

`SkillManager` now subscribes to both completion topics. On either it takes the set `find_skill_plugins()` still returns, shuts down every tracked plugin skill whose id is no longer in it through the existing `_unload_plugin_skill`, and clears that id from the load-retry bookkeeping (`_plugin_skill_failures`, and the one-shot blacklist warning) so a later reinstall loads again on the next pass instead of being treated as tracked or waiting out a backoff. Backoff records are cleared for undiscoverable ids even when no loader exists, since a load that raised before a loader was built leaves exactly that shape behind.

Discovery is not trusted unconditionally. If `find_skill_plugins()` raises, nothing is unloaded and no bookkeeping is cleared. If it returns nothing while more than one plugin skill is loaded, that is treated as a discovery hiccup (a metadata race, a half-written dist-info during a concurrent install) rather than a mass removal: a warning is logged, every skill is kept and no bookkeeping is cleared, because an uninstall of one package cannot legitimately make every other package vanish. With exactly one skill loaded, an empty result is the legitimate removal of the last skill and it is unloaded. The handler runs on the bus client's `ExecutorEventEmitter` thread pool alongside the periodic scan, so the removal list and the loader instances behind it are taken under `_plugin_skills_lock` in one critical section. Naming only the id there would be unsafe: the moment an id stops being tracked an overlapping pass is free to load a replacement under it, and a later detach by id would pop and shut that replacement down. Each shutdown still runs outside the lock, through a `_shutdown_skill_loader` helper `_unload_plugin_skill` shares, the same discipline `shutdown()` uses.

Six tests in `test/unittests/test_skill_manager.py` cover a removed skill being shut down on both topics while a still-discoverable one is untouched and its failure record dropped, a removed-then-reinstalled skill loading again on the next pass despite a backoff record, a discovery error leaving the loaded skills alone, an empty discovery with two skills loaded warning and keeping both with no bookkeeping cleared, an empty discovery with one skill loaded unloading it without a warning, and a replacement loaded under a removed id mid-pass surviving that pass untouched. With the tests kept and only the source reverted to `dev`, `test_skill_manager.py` is 10 failed, 27 passed; with the source restored it is 35 passed, 2 subtests. The full `test/unittests` suite is 624 passed, 41 subtests, and the warnings are pre-existing `ovos_utils.log` deprecations. mypy's error count on the repo is unchanged and flake8 reports nothing new on the touched files.

`README.md`, `docs/skill-manager.md`, `docs/bus-events.md`, `docs/skill-installer.md` and a `docs/prerelease-quirks.md` entry are updated in the same change. #977 adds the matching install-side handlers on a separate branch; both touch the same handler-registration block and the same handler-list tests, so whichever lands second needs a trivial rebase.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Newly installed skills are discovered and loaded immediately after installation completes.
  - Added on-demand skill rescanning with a response listing newly loaded skills.
  - Skills no longer discoverable after uninstall are unloaded automatically without requiring a restart.
  - In-progress loads for uninstalled skills are safely discarded.
  - Skills can be reinstalled and loaded again after removal.
  - Loaded skills remain available when discovery or metadata checks fail during uninstall processing.

- **Documentation**
  - Updated skill management, bus event, installer, README, and prerelease documentation with runtime install, rescan, and uninstall behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->