### PR TITLE
fix: include the installer's error output in the failure reply

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Browse OVOS-compatible skills on [PyPI](https://pypi.org/search/?q=ovos-skill-) 
 
 Most classic Mycroft skills also work on OVOS.
 
+When an install or uninstall requested over the bus fails, the `.failed` reply carries the installer's own output in `detail`, so a remote caller can see why without reading the service log. See [docs/skill-installer.md](docs/skill-installer.md).
+
 ---
 
 ## Persona Support

--- a/docs/bus-events.md
+++ b/docs/bus-events.md
@@ -71,12 +71,16 @@ All events use the OVOS `Message` format: `{type, data, context}`.
 |---|---|---|
 | `ovos.skills.install` | * → core | Install skill packages via pip |
 | `ovos.skills.install.complete` | core → * | Install succeeded |
-| `ovos.skills.install.failed` | core → * | Install failed |
+| `ovos.skills.install.failed` | core → * | Install failed: `{error, detail}`, `detail` being the tail of the installer's output |
 | `ovos.skills.uninstall` | * → core | Uninstall skill packages |
 | `ovos.skills.uninstall.complete` | core → * | Uninstall succeeded |
-| `ovos.skills.uninstall.failed` | core → * | Uninstall failed |
+| `ovos.skills.uninstall.failed` | core → * | Uninstall failed: `{error, detail}` |
 | `ovos.pip.install` | * → core | Install arbitrary pip packages |
 | `ovos.pip.uninstall` | * → core | Uninstall arbitrary pip packages |
+| `ovos.pip.install.complete` | core → * | Install succeeded |
+| `ovos.pip.install.failed` | core → * | Install failed: `{error, detail}` |
+| `ovos.pip.uninstall.complete` | core → * | Uninstall succeeded |
+| `ovos.pip.uninstall.failed` | core → * | Uninstall failed: `{error, detail}` |
 
 ## Connectivity / Network
 

--- a/docs/prerelease-quirks.md
+++ b/docs/prerelease-quirks.md
@@ -9,6 +9,19 @@ This file resets at the next stable release. At that point its contents
 become upgrade notes for the `2.1.1 -> next-stable` jump, and a new, empty
 quirks log starts.
 
+## #979 (alpha of 2026-09-09)
+
+`SkillsStore` always captures pip/uv output now (stdout and stderr as one
+stream), echoing it through the log line by line when `print_logs` is set
+instead of letting the subprocess inherit the service's stdout. A failed run
+still raises `RuntimeError`, which now carries the captured text. Every
+`.failed` reply (`ovos.skills.install.failed`, `ovos.skills.uninstall.failed`,
+`ovos.pip.install.failed`, `ovos.pip.uninstall.failed`) gains a `detail`
+field holding the last 2000 characters of that output, empty when pip never
+ran; `error` is unchanged, so existing consumers keep working. Before this a
+remote caller saw only the `InstallError` string and could not tell "this
+version is not published yet" from "this dependency conflicts".
+
 ## #935 (alpha of 2026-09-06)
 
 The floor on `ovos-bus-client` moves to 2.11.13a1. Core no longer subscribes

--- a/docs/skill-installer.md
+++ b/docs/skill-installer.md
@@ -52,7 +52,7 @@ ovos.skills.install
     "constraints": "https://..."      # optional override
   }
   → ovos.skills.install.complete  (success)
-  → ovos.skills.install.failed    (error)
+  → ovos.skills.install.failed    {"error": "...", "detail": "..."}
 ```
 
 ### Uninstall a skill
@@ -61,7 +61,7 @@ ovos.skills.install
 ovos.skills.uninstall
   data: {"packages": ["ovos-skill-foo"]}
   → ovos.skills.uninstall.complete
-  → ovos.skills.uninstall.failed
+  → ovos.skills.uninstall.failed  {"error": "...", "detail": "..."}
 ```
 
 ### Install arbitrary Python packages
@@ -69,6 +69,8 @@ ovos.skills.uninstall
 ```
 ovos.pip.install
   data: {"packages": ["some-lib>=1.0"]}
+  → ovos.pip.install.complete
+  → ovos.pip.install.failed  {"error": "...", "detail": "..."}
 ```
 
 ### Uninstall arbitrary Python packages
@@ -76,7 +78,15 @@ ovos.pip.install
 ```
 ovos.pip.uninstall
   data: {"packages": ["some-lib"]}
+  → ovos.pip.uninstall.complete
+  → ovos.pip.uninstall.failed  {"error": "...", "detail": "..."}
 ```
+
+### Failure replies
+
+Every `.failed` reply carries two fields. `error` is the `InstallError` value naming the failure (see below); `detail` is the last `FAILURE_DETAIL_CHARS` (2000) characters of what pip or uv printed, so a caller can tell "this version is not published yet" from "this dependency conflicts" without reading the service log. `detail` is an empty string when pip never ran (disabled installer, bad URL, empty package list, protected package).
+
+pip's stdout and stderr are always captured as one stream, whichever backend runs; with `print_logs` (the default) each line is also echoed through the service log as it arrives, prefixed `(pip)`. A non-zero exit raises `RuntimeError` carrying the full captured output.
 
 After a successful skill install, `ovos-plugin-manager`'s entry point cache is reloaded so the new skill is discovered on the next `SkillManager` scan cycle (every 30 s).
 

--- a/ovos_core/skill_installer.py
+++ b/ovos_core/skill_installer.py
@@ -3,7 +3,7 @@ import shutil
 import sys
 from importlib import reload
 from os.path import exists
-from subprocess import Popen, PIPE
+from subprocess import Popen, PIPE, STDOUT
 from typing import Optional
 
 import requests
@@ -21,6 +21,10 @@ class InstallError(str, enum.Enum):
     PIP_ERROR = "error in pip subprocess"
     BAD_URL = "skill url validation failed"
     NO_PKGS = "no packages to install"
+
+
+#: how much of the installer's output a ``.failed`` reply carries in ``detail``
+FAILURE_DETAIL_CHARS = 2000
 
 
 class SkillsStore:
@@ -60,6 +64,61 @@ class SkillsStore:
         self.bus.emit(Message("mycroft.audio.play_sound", {"uri": snd}))
 
     @staticmethod
+    def failure_detail(output) -> str:
+        """The tail of an installer run's output, sized for a bus reply.
+
+        Args:
+            output: The captured output, or the ``RuntimeError`` carrying it.
+
+        Returns:
+            str: At most ``FAILURE_DETAIL_CHARS`` characters, taken from the end,
+                since that is where pip and uv explain why a run failed.
+        """
+        return str(output or "")[-FAILURE_DETAIL_CHARS:]
+
+    def _reply_failed(self, message: Message, topic: str, error: str, detail: str = "") -> None:
+        """Reply to a request with a ``.failed`` message.
+
+        Args:
+            message (Message): The request being answered.
+            topic (str): The ``.failed`` topic.
+            error (str): The ``InstallError`` value (or exception text) naming the failure.
+            detail (str): The installer's output tail, empty when pip did not run.
+        """
+        self.bus.emit(message.reply(topic, {"error": error, "detail": detail}))
+
+    @staticmethod
+    def _run_pip(pip_command: list, print_logs: bool) -> str:
+        """Run one pip/uv command and return what it printed.
+
+        stdout and stderr are captured as a single stream: uv writes everything
+        to stderr, pip splits progress and errors across the two, and the last
+        lines of the merged stream are the ones that say why a run failed. With
+        ``print_logs`` every line is also echoed through ``LOG`` as it arrives.
+
+        Args:
+            pip_command (list): The full command line.
+            print_logs (bool): Whether to echo the output to the log.
+
+        Returns:
+            str: The captured output.
+
+        Raises:
+            RuntimeError: On a non-zero exit, carrying the captured output.
+        """
+        lines = []
+        with Popen(pip_command, stdout=PIPE, stderr=STDOUT, text=True, errors="replace") as proc:
+            for line in proc.stdout or []:
+                line = line.rstrip("\n")
+                lines.append(line)
+                if print_logs:
+                    LOG.info(f"(pip) {line}")
+        output = "\n".join(lines)
+        if proc.returncode != 0:
+            raise RuntimeError(output)
+        return output
+
+    @staticmethod
     def validate_constraints(constraints: str) -> bool:
         """Validate a constraints file path or URL.
 
@@ -96,7 +155,7 @@ class SkillsStore:
         Args:
             packages (list): List of package specifiers to install.
             constraints (str): Optional constraints file path or URL.
-            print_logs (bool): Whether to print pip output to stdout.
+            print_logs (bool): Whether to echo pip output to the log.
 
         Returns:
             bool: True if all packages were installed successfully, False otherwise.
@@ -136,17 +195,11 @@ class SkillsStore:
                 LOG.info("(pip) Installing " + dependent_python_package)
                 pip_command = pip_args + [dependent_python_package]
                 LOG.debug(" ".join(pip_command))
-                if print_logs:
-                    proc = Popen(pip_command)
-                else:
-                    proc = Popen(pip_command, stdout=PIPE, stderr=PIPE)
-                pip_code = proc.wait()
-                if pip_code != 0:
-                    stderr = proc.stderr
-                    if stderr:
-                        stderr = stderr.read().decode()
+                try:
+                    self._run_pip(pip_command, print_logs)
+                except RuntimeError:
                     self.play_error_sound()
-                    raise RuntimeError(stderr)
+                    raise
 
         reload(ovos_plugin_manager)  # force core to pick new entry points
         self.play_success_sound()
@@ -162,7 +215,7 @@ class SkillsStore:
         Args:
             packages (list): List of package names to uninstall.
             constraints (str): Optional constraints file path or URL used to identify protected packages.
-            print_logs (bool): Whether to print pip output to stdout.
+            print_logs (bool): Whether to echo pip output to the log.
 
         Returns:
             bool: True if all packages were uninstalled successfully, False otherwise.
@@ -220,15 +273,11 @@ class SkillsStore:
                 LOG.info("(pip) Uninstalling " + dependent_python_package)
                 pip_command = pip_args + [dependent_python_package]
                 LOG.debug(" ".join(pip_command))
-                if print_logs:
-                    proc = Popen(pip_command)
-                else:
-                    proc = Popen(pip_command, stdout=PIPE, stderr=PIPE)
-                pip_code = proc.wait()
-                if pip_code != 0:
-                    stderr = proc.stderr.read().decode()
+                try:
+                    self._run_pip(pip_command, print_logs)
+                except RuntimeError:
                     self.play_error_sound()
-                    raise RuntimeError(stderr)
+                    raise
 
         reload(ovos_plugin_manager)  # force core to pick new entry points
         self.play_success_sound()
@@ -302,27 +351,26 @@ class SkillsStore:
         if not self.config.get("allow_pip"):
             LOG.error(InstallError.DISABLED.value)
             self.play_error_sound()
-            self.bus.emit(message.reply("ovos.skills.install.failed",
-                                        {"error": InstallError.DISABLED.value}))
+            self._reply_failed(message, "ovos.skills.install.failed", InstallError.DISABLED.value)
             return
 
         url = message.data["url"]
         if self.validate_skill(url):
+            detail = ""
             try:
                 success = self.pip_install([f"git+{url}"])
             except RuntimeError as e:
                 LOG.error(f"pip failed: {e}")
                 success = False
+                detail = self.failure_detail(e)
             if success:
                 self.bus.emit(message.reply("ovos.skills.install.complete"))
             else:
-                self.bus.emit(message.reply("ovos.skills.install.failed",
-                                            {"error": InstallError.PIP_ERROR.value}))
+                self._reply_failed(message, "ovos.skills.install.failed", InstallError.PIP_ERROR.value, detail)
         else:
             LOG.error("invalid skill url, does not appear to be a github skill")
             self.play_error_sound()
-            self.bus.emit(message.reply("ovos.skills.install.failed",
-                                        {"error": InstallError.BAD_URL.value}))
+            self._reply_failed(message, "ovos.skills.install.failed", InstallError.BAD_URL.value)
 
     def handle_uninstall_skill(self, message: Message) -> None:
         """Handle a request to uninstall a skill.
@@ -333,16 +381,14 @@ class SkillsStore:
         if not self.config.get("allow_pip"):
             LOG.error(InstallError.DISABLED.value)
             self.play_error_sound()
-            self.bus.emit(message.reply("ovos.skills.uninstall.failed",
-                                        {"error": InstallError.DISABLED.value}))
+            self._reply_failed(message, "ovos.skills.uninstall.failed", InstallError.DISABLED.value)
             return
 
         skill = message.data.get("skill")
         if not skill:
             LOG.error("no skill specified for uninstall")
             self.play_error_sound()
-            self.bus.emit(message.reply("ovos.skills.uninstall.failed",
-                                        {"error": InstallError.NO_PKGS.value}))
+            self._reply_failed(message, "ovos.skills.uninstall.failed", InstallError.NO_PKGS.value)
             return
 
         # Treat skill_id as a package name (e.g., 'skill-name.author' -> 'skill-name-author')
@@ -355,12 +401,10 @@ class SkillsStore:
                 self.bus.emit(message.reply("ovos.skills.uninstall.complete"))
             else:
                 LOG.error(f"Failed to uninstall skill: {skill}")
-                self.bus.emit(message.reply("ovos.skills.uninstall.failed",
-                                            {"error": InstallError.PIP_ERROR.value}))
+                self._reply_failed(message, "ovos.skills.uninstall.failed", InstallError.PIP_ERROR.value)
         except Exception as e:
             LOG.exception(f"Error uninstalling skill {skill}: {e}")
-            self.bus.emit(message.reply("ovos.skills.uninstall.failed",
-                                        {"error": str(e)}))
+            self._reply_failed(message, "ovos.skills.uninstall.failed", str(e), self.failure_detail(e))
 
     def _addressed_to_us(self, message: Message) -> bool:
         """Whether this service should act on a pip request.
@@ -388,24 +432,23 @@ class SkillsStore:
         if not self.config.get("allow_pip"):
             LOG.error(InstallError.DISABLED.value)
             self.play_error_sound()
-            self.bus.emit(message.reply("ovos.pip.install.failed",
-                                        {"error": InstallError.DISABLED.value}))
+            self._reply_failed(message, "ovos.pip.install.failed", InstallError.DISABLED.value)
             return
         pkgs = message.data.get("packages")
         if pkgs:
+            detail = ""
             try:
                 success = self.pip_install(pkgs)
             except RuntimeError as e:
                 LOG.error(f"pip failed: {e}")
                 success = False
+                detail = self.failure_detail(e)
             if success:
                 self.bus.emit(message.reply("ovos.pip.install.complete"))
             else:
-                self.bus.emit(message.reply("ovos.pip.install.failed",
-                                            {"error": InstallError.PIP_ERROR.value}))
+                self._reply_failed(message, "ovos.pip.install.failed", InstallError.PIP_ERROR.value, detail)
         else:
-            self.bus.emit(message.reply("ovos.pip.install.failed",
-                                        {"error": InstallError.NO_PKGS.value}))
+            self._reply_failed(message, "ovos.pip.install.failed", InstallError.NO_PKGS.value)
 
     def handle_uninstall_python(self, message: Message) -> None:
         """Handle a request to uninstall Python packages via pip."""
@@ -414,24 +457,23 @@ class SkillsStore:
         if not self.config.get("allow_pip"):
             LOG.error(InstallError.DISABLED.value)
             self.play_error_sound()
-            self.bus.emit(message.reply("ovos.pip.uninstall.failed",
-                                        {"error": InstallError.DISABLED.value}))
+            self._reply_failed(message, "ovos.pip.uninstall.failed", InstallError.DISABLED.value)
             return
         pkgs = message.data.get("packages")
         if pkgs:
+            detail = ""
             try:
                 success = self.pip_uninstall(pkgs)
             except RuntimeError as e:
                 LOG.error(f"pip failed: {e}")
                 success = False
+                detail = self.failure_detail(e)
             if success:
                 self.bus.emit(message.reply("ovos.pip.uninstall.complete"))
             else:
-                self.bus.emit(message.reply("ovos.pip.uninstall.failed",
-                                            {"error": InstallError.PIP_ERROR.value}))
+                self._reply_failed(message, "ovos.pip.uninstall.failed", InstallError.PIP_ERROR.value, detail)
         else:
-            self.bus.emit(message.reply("ovos.pip.uninstall.failed",
-                                        {"error": InstallError.NO_PKGS.value}))
+            self._reply_failed(message, "ovos.pip.uninstall.failed", InstallError.NO_PKGS.value)
 
 
 def launch_standalone():

--- a/test/unittests/test_skill_installer.py
+++ b/test/unittests/test_skill_installer.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock, patch, MagicMock
 import pytest
 
 from ovos_bus_client import Message
-from ovos_core.skill_installer import SkillsStore
+from ovos_core.skill_installer import SkillsStore, FAILURE_DETAIL_CHARS
 
 
 def _make_github_response(status_code: int = 200, file_names: list = None,
@@ -229,7 +229,7 @@ def test_handle_install_skill_not_allowed(skills_store):
     skills_store.handle_install_skill(Message(msg_type="test", data={}))
     skills_store.play_error_sound.assert_called_once()
     assert skills_store.bus.message_types[-1] == "ovos.skills.install.failed"
-    assert skills_store.bus.message_data[-1] == {"error": "pip disabled in mycroft.conf"}
+    assert skills_store.bus.message_data[-1] == {"error": "pip disabled in mycroft.conf", "detail": ""}
     skills_store.validate_skill.assert_not_called()
 
 
@@ -239,7 +239,7 @@ def test_handle_install_skill_not_from_github(skills_store):
     skills_store.handle_install_skill(Message(msg_type="test", data={"url": "beautifulsoup4"}))
     skills_store.play_error_sound.assert_called_once()
     assert skills_store.bus.message_types[-1] == "ovos.skills.install.failed"
-    assert skills_store.bus.message_data[-1] == {"error": "skill url validation failed"}
+    assert skills_store.bus.message_data[-1] == {"error": "skill url validation failed", "detail": ""}
 
 
 @pytest.mark.parametrize('skills_store', [{"allow_pip": True}], indirect=True)
@@ -273,7 +273,7 @@ def test_handle_uninstall_skill_not_allowed(skills_store):
     skills_store.handle_uninstall_skill(Message(msg_type="test", data={}))
     skills_store.play_error_sound.assert_called_once()
     assert skills_store.bus.message_types[-1] == "ovos.skills.uninstall.failed"
-    assert skills_store.bus.message_data[-1] == {"error": "pip disabled in mycroft.conf"}
+    assert skills_store.bus.message_data[-1] == {"error": "pip disabled in mycroft.conf", "detail": ""}
 
 
 @pytest.mark.parametrize('skills_store', [{"allow_pip": True}], indirect=True)
@@ -293,7 +293,7 @@ def test_handle_install_python_not_allowed(skills_store):
     skills_store.handle_install_python(Message(msg_type="test", data={}))
     skills_store.play_error_sound.assert_called_once()
     assert skills_store.bus.message_types[-1] == "ovos.pip.install.failed"
-    assert skills_store.bus.message_data[-1] == {"error": "pip disabled in mycroft.conf"}
+    assert skills_store.bus.message_data[-1] == {"error": "pip disabled in mycroft.conf", "detail": ""}
     skills_store.pip_install.assert_not_called()
 
 
@@ -302,7 +302,7 @@ def test_handle_install_python_no_packages(skills_store):
     skills_store.pip_install = Mock()
     skills_store.handle_install_python(Message(msg_type="test", data={}))
     assert skills_store.bus.message_types[-1] == "ovos.pip.install.failed"
-    assert skills_store.bus.message_data[-1] == {"error": "no packages to install"}
+    assert skills_store.bus.message_data[-1] == {"error": "no packages to install", "detail": ""}
     skills_store.pip_install.assert_not_called()
 
 
@@ -325,7 +325,7 @@ def test_handle_uninstall_python_not_allowed(skills_store):
     skills_store.handle_uninstall_python(Message(msg_type="test", data={}))
     skills_store.play_error_sound.assert_called_once()
     assert skills_store.bus.message_types[-1] == "ovos.pip.uninstall.failed"
-    assert skills_store.bus.message_data[-1] == {"error": "pip disabled in mycroft.conf"}
+    assert skills_store.bus.message_data[-1] == {"error": "pip disabled in mycroft.conf", "detail": ""}
     skills_store.pip_uninstall.assert_not_called()
 
 
@@ -334,7 +334,7 @@ def test_handle_uninstall_python_no_packages(skills_store):
     skills_store.pip_uninstall = Mock()
     skills_store.handle_uninstall_python(Message(msg_type="test", data={}))
     assert skills_store.bus.message_types[-1] == "ovos.pip.uninstall.failed"
-    assert skills_store.bus.message_data[-1] == {"error": "no packages to install"}
+    assert skills_store.bus.message_data[-1] == {"error": "no packages to install", "detail": ""}
     skills_store.pip_uninstall.assert_not_called()
 
 
@@ -361,7 +361,8 @@ def test_handle_install_python_pip_raises(skills_store):
     skills_store.handle_install_python(Message(msg_type="test", data={"packages": packages}))
     skills_store.pip_install.assert_called_once_with(packages)
     assert skills_store.bus.message_types[-1] == "ovos.pip.install.failed"
-    assert skills_store.bus.message_data[-1] == {"error": "error in pip subprocess"}
+    assert skills_store.bus.message_data[-1] == {"error": "error in pip subprocess",
+                                                 "detail": "pip exited with status 1"}
 
 
 @pytest.mark.parametrize('skills_store', [{"allow_pip": True}], indirect=True)
@@ -372,7 +373,8 @@ def test_handle_uninstall_python_pip_raises(skills_store):
     skills_store.handle_uninstall_python(Message(msg_type="test", data={"packages": packages}))
     skills_store.pip_uninstall.assert_called_once_with(packages)
     assert skills_store.bus.message_types[-1] == "ovos.pip.uninstall.failed"
-    assert skills_store.bus.message_data[-1] == {"error": "error in pip subprocess"}
+    assert skills_store.bus.message_data[-1] == {"error": "error in pip subprocess",
+                                                 "detail": "pip exited with status 1"}
 
 
 @pytest.mark.parametrize('skills_store', [{"allow_pip": True}], indirect=True)
@@ -384,7 +386,108 @@ def test_handle_install_skill_pip_raises(skills_store):
         Message(msg_type="test", data={"url": "https://github.com/OpenVoiceOS/skill-foo"}))
     skills_store.pip_install.assert_called_once_with(["git+https://github.com/OpenVoiceOS/skill-foo"])
     assert skills_store.bus.message_types[-1] == "ovos.skills.install.failed"
-    assert skills_store.bus.message_data[-1] == {"error": "error in pip subprocess"}
+    assert skills_store.bus.message_data[-1] == {"error": "error in pip subprocess",
+                                                 "detail": "pip exited with status 1"}
+
+
+# ---------------------------------------------------------------------------
+# the installer's output reaches the .failed reply
+# ---------------------------------------------------------------------------
+
+def _fake_uv(tmp_path, stderr_text: str, exit_code: int = 1) -> str:
+    """A stand-in for the uv binary that prints ``stderr_text`` and exits."""
+    script = tmp_path / "uv"
+    script.write_text("#!/usr/bin/env python3\n"
+                      "import sys\n"
+                      f"sys.stderr.write({stderr_text!r})\n"
+                      f"sys.exit({exit_code})\n")
+    script.chmod(0o755)
+    return str(script)
+
+
+def _store_with_fake_uv(tmp_path, monkeypatch, stderr_text: str) -> SkillsStore:
+    """A store whose pip backend is a failing fake uv and whose constraints file exists."""
+    monkeypatch.setattr(SkillsStore, "UV", _fake_uv(tmp_path, stderr_text))
+    constraints = tmp_path / "constraints.txt"
+    constraints.write_text("")
+    store = SkillsStore(bus=MessageBusMock(), config={"allow_pip": True, "constraints": str(constraints)})
+    store.play_error_sound = Mock()
+    return store
+
+
+UNPUBLISHED = ("error: No solution found when resolving dependencies:\n"
+               "  Because ovos-skill-foo==9.9.9 was not found in the package registry")
+
+
+def test_failed_reply_carries_the_installers_output(tmp_path, monkeypatch):
+    """A remote caller can tell "not published yet" from "conflict" only if the
+    reply carries what pip or uv actually said."""
+    store = _store_with_fake_uv(tmp_path, monkeypatch, UNPUBLISHED)
+
+    store.handle_install_python(Message("ovos.pip.install", {"packages": ["ovos-skill-foo==9.9.9"]}))
+
+    assert store.bus.message_types[-1] == "ovos.pip.install.failed"
+    reply = store.bus.message_data[-1]
+    assert reply["error"] == "error in pip subprocess"
+    assert "ovos-skill-foo==9.9.9 was not found" in reply["detail"]
+    store.play_error_sound.assert_called_once()
+
+
+def test_every_pip_backed_failed_reply_carries_detail(tmp_path, monkeypatch):
+    store = _store_with_fake_uv(tmp_path, monkeypatch, UNPUBLISHED)
+    store.validate_skill = Mock(return_value=True)
+
+    store.handle_install_skill(Message("ovos.skills.install", {"url": "https://github.com/OpenVoiceOS/skill-foo"}))
+    store.handle_uninstall_python(Message("ovos.pip.uninstall", {"packages": ["ovos-skill-foo"]}))
+    store.handle_uninstall_skill(Message("ovos.skills.uninstall", {"skill": "skill-foo.openvoiceos"}))
+
+    assert store.bus.message_types[-3:] == ["ovos.skills.install.failed",
+                                            "ovos.pip.uninstall.failed",
+                                            "ovos.skills.uninstall.failed"]
+    for reply in store.bus.message_data[-3:]:
+        assert "ovos-skill-foo" in reply["detail"]
+        assert reply["error"]
+
+
+def test_refusals_before_pip_runs_carry_an_empty_detail():
+    """The reply shape is stable: ``detail`` is present and empty when pip never ran."""
+    store = SkillsStore(bus=MessageBusMock(), config={"allow_pip": True})
+    store.play_error_sound = Mock()
+
+    store.handle_install_python(Message("ovos.pip.install", {"packages": []}))
+
+    assert store.bus.message_types[-1] == "ovos.pip.install.failed"
+    assert store.bus.message_data[-1] == {"error": "no packages to install", "detail": ""}
+
+
+def test_pip_output_is_still_logged_when_print_logs_is_true(tmp_path, monkeypatch):
+    store = _store_with_fake_uv(tmp_path, monkeypatch, "first line\nsecond line\n")
+
+    with patch("ovos_core.skill_installer.LOG") as log:
+        with pytest.raises(RuntimeError) as raised:
+            store.pip_install(["ovos-skill-foo"], print_logs=True)
+    logged = [call.args[0] for call in log.info.call_args_list]
+    assert "(pip) first line" in logged
+    assert "(pip) second line" in logged
+    assert str(raised.value) == "first line\nsecond line"
+
+    with patch("ovos_core.skill_installer.LOG") as log:
+        with pytest.raises(RuntimeError):
+            store.pip_install(["ovos-skill-foo"], print_logs=False)
+    assert not [call for call in log.info.call_args_list if "first line" in call.args[0]]
+
+
+def test_detail_is_bounded_to_the_tail_of_the_output(tmp_path, monkeypatch):
+    """A long resolver trace must not turn a bus reply into a multi-kilobyte
+    payload; the end of the output is the part that explains the failure."""
+    marker = "the reason is at the end"
+    store = _store_with_fake_uv(tmp_path, monkeypatch, "x" * (3 * FAILURE_DETAIL_CHARS) + marker)
+
+    store.handle_install_python(Message("ovos.pip.install", {"packages": ["ovos-skill-foo"]}))
+
+    detail = store.bus.message_data[-1]["detail"]
+    assert len(detail) == FAILURE_DETAIL_CHARS
+    assert detail.endswith(marker)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5.1 (claude-fable-5-1) via Claude Code — NOT human-reviewed. Verify before acting.

`SkillsStore.pip_install` and `pip_uninstall` ran `Popen(pip_command)` whenever `print_logs` was true, which is the default, so the subprocess inherited the service's stdout and stderr and nothing was captured; on a non-zero exit the `RuntimeError` carried `None`. The four bus handlers then answered `.failed` with only the `InstallError` string, so a remote caller driving installs over the bus saw `error in pip subprocess` for every cause and could not tell "this version is not published yet" from "this dependency conflicts" without reading the service log on the device.

Both functions now go through one `_run_pip` helper that always captures the output. stdout and stderr are captured as a single stream: uv writes everything to stderr, pip splits progress and errors across the two, and the last lines of the merged stream are the ones that explain a failure. With `print_logs` each line is echoed through `LOG.info` as it arrives, prefixed `(pip)`, so the service log still shows the run live rather than in one block at the end. The `Popen` runs as a context manager so the pipe is closed on every path. A non-zero exit still raises `RuntimeError`, now carrying the full captured text, and `play_error_sound` still fires before it propagates.

Every `.failed` reply (`ovos.skills.install.failed`, `ovos.skills.uninstall.failed`, `ovos.pip.install.failed`, `ovos.pip.uninstall.failed`) is emitted through one `_reply_failed` helper and carries two fields: `error`, unchanged, and `detail`, the last `FAILURE_DETAIL_CHARS` (2000) characters of the installer's output, taken from the end because that is where pip and uv state the reason. `detail` is an empty string when pip never ran (installer disabled, bad URL, empty package list, protected package), so the shape is the same on every failure. `handle_uninstall_skill`'s catch-all branch keeps `error: str(e)` as before and adds the same `detail` tail. Existing consumers that only read `error` are unaffected.

Five tests in `test/unittests/test_skill_installer.py` run a real subprocess against a fake `uv` (a small Python script installed via `monkeypatch` on `SkillsStore.UV`) rather than a mocked `pip_install`: a failing install answers `.failed` with the fake's unpublished-version text in `detail`; all three other pip-backed handlers carry `detail` too; a refusal before pip runs carries `detail: ""`; `print_logs=True` echoes each output line through `LOG.info` and `print_logs=False` does not, with the `RuntimeError` carrying the full text either way; and a 6000-character output yields a `detail` of exactly 2000 characters ending on the output's last line. The ten existing exact-payload assertions on `.failed` replies gain the `detail` key. With only the source reverted to `dev`, the module fails to collect (`ImportError: cannot import name 'FAILURE_DETAIL_CHARS'`), and reverting the constant alone leaves the five new tests plus the ten updated assertions failing on the missing `detail` key; with the source restored the module is 51 passed. The full `test/unittests` suite is 623 passed, 39 subtests, 2 warnings, both pre-existing `ovos_utils.log` deprecations; an intermediate revision without the context manager added seven unclosed-file `ResourceWarning`s, which is why the pipe is closed explicitly. mypy on the file drops from 9 reported errors to 8 and flake8 reports nothing new.

`README.md`, `docs/skill-installer.md` (reply shapes and a section on failure replies), `docs/bus-events.md` (the four `.failed` rows, plus the `ovos.pip.*.complete/.failed` rows that were missing) and a `docs/prerelease-quirks.md` entry are updated in the same change. Independent of #977 and #978; the three touch different files except `docs/bus-events.md`, `README.md` and the quirks log, where a rebase is a matter of keeping both lines.
